### PR TITLE
fix issue with sort on TABLE_ROWS

### DIFF
--- a/vuu-ui/packages/vuu-data/src/message-utils.ts
+++ b/vuu-ui/packages/vuu-data/src/message-utils.ts
@@ -43,3 +43,14 @@ export const getFirstAndLastRows = (
   const lastRow = rows.at(-1) as VuuRow;
   return [firstRow, lastRow];
 };
+
+export type ViewportRowMap = { [key: string]: VuuRow[] };
+export const groupRowsByViewport = (rows: VuuRow[]): ViewportRowMap => {
+  const result: ViewportRowMap = {};
+  for (const row of rows) {
+    const rowsForViewport =
+      result[row.viewPortId] || (result[row.viewPortId] = []);
+    rowsForViewport.push(row);
+  }
+  return result;
+};

--- a/vuu-ui/packages/vuu-data/src/server-proxy/viewport.ts
+++ b/vuu-ui/packages/vuu-data/src/server-proxy/viewport.ts
@@ -168,8 +168,6 @@ export class Viewport {
   private batchMode = true;
   private useBatchMode = true;
 
-  private ignorePostFilterRepeats = false;
-
   private rangeMonitor = new RangeMonitor("ViewPort");
 
   public clientViewportId: string;
@@ -632,8 +630,6 @@ export class Viewport {
       data: dataSourceFilter,
     });
 
-    this.ignorePostFilterRepeats = true;
-
     if (this.useBatchMode) {
       this.batchMode = true;
     }
@@ -743,16 +739,6 @@ export class Viewport {
     const [firstRow, lastRow] = getFirstAndLastRows(rows);
     if (firstRow && lastRow) {
       this.removePendingRangeRequest(firstRow.rowIndex, lastRow.rowIndex);
-    }
-
-    if (this.ignorePostFilterRepeats) {
-      if (firstRow.vpSize === this.dataWindow?.rowCount) {
-        debug?.(`ignore data, rows are post filter repeats`);
-        this.ignorePostFilterRepeats = false;
-        return;
-      } else {
-        this.ignorePostFilterRepeats = false;
-      }
     }
 
     if (rows.length === 1 && firstRow.vpSize === 0 && this.disabled) {

--- a/vuu-ui/packages/vuu-data/test/message-utils.test.ts
+++ b/vuu-ui/packages/vuu-data/test/message-utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createTableRows } from "./test-utils";
+
+import { groupRowsByViewport } from "../src/message-utils";
+
+describe("message-utils", () => {
+  describe("groupRowsByViewport", () => {
+    it("returns empty map for empty rowset", () => {
+      expect(groupRowsByViewport([])).toEqual({});
+    });
+    it("preserves order of rows in map by viewport, simple rowset", () => {
+      const rows = createTableRows("server-vp-1", 0, 10);
+      expect(groupRowsByViewport(rows)).toEqual({
+        "server-vp-1": rows,
+      });
+    });
+
+    it("preserves order of rows in map by viewport, multiple rowsets, same viewport", () => {
+      const rows1 = createTableRows("server-vp-1", 0, 10);
+      const rows2 = createTableRows("server-vp-1", 0, 10);
+      expect(groupRowsByViewport(rows1.concat(rows2))).toEqual({
+        "server-vp-1": rows1.concat(rows2),
+      });
+    });
+
+    it("preserves order of rows in map by viewport, multiple rowsets, multiple viewports", () => {
+      const rows1 = createTableRows("server-vp-1", 0, 10);
+      const rows2 = createTableRows("server-vp-2", 0, 10);
+      expect(groupRowsByViewport(rows1.concat(rows2))).toEqual({
+        "server-vp-1": rows1,
+        "server-vp-2": rows2,
+      });
+    });
+
+    it("preserves order of rows in map by viewport, multiple rowsets, multiple viewports, interleaved", () => {
+      const rows1 = createTableRows("server-vp-1", 0, 10);
+      const rows2 = createTableRows("server-vp-2", 0, 10);
+      const rows = rows1
+        .concat(rows2)
+        .sort(({ rowIndex: i1 }, { rowIndex: i2 }) => i1 - i2);
+      expect(groupRowsByViewport(rows)).toEqual({
+        "server-vp-1": rows1,
+        "server-vp-2": rows2,
+      });
+    });
+  });
+});


### PR DESCRIPTION
client sorts TABLE_ROW batches by viewport/rowIndex/timestamp. This is wrong, multiple data records for a single viewport/rowIndex can be present within a single batch, with the same timestamp. Because JavaScript sort is unstable, we are losing the original input sequence. 