### PR TITLE
Issue 595 datasource api

### DIFF
--- a/vuu-ui/packages/vuu-data/src/data-source.ts
+++ b/vuu-ui/packages/vuu-data/src/data-source.ts
@@ -90,6 +90,11 @@ export interface DataSourceGroupByMessage extends MessageWithClientViewportId {
   type: "groupBy";
   groupBy: VuuGroupBy | undefined;
 }
+export interface DataSourceSetConfigMessage
+  extends MessageWithClientViewportId {
+  type: "config";
+  config: DataSourceConfig;
+}
 
 export interface DataSourceMenusMessage extends MessageWithClientViewportId {
   type: "vuu-menu";
@@ -106,7 +111,8 @@ export type DataSourceConfigMessage =
   | DataSourceColumnsMessage
   | DataSourceFilterMessage
   | DataSourceGroupByMessage
-  | DataSourceSortMessage;
+  | DataSourceSortMessage
+  | DataSourceSetConfigMessage;
 
 export const toDataSourceConfig = (
   message: DataSourceConfigMessage
@@ -122,7 +128,110 @@ export const toDataSourceConfig = (
       return { groupBy: message.groupBy };
     case "sort":
       return { sort: message.sort };
+    case "config":
+      return message.config;
   }
+};
+
+const exactlyTheSame = (a: unknown, b: unknown) => {
+  if (a === b) {
+    return true;
+  } else if (a === undefined && b === undefined) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+type DataConfigPredicate = (
+  config: DataSourceConfig,
+  newConfig: DataSourceConfig
+) => boolean;
+
+const filterChanged: DataConfigPredicate = (c1, c2) => {
+  return c1.filter?.filter !== c2.filter?.filter;
+};
+
+const sortChanged: DataConfigPredicate = ({ sort: s1 }, { sort: s2 }) => {
+  if (exactlyTheSame(s1, s2)) {
+    return false;
+  } else if (s1 === undefined || s2 === undefined) {
+    return true;
+  } else if (s1?.sortDefs.length !== s2?.sortDefs.length) {
+    return true;
+  }
+  return s1.sortDefs.some(
+    ({ column, sortType }, i) =>
+      column !== s2.sortDefs[i].column || sortType !== s2.sortDefs[i].sortType
+  );
+};
+const groupByChanged: DataConfigPredicate = (
+  { groupBy: g1 },
+  { groupBy: g2 }
+) => {
+  if (exactlyTheSame(g1, g2)) {
+    return false;
+  } else if (g1 === undefined || g2 === undefined) {
+    return true;
+  } else if (g1?.length !== g2?.length) {
+    return true;
+  }
+  return g1.some((column, i) => column !== g2?.[i]);
+};
+const columnsChanged: DataConfigPredicate = (
+  { columns: cols1 },
+  { columns: cols2 }
+) => {
+  if (exactlyTheSame(cols1, cols2)) {
+    return false;
+  } else if (cols1 === undefined || cols2 === undefined) {
+    return true;
+  } else if (cols1?.length !== cols2?.length) {
+    return true;
+  }
+  return cols1.some((column, i) => column !== cols2?.[i]);
+};
+const aggregationsChanged: DataConfigPredicate = (
+  { aggregations: agg1 },
+  { aggregations: agg2 }
+) => {
+  if (exactlyTheSame(agg1, agg2)) {
+    return false;
+  } else if (agg1 === undefined || agg2 === undefined) {
+    return true;
+  } else if (agg1.length !== agg2.length) {
+    return true;
+  }
+  return agg1.some(
+    ({ column, aggType }, i) =>
+      column !== agg2[i].column || aggType !== agg2[i].aggType
+  );
+};
+const visualLinkChanged: DataConfigPredicate = () => {
+  // TODO
+  return false;
+};
+
+export const configChanged = (
+  config: DataSourceConfig | undefined,
+  newConfig: DataSourceConfig | undefined
+) => {
+  if (exactlyTheSame(config, newConfig)) {
+    return false;
+  }
+
+  if (config === undefined || newConfig === undefined) {
+    return true;
+  }
+
+  return (
+    columnsChanged(config, newConfig) ||
+    filterChanged(config, newConfig) ||
+    sortChanged(config, newConfig) ||
+    groupByChanged(config, newConfig) ||
+    aggregationsChanged(config, newConfig) ||
+    visualLinkChanged(config, newConfig)
+  );
 };
 
 export interface DataSourceSubscribedMessage
@@ -179,6 +288,7 @@ export type DataSourceCallbackMessage =
   | DataSourceVisualLinksMessage;
 
 const datasourceMessages = [
+  "config",
   "aggregate",
   "viewport-update",
   "columns",
@@ -221,7 +331,9 @@ export const shouldMessageBeRoutedToDataSource = (
 export const isDataSourceConfigMessage = (
   message: DataSourceCallbackMessage
 ): message is DataSourceConfigMessage =>
-  ["aggregate", "columns", "filter", "groupBy", "sort"].includes(message.type);
+  ["config", "aggregate", "columns", "filter", "groupBy", "sort"].includes(
+    message.type
+  );
 
 /**
  * Described the configuration values that should typically be
@@ -268,7 +380,7 @@ export interface DataSource extends EventEmitter<DataSourceEvents> {
   aggregations: VuuAggregation[];
   closeTreeNode: (key: string) => void;
   columns: string[];
-  readonly config: DataSourceConfig | undefined;
+  config: DataSourceConfig | undefined;
   enable?: () => void;
   disable?: () => void;
   filter: DataSourceFilter;

--- a/vuu-ui/packages/vuu-data/src/data-source.ts
+++ b/vuu-ui/packages/vuu-data/src/data-source.ts
@@ -148,7 +148,7 @@ type DataConfigPredicate = (
   newConfig: DataSourceConfig
 ) => boolean;
 
-const filterChanged: DataConfigPredicate = (c1, c2) => {
+export const filterChanged: DataConfigPredicate = (c1, c2) => {
   return c1.filter?.filter !== c2.filter?.filter;
 };
 
@@ -165,6 +165,12 @@ const sortChanged: DataConfigPredicate = ({ sort: s1 }, { sort: s2 }) => {
       column !== s2.sortDefs[i].column || sortType !== s2.sortDefs[i].sortType
   );
 };
+
+export const hasGroupBy = (config?: DataSourceConfig): config is WithGroupBy =>
+  config !== undefined &&
+  config.groupBy !== undefined &&
+  config.groupBy.length > 0;
+
 const groupByChanged: DataConfigPredicate = (
   { groupBy: g1 },
   { groupBy: g2 }
@@ -346,6 +352,10 @@ export interface DataSourceConfig {
   groupBy?: VuuGroupBy;
   sort?: VuuSort;
   visualLink?: LinkDescriptorWithLabel;
+}
+
+export interface WithGroupBy extends DataSourceConfig {
+  groupBy: VuuGroupBy;
 }
 
 export interface DataSourceConstructorProps extends DataSourceConfig {

--- a/vuu-ui/packages/vuu-data/src/remote-data-source.ts
+++ b/vuu-ui/packages/vuu-data/src/remote-data-source.ts
@@ -27,6 +27,7 @@ import {
 } from "./data-source";
 import { getServerAPI, ServerAPI } from "./connection-manager";
 import { MenuRpcResponse } from "./vuuUIMessageTypes";
+import { parseFilter } from "@finos/vuu-filters";
 
 type RangeRequest = (range: VuuRange) => void;
 
@@ -336,13 +337,24 @@ export class RemoteDataSource
 
   set config(config: DataSourceConfig | undefined) {
     if (configChanged(this.#config, config)) {
-      this.#config = config;
-      if (this.viewport && this.server) {
+      if (config?.filter && config?.filter.filterStruct === undefined) {
+        this.#config = {
+          ...config,
+          filter: {
+            filter: config.filter.filter,
+            filterStruct: parseFilter(config.filter.filter),
+          },
+        };
+      } else {
+        this.#config = config;
+      }
+
+      if (this.#config && this.viewport && this.server) {
         if (config) {
           this.server?.send({
             viewport: this.viewport,
             type: "config",
-            config,
+            config: this.#config,
           });
         }
       }

--- a/vuu-ui/packages/vuu-data/src/remote-data-source.ts
+++ b/vuu-ui/packages/vuu-data/src/remote-data-source.ts
@@ -23,6 +23,7 @@ import {
   isSizeOnly,
   DataSourceDataMessage,
   OptimizeStrategy,
+  configChanged,
 } from "./data-source";
 import { getServerAPI, ServerAPI } from "./connection-manager";
 import { MenuRpcResponse } from "./vuuUIMessageTypes";
@@ -331,6 +332,22 @@ export class RemoteDataSource
 
   get config() {
     return this.#config;
+  }
+
+  set config(config: DataSourceConfig | undefined) {
+    if (configChanged(this.#config, config)) {
+      this.#config = config;
+      if (this.viewport && this.server) {
+        if (config) {
+          this.server?.send({
+            viewport: this.viewport,
+            type: "config",
+            config,
+          });
+        }
+      }
+      this.emit("config", this.#config);
+    }
   }
 
   get optimize() {

--- a/vuu-ui/packages/vuu-data/src/server-proxy/server-proxy.ts
+++ b/vuu-ui/packages/vuu-data/src/server-proxy/server-proxy.ts
@@ -32,6 +32,7 @@ import {
   VuuUIMessageOutAggregate,
   VuuUIMessageOutCloseTreeNode,
   VuuUIMessageOutColumns,
+  VuuUIMessageOutConfig,
   VuuUIMessageOutConnect,
   VuuUIMessageOutCreateLink,
   VuuUIMessageOutFilter,
@@ -290,6 +291,12 @@ export class ServerProxy {
     }
   }
 
+  private setConfig(viewport: Viewport, message: VuuUIMessageOutConfig) {
+    const requestId = nextRequestId();
+    const request = viewport.setConfig(requestId, message.config);
+    this.sendIfReady(request, requestId, viewport.status === "subscribed");
+  }
+
   private aggregate(viewport: Viewport, message: VuuUIMessageOutAggregate) {
     const requestId = nextRequestId();
     const request = viewport.aggregateRequest(requestId, message.aggregations);
@@ -482,6 +489,8 @@ export class ServerProxy {
         switch (message.type) {
           case "setViewRange":
             return this.setViewRange(viewport, message);
+          case "config":
+            return this.setConfig(viewport, message);
           case "aggregate":
             return this.aggregate(viewport, message);
           case "sort":

--- a/vuu-ui/packages/vuu-data/src/vuuUIMessageTypes.ts
+++ b/vuu-ui/packages/vuu-data/src/vuuUIMessageTypes.ts
@@ -14,7 +14,10 @@ import {
 } from "@finos/vuu-protocol-types";
 import { DataSourceFilter } from "@finos/vuu-data-types";
 import { WithRequestId } from "./message-utils";
-import { DataSourceVisualLinkCreatedMessage } from "./data-source";
+import {
+  DataSourceConfig,
+  DataSourceVisualLinkCreatedMessage,
+} from "./data-source";
 import { Selection } from "@finos/vuu-datagrid-types";
 
 export type ConnectionStatus =
@@ -209,10 +212,16 @@ export interface VuuUIMessageOutGroupby extends ViewportMessageOut {
   type: "groupBy";
 }
 
+export interface VuuUIMessageOutConfig extends ViewportMessageOut {
+  config: DataSourceConfig;
+  type: "config";
+}
+
 export type VuuUIMessageOutViewport =
   | VuuUIMessageOutAggregate
   | VuuUIMessageOutCloseTreeNode
   | VuuUIMessageOutColumns
+  | VuuUIMessageOutConfig
   | VuuUIMessageOutCreateLink
   | VuuUIMessageOutFilter
   | VuuUIMessageOutDisable

--- a/vuu-ui/packages/vuu-data/test/remote-data-source.test.ts
+++ b/vuu-ui/packages/vuu-data/test/remote-data-source.test.ts
@@ -444,7 +444,7 @@ describe("RemoteDataSource", () => {
       });
 
       config = {
-        filter: { filter: 'ccy = "EUR"' },
+        columns: ["col1", "col2", "col3"],
       };
 
       dataSource.config = config;
@@ -454,9 +454,18 @@ describe("RemoteDataSource", () => {
         config,
         viewport: "vp1",
       });
+    });
 
-      config = {
-        columns: ["col1", "col2", "col3"],
+    it("parses filterStruct, if filterQuery only is provided", async () => {
+      const serverSend = vi.fn();
+      vi.spyOn(connectionExports, "getServerAPI").mockImplementation(
+        // @ts-ignore
+        () => Promise.resolve({ send: serverSend, subscribe: callback })
+      );
+      const dataSource = new RemoteDataSource({ table, viewport: "vp1" });
+      await dataSource.subscribe({}, callback);
+
+      const config: DataSourceConfig = {
         filter: { filter: 'ccy = "EUR"' },
       };
 
@@ -464,7 +473,16 @@ describe("RemoteDataSource", () => {
 
       expect(serverSend).toHaveBeenCalledWith({
         type: "config",
-        config,
+        config: {
+          filter: {
+            filter: 'ccy = "EUR"',
+            filterStruct: {
+              column: "ccy",
+              op: "=",
+              value: "EUR",
+            },
+          },
+        },
         viewport: "vp1",
       });
     });

--- a/vuu-ui/packages/vuu-data/test/remote-data-source.test.ts
+++ b/vuu-ui/packages/vuu-data/test/remote-data-source.test.ts
@@ -4,13 +4,9 @@ import "./global-mocks";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as connectionExports from "../src/connection-manager";
 //----------------------------------------------------
-import {
-  LinkDescriptorWithLabel,
-  VuuLink,
-  VuuSortCol,
-  VuuSortType,
-} from "@finos/vuu-protocol-types";
+import { LinkDescriptorWithLabel, VuuSortCol } from "@finos/vuu-protocol-types";
 import { RemoteDataSource } from "../src/remote-data-source";
+import { DataSourceConfig } from "../src";
 
 const defaultSubscribeOptions = {
   aggregations: [],
@@ -424,6 +420,74 @@ describe("RemoteDataSource", () => {
         groupBy,
         viewport: "vp1",
       });
+    });
+
+    it("calls server when config set, if config has changed", async () => {
+      const serverSend = vi.fn();
+      vi.spyOn(connectionExports, "getServerAPI").mockImplementation(
+        // @ts-ignore
+        () => Promise.resolve({ send: serverSend, subscribe: callback })
+      );
+      const dataSource = new RemoteDataSource({ table, viewport: "vp1" });
+      await dataSource.subscribe({}, callback);
+
+      let config: DataSourceConfig = {
+        sort: { sortDefs: [{ column: "col1", sortType: "A" }] },
+      };
+
+      dataSource.config = config;
+
+      expect(serverSend).toHaveBeenCalledWith({
+        type: "config",
+        config,
+        viewport: "vp1",
+      });
+
+      config = {
+        filter: { filter: 'ccy = "EUR"' },
+      };
+
+      dataSource.config = config;
+
+      expect(serverSend).toHaveBeenCalledWith({
+        type: "config",
+        config,
+        viewport: "vp1",
+      });
+
+      config = {
+        columns: ["col1", "col2", "col3"],
+        filter: { filter: 'ccy = "EUR"' },
+      };
+
+      dataSource.config = config;
+
+      expect(serverSend).toHaveBeenCalledWith({
+        type: "config",
+        config,
+        viewport: "vp1",
+      });
+    });
+
+    it("does not call server when config set, if config has not changed", async () => {
+      const serverSend = vi.fn();
+      vi.spyOn(connectionExports, "getServerAPI").mockImplementation(
+        // @ts-ignore
+        () => Promise.resolve({ send: serverSend, subscribe: callback })
+      );
+      const dataSource = new RemoteDataSource({ table, viewport: "vp1" });
+      await dataSource.subscribe({}, callback);
+
+      const config: DataSourceConfig = {
+        sort: { sortDefs: [{ column: "col1", sortType: "A" }] },
+      };
+
+      dataSource.config = config;
+      serverSend.mockClear();
+
+      dataSource.config = config;
+
+      expect(serverSend).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/vuu-ui/packages/vuu-filters/src/filter-input/filter-language-parser/index.ts
+++ b/vuu-ui/packages/vuu-filters/src/filter-input/filter-language-parser/index.ts
@@ -1,1 +1,2 @@
 export * from "./FilterLanguage";
+export { parseFilter } from "./FilterParser";

--- a/vuu-ui/packages/vuu-filters/src/filter-input/index.ts
+++ b/vuu-ui/packages/vuu-filters/src/filter-input/index.ts
@@ -1,3 +1,4 @@
 export * from "./FilterInput";
 export * from "./useCodeMirrorEditor";
 export * from "./useFilterSuggestionProvider";
+export { parseFilter } from "./filter-language-parser";

--- a/vuu-ui/showcase/src/examples/Table/Table.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Table.examples.tsx
@@ -21,10 +21,12 @@ import {
   VuuTable,
 } from "@finos/vuu-protocol-types";
 import {
+  Checkbox,
   ToggleButton,
   ToggleButtonGroup,
   ToggleButtonGroupChangeEventHandler,
   Toolbar,
+  ToolbarField,
   Tooltray,
 } from "@heswell/salt-lab";
 import { Button } from "@salt-ds/core";
@@ -98,12 +100,33 @@ const useTableConfig = ({
 
 export const DefaultTable = () => {
   const config = useTableConfig();
+  const [zebraStripes, setZebraStripes] = useState(true);
+  const handleZebraChanged = useCallback((_evt, checked) => {
+    setZebraStripes(checked);
+  }, []);
   return (
-    <>
-      {/* <DragVisualizer orientation="horizontal"> */}
-      <Table {...config} height={700} renderBufferSize={50} width={700} />
-      {/* </DragVisualizer> */}
-    </>
+    <div style={{ display: "flex", gap: 12 }}>
+      <Table
+        {...config}
+        height={700}
+        renderBufferSize={50}
+        width={700}
+        zebraStripes={zebraStripes}
+      />
+      <Toolbar
+        orientation="vertical"
+        style={
+          { height: "unset", "--saltFormField-margin": "6px" } as CSSProperties
+        }
+      >
+        <ToolbarField label="Zebra Stripes">
+          <Checkbox
+            checked={zebraStripes === true}
+            onChange={handleZebraChanged}
+          />
+        </ToolbarField>
+      </Toolbar>
+    </div>
   );
 };
 DefaultTable.displaySequence = displaySequence++;
@@ -582,7 +605,10 @@ export const VuuTableCalculatedColumns = () => {
   const handleConfigChange = useCallback(
     (config: GridConfig, closePanel = false) => {
       setTableConfig((currentConfig) => {
-        if (itemsChanged(currentConfig.columns, config.columns, "name")) {
+        if (
+          dataSource &&
+          itemsChanged(currentConfig.columns, config.columns, "name")
+        ) {
           dataSource.columns = config.columns.map(toDataSourceColumns);
         }
         return (configRef.current = config);
@@ -616,10 +642,15 @@ export const VuuTableCalculatedColumns = () => {
   }, []);
 
   const groupByCurrency = useCallback(() => {
-    dataSource.groupBy = ["currency"];
+    if (dataSource) {
+      dataSource.groupBy = ["currency"];
+    }
   }, [dataSource]);
+
   const groupByCurrencyExchange = useCallback(() => {
-    dataSource.groupBy = ["currency", "exchange"];
+    if (dataSource) {
+      dataSource.groupBy = ["currency", "exchange"];
+    }
   }, [dataSource]);
 
   const handleSubmitFilter = useCallback(
@@ -1049,6 +1080,7 @@ export const SwitchColumns = () => {
       {
         "datasource-config": {
           columns: parentOrdersSchema.columns.map((col) => col.name),
+          filterSpec: { filter: 'algo = "TWAP"' },
         },
         "table-config": {
           columns: parentOrdersSchema.columns,
@@ -1085,7 +1117,7 @@ export const SwitchColumns = () => {
       })
     );
     if (dataSource) {
-      dataSource.columns = namedConfiguration["datasource-config"].columns;
+      dataSource.config = namedConfiguration["datasource-config"];
     }
   }, [dataSource, namedConfiguration]);
 

--- a/vuu-ui/showcase/src/examples/Table/Table.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Table.examples.tsx
@@ -4,7 +4,11 @@ import {
   DatagridSettingsPanel,
   DataSourceStats,
 } from "@finos/vuu-table-extras";
-import { ColumnDescriptor, GridConfig } from "@finos/vuu-datagrid-types";
+import {
+  ColumnDescriptor,
+  GridConfig,
+  KeyedColumnDescriptor,
+} from "@finos/vuu-datagrid-types";
 import { Table, TableProps } from "@finos/vuu-table";
 import { FilterInput } from "@finos/vuu-filters";
 import { Flexbox, useViewContext, View } from "@finos/vuu-layout";
@@ -1040,12 +1044,17 @@ export const toColumnDescriptor =
     }
   };
 
+type SavedConfig = Array<{
+  "datasource-config": DataSourceConfig;
+  "table-config": { columns: ColumnDescriptor[] };
+}>;
+
 export const SwitchColumns = () => {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const { schemas } = useSchemas();
   const { parentOrders: parentOrdersSchema } = schemas;
 
-  const namedConfigurations = useMemo(() => {
+  const namedConfigurations = useMemo<SavedConfig>(() => {
     // prettier-ignore
     const whpColumns = ["account", "algo", "ccy", "exchange", "ric"]
     // prettier-ignore
@@ -1064,6 +1073,7 @@ export const SwitchColumns = () => {
       {
         "datasource-config": {
           columns: wovColumns,
+          groupBy: ["account"],
         },
         "table-config": {
           columns: wovColumns.map(toColumnDescriptor(parentOrdersSchema)),
@@ -1080,7 +1090,7 @@ export const SwitchColumns = () => {
       {
         "datasource-config": {
           columns: parentOrdersSchema.columns.map((col) => col.name),
-          filterSpec: { filter: 'algo = "TWAP"' },
+          filter: { filter: 'algo = "TWAP"' },
         },
         "table-config": {
           columns: parentOrdersSchema.columns,


### PR DESCRIPTION
Extend client DataSource API to allow multiple DataSource attributes to be set simultaneously on client side (Server API is already designed this way)
Allows sets of config to be saved and reapplied
