### PR TITLE
when a component is removed, unsubscribe to remove the viewport

### DIFF
--- a/vuu-ui/packages/vuu-data/src/connection-manager.ts
+++ b/vuu-ui/packages/vuu-data/src/connection-manager.ts
@@ -194,8 +194,9 @@ class _ConnectionManager extends EventEmitter {
       },
 
       destroy: (viewportId?: string) => {
-        console.log(`ServerAPI destroy ${viewportId}`);
-        // TODO kill all subscriptions
+        if (viewportId && viewports.has(viewportId)) {
+          viewports.delete(viewportId);
+        }
       },
 
       rpcCall: async (message) => asyncRequest(message),

--- a/vuu-ui/packages/vuu-data/src/remote-data-source.ts
+++ b/vuu-ui/packages/vuu-data/src/remote-data-source.ts
@@ -182,12 +182,10 @@ export class RemoteDataSource extends EventEmitter implements DataSource {
   };
 
   unsubscribe() {
-    if (!this.disabled && !this.suspended) {
-      if (this.viewport) {
-        this.server?.unsubscribe(this.viewport);
-      }
-      this.server?.destroy(this.viewport);
+    if (this.viewport) {
+      this.server?.unsubscribe(this.viewport);
     }
+    this.server?.destroy(this.viewport);
   }
 
   suspend() {

--- a/vuu-ui/packages/vuu-datagrid/src/use-data-source.ts
+++ b/vuu-ui/packages/vuu-datagrid/src/use-data-source.ts
@@ -187,12 +187,13 @@ export default function useDataSource(
     title,
   ]);
 
-  useEffect(
-    () => () => {
-      dataSource.unsubscribe();
-    },
-    [dataSource]
-  );
+  // we rely on the view to unsubscribe. DOing it here interferes with the disable/enable mechanism
+  // useEffect(
+  //   () => () => {
+  //     dataSource.unsubscribe();
+  //   },
+  //   [dataSource]
+  // );
 
   return [data.current, setRange, dataSource];
 }

--- a/vuu-ui/packages/vuu-layout/src/use-persistent-state.ts
+++ b/vuu-ui/packages/vuu-layout/src/use-persistent-state.ts
@@ -40,7 +40,7 @@ export const usePersistentState = () => {
     }
   }, []);
 
-  const purgeSessionState = useCallback((id, key) => {
+  const purgeSessionState = useCallback((id: string, key?: string) => {
     if (sessionState.has(id)) {
       if (key === undefined) {
         sessionState.delete(id);
@@ -86,7 +86,7 @@ export const usePersistentState = () => {
     []
   );
 
-  const purgeState = useCallback((id, key) => {
+  const purgeState = useCallback((id: string, key?: string) => {
     if (persistentState.has(id)) {
       if (key === undefined) {
         persistentState.delete(id);


### PR DESCRIPTION
This should work ok, but requires a bit more thought.
It now means management of the datasource for a component is handled in multiple places . 
There is scope to tidy this up, also to relieve the Feature of the responsibility for storing the datasource in session state.