### PR TITLE
don't expect a function name for InlinedWorker in minified code

### DIFF
--- a/vuu-ui/packages/vuu-data/src/connection-manager.ts
+++ b/vuu-ui/packages/vuu-data/src/connection-manager.ts
@@ -26,7 +26,7 @@ import {
 // Note: the InlinedWorker is a generated file, it must be built
 import { InlinedWorker } from "./inlined-worker";
 const workerSource = InlinedWorker.toString().replace(
-  /(?:^function\s+[^(]+\(\)\s*\{)|(?:\}$)/g,
+  /(?:^function\s+[^(]*\(\)\s*\{)|(?:\}$)/g,
   ""
 );
 const workerBlob = new Blob([workerSource], { type: "text/javascript" });


### PR DESCRIPTION
further refinement for issue . 

When package is included into a webpack bundle, the minifier used by webpack may remove the function name entirely.