### PR TITLE
ensure showcase examples load correctly in prod build

### DIFF
--- a/vuu-ui/packages/vuu-layout/src/palette/Palette.tsx
+++ b/vuu-ui/packages/vuu-layout/src/palette/Palette.tsx
@@ -9,7 +9,7 @@ import {
   ReactElement,
 } from "react";
 import { useLayoutProviderDispatch } from "../layout-provider";
-import { View } from "../layout-view";
+import { View, ViewProps } from "../layout-view";
 import { registerComponent } from "../registry/ComponentRegistry";
 
 import "./Palette.css";
@@ -57,12 +57,14 @@ export interface PaletteProps
   children: ReactElement[];
   orientation: "horizontal" | "vertical";
   selection?: string;
+  ViewProps?: Partial<ViewProps>;
 }
 
 export const Palette = ({
   children,
   className,
   orientation = "horizontal",
+  ViewProps,
   ...props
 }: PaletteProps) => {
   const dispatch = useLayoutProviderDispatch();
@@ -89,7 +91,7 @@ export const Palette = ({
     const component = template ? (
       payload
     ) : (
-      <View {...identifiers} {...props} title={props.label}>
+      <View {...ViewProps} {...identifiers} {...props} title={props.label}>
         {payload}
       </View>
     );

--- a/vuu-ui/sample-apps/app-vuu-example/src/app-sidepanel/AppSidePanel.tsx
+++ b/vuu-ui/sample-apps/app-vuu-example/src/app-sidepanel/AppSidePanel.tsx
@@ -1,5 +1,5 @@
 import { TableSchema } from "@finos/vuu-data";
-import { Palette, PaletteItem } from "@finos/vuu-layout";
+import { Palette, PaletteItem, ViewProps } from "@finos/vuu-layout";
 import { Feature, Features } from "@finos/vuu-shell";
 import {
   Accordion,
@@ -19,6 +19,7 @@ const NULL_FEATURE = {};
 export interface AppSidePanelProps {
   features?: Features;
   tables?: Map<string, TableSchema>;
+  ViewProps?: Partial<ViewProps>;
 }
 
 type FeatureDescriptor = {
@@ -59,6 +60,7 @@ const classBase = "vuuAppSidePanel";
 export const AppSidePanel = ({
   features = NO_FEATURES,
   tables,
+  ViewProps,
 }: AppSidePanelProps) => {
   const gridFeatures = useMemo(
     () =>
@@ -140,6 +142,7 @@ export const AppSidePanel = ({
             <Palette
               orientation="vertical"
               style={{ width: "100%", height: "100%" }}
+              ViewProps={ViewProps}
             >
               {paletteItems.map((spec) => (
                 <PaletteItem

--- a/vuu-ui/showcase/scripts/build.mjs
+++ b/vuu-ui/showcase/scripts/build.mjs
@@ -26,12 +26,12 @@ const HTML_TEMPLATE = `
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/manifest.json">    
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="index.css"/>
+    <link rel="stylesheet" href="/index.css"/>
     <title>Vite Showcase</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="index.js"></script>
+    <script type="module" src="/index.js"></script>
   </body>
 </html>
 `;

--- a/vuu-ui/showcase/src/examples/Apps/SampleApp.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/SampleApp.examples.tsx
@@ -1,0 +1,38 @@
+import { Shell } from "@finos/vuu-shell";
+import { AppSidePanel } from "app-vuu-example/src/app-sidepanel";
+import { CSSProperties } from "react";
+import { useMockFeatureData } from "../utils/mock-data";
+import { VuuBlotterHeader } from "../VuuFeatures/VuuBlotter/VuuBlotterHeader";
+
+const user = { username: "test-user", token: "test-token" };
+
+let displaySequence = 1;
+
+const viewProps = {
+  Header: VuuBlotterHeader,
+};
+
+export const SampleApp = () => {
+  const { features, schemas } = useMockFeatureData();
+  return (
+    <Shell
+      leftSidePanel={
+        <AppSidePanel
+          features={features}
+          tables={schemas}
+          ViewProps={viewProps}
+        />
+      }
+      loginUrl={window.location.toString()}
+      user={user}
+      style={
+        {
+          "--vuuShell-height": "100%",
+          "--vuuShell-width": "100%",
+        } as CSSProperties
+      }
+    />
+  );
+};
+
+SampleApp.displaySequence = displaySequence++;

--- a/vuu-ui/showcase/src/examples/Apps/index.ts
+++ b/vuu-ui/showcase/src/examples/Apps/index.ts
@@ -1,0 +1,1 @@
+export * from "./SampleApp.examples";

--- a/vuu-ui/showcase/src/examples/index.ts
+++ b/vuu-ui/showcase/src/examples/index.ts
@@ -1,3 +1,4 @@
+export * as Apps from "./Apps";
 export * as ColumnConfiguration from "./ColumnConfiguration";
 export * as DataGrid from "./DataGrid";
 export * as Filters from "./Filters";


### PR DESCRIPTION
paths for javascript and css must be absolute, in order to be resolved correctly when showcase is opened at a specific example location.