### PR TITLE
server-proxy must return data size after viewport re-enabled

### DIFF
--- a/vuu-ui/packages/vuu-data/src/server-proxy/server-proxy.ts
+++ b/vuu-ui/packages/vuu-data/src/server-proxy/server-proxy.ts
@@ -663,6 +663,7 @@ export class ServerProxy {
                 clientViewportId: viewport.clientViewportId,
                 mode: "batch",
                 rows,
+                size: viewport.size,
                 type: "viewport-update",
               });
             }

--- a/vuu-ui/packages/vuu-data/src/server-proxy/viewport.ts
+++ b/vuu-ui/packages/vuu-data/src/server-proxy/viewport.ts
@@ -182,6 +182,10 @@ export class Viewport {
     return this.rowCountChanged || this.hasUpdates;
   }
 
+  get size() {
+    return this.dataWindow?.rowCount ?? 0;
+  }
+
   subscribe() {
     const { filter } = this.filter;
     this.status =

--- a/vuu-ui/packages/vuu-datatable/src/DataTable.css
+++ b/vuu-ui/packages/vuu-datatable/src/DataTable.css
@@ -142,6 +142,7 @@ table:is(.vuuPinLeft, .vuuPinRight, .vuuPinFloating) {
   position: absolute;
   right: 0;
   top:0;
+  width: 15px;
 }
 
 .vuuDataTable:has(.vuuTable-headerCell-resizing) * {

--- a/vuu-ui/packages/vuu-datatable/src/useTableModel.ts
+++ b/vuu-ui/packages/vuu-datatable/src/useTableModel.ts
@@ -137,7 +137,6 @@ export type ColumnActionDispatch = (action: GridModelAction) => void;
 const columnReducer: GridModelReducer = (state, action) => {
   switch (action.type) {
     case "init":
-      console.log("modeel init");
       return init(action);
     case "moveColumn":
       return moveColumn(state, action);
@@ -300,8 +299,6 @@ function setTypes(
         serverDataType,
       };
     });
-
-    console.log(`setTypes ${JSON.stringify(cols, null, 2)}`);
 
     return {
       ...state,


### PR DESCRIPTION
after viewport is re-enabled, ServerProxy returns rows from cache. Because it did not return the rowcount, DataTable still has rowCount 0 so shows no scrollbar.