### PR TITLE
use modern build target for vuu app

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -25,8 +25,8 @@ jobs:
         run: cd ./vuu-ui && yarn
       - run: cd ./vuu-ui && yarn test:vite
 
-  # ensure the showcase still builds
-  showcase-build:
+  # ensure the vuu example and showcase still build
+  vuu-and-showcase-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -39,3 +39,4 @@ jobs:
         run: cd ./vuu-ui && yarn
       - name: Build showcase
         run: cd ./vuu-ui && yarn showcase:build
+      - run: cd ./vuu-ui && yarn build:app

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -39,4 +39,5 @@ jobs:
         run: cd ./vuu-ui && yarn
       - name: Build showcase
         run: cd ./vuu-ui && yarn showcase:build
-      - run: cd ./vuu-ui && yarn build:app
+      - name: Build Vuu app
+        run: cd ./vuu-ui && yarn build:app

--- a/vuu-ui/sample-apps/app-vuu-example/scripts/build.mjs
+++ b/vuu-ui/sample-apps/app-vuu-example/scripts/build.mjs
@@ -31,24 +31,17 @@ const featureEntryPoints = features
   .split(",")
   .map((featureName) => `../${featureName}/index.ts`);
 
-console.log({ featureEntryPoints });
-// const featureEntryPoints = [
-//   // "src/features/ag-grid/index.ts",
-//   "../feature-filtered-grid/index.ts",
-//   "../feature-vuu-blotter/index.ts",
-//   // "src/features/metrics/index.js",
-// ];
-
 assertFileExists(configFile, true);
 
 const { name: projectName } = readPackageJson();
 
-const exbuildConfig = {
+const esbuildConfig = {
   entryPoints: entryPoints.concat(featureEntryPoints),
   env: development ? "development" : "production",
   name: "app-vuu-example",
   outdir,
   splitting: true,
+  target: "esnext",
 };
 
 async function writeFeatureEntriesToConfigJson(featureBundles) {
@@ -110,7 +103,7 @@ async function main() {
       result: { metafile },
       duration,
     },
-  ] = await Promise.all([build(exbuildConfig)]).catch((e) => {
+  ] = await Promise.all([build(esbuildConfig)]).catch((e) => {
     console.error(e);
     process.exit(1);
   });

--- a/vuu-ui/scripts/build.mjs
+++ b/vuu-ui/scripts/build.mjs
@@ -24,7 +24,7 @@ export default async function main(customConfig) {
   };
 
   const packageJson = readPackageJson();
-  const { distPath: DIST_PATH, licencePath: LICENCE_PATH } = config;
+  const { distPath: DIST_PATH, licencePath: LICENCE_PATH, target } = config;
 
   const { name: scopedPackageName, peerDependencies = NO_DEPENDENCIES } =
     packageJson;
@@ -54,6 +54,7 @@ export default async function main(customConfig) {
     external,
     outdir: `${outdir}/esm`,
     name: scopedPackageName,
+    target,
   };
 
   const inlineWorkerConfig = hasWorker

--- a/vuu-ui/scripts/esbuild.mjs
+++ b/vuu-ui/scripts/esbuild.mjs
@@ -15,6 +15,7 @@ export async function build(config) {
     outfile,
     sourcemap = true,
     splitting,
+    target = ["es2020", "chrome79"],
   } = config;
 
   return esbuild({
@@ -36,14 +37,13 @@ export async function build(config) {
     },
     mainFields: ["module", "main"],
     metafile: true,
-    // minify: config.env === "production",
-    minify: false,
+    minify: config.env === "production",
     outbase,
     outdir,
     outfile,
     sourcemap,
     splitting,
-    target: ["es2020", "chrome79"],
+    target,
     watch: false,
   })
     .then((result) => {


### PR DESCRIPTION
default build target for esbuild was downgraded to es2020. This causes app build to fail, as app-vuu-example uses a top-level await.

Make the target configurable and use a modern target for app, preserving the older target for library packages.

Add app build to git actions, so we fail if app build fails