### PR TITLE
Locally-Persisted Filters

### DIFF
--- a/vuu-ui/package-lock.json
+++ b/vuu-ui/package-lock.json
@@ -965,6 +965,12 @@
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "15.0.15",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.15.tgz",
@@ -4324,6 +4330,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
@@ -5201,7 +5215,11 @@
         "@finos/vuu-data": "0.0.26",
         "@finos/vuu-utils": "0.0.26",
         "@heswell/salt-lab": "1.0.0-alpha.2",
-        "@salt-ds/core": "1.2.0"
+        "@salt-ds/core": "1.2.0",
+        "uuid": "9.0.0"
+      },
+      "devDependencies": {
+        "@types/uuid": "^9.0.2"
       },
       "peerDependencies": {
         "react": "^17.0.2",

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -4,3 +4,8 @@ import { Filter } from "@finos/vuu-filter-types";
 export interface DataSourceFilter extends VuuFilter {
   filterStruct?: Filter;
 }
+
+export interface NamedDataSourceFilter extends DataSourceFilter {
+  id?: string;
+  name?: string;
+}

--- a/vuu-ui/packages/vuu-filters/package.json
+++ b/vuu-ui/packages/vuu-filters/package.json
@@ -15,10 +15,14 @@
     "@finos/vuu-data": "0.0.26",
     "@finos/vuu-utils": "0.0.26",
     "@salt-ds/core": "1.2.0",
-    "@heswell/salt-lab": "1.0.0-alpha.2"
+    "@heswell/salt-lab": "1.0.0-alpha.2",
+    "uuid": "9.0.0"
   },
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "@types/uuid": "^9.0.2"
   }
 }

--- a/vuu-ui/packages/vuu-filters/src/column-filter/ColumnFilter.tsx
+++ b/vuu-ui/packages/vuu-filters/src/column-filter/ColumnFilter.tsx
@@ -1,5 +1,4 @@
 import { ColumnDescriptor } from "@finos/vuu-datagrid-types";
-import { Filter } from "@finos/vuu-filter-types";
 import { TypeaheadParams, VuuTable } from "@finos/vuu-protocol-types";
 import {
   Dropdown,
@@ -14,11 +13,12 @@ import { RangeFilter } from "./RangeFilter";
 import { TypeaheadFilter } from "./TypeaheadFilter";
 import { ColumnListItem } from "./ColumnListItem";
 import { useColumnFilterStore } from "./useColumnFilterStore";
+import { DataSourceFilter } from "@finos/vuu-data-types";
 
 type FilterPanelProps = HTMLAttributes<HTMLDivElement> & {
   table: VuuTable;
   columns: ColumnDescriptor[];
-  onFilterSubmit: (filterQuery: string, filter?: Filter) => void;
+  onFilterSubmit: (filter: DataSourceFilter) => void;
 };
 
 export const ColumnFilter = ({

--- a/vuu-ui/packages/vuu-filters/src/column-filter/useColumnFilterStore.ts
+++ b/vuu-ui/packages/vuu-filters/src/column-filter/useColumnFilterStore.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from "react";
 import { addFilter, AND, filterAsQuery } from "../filter-utils";
 import { IRange } from "./RangeFilter";
 import { ColumnDescriptor } from "@finos/vuu-datagrid-types";
+import { DataSourceFilter } from "@finos/vuu-data-types";
 
 type SavedValue<T extends string[] | IRange> = { column: string; value: T };
 type SavedFilter = { column: string; filter: Filter | undefined };
@@ -12,7 +13,7 @@ const addOrReplace = <T>(array: T[], newValue: T, key: keyof T): T[] =>
   array.filter((oldValue) => oldValue[key] !== newValue[key]).concat(newValue);
 
 export const useColumnFilterStore = (
-  onFilterSubmit: (filterQuery: string, filter?: Filter) => void
+  onFilterSubmit: (filter: DataSourceFilter) => void
 ) => {
   const [selectedColumnName, setSelectedColumnName] = useState("");
   const [savedFilters, setSavedFilters] = useState<SavedFilter[]>([]);
@@ -26,7 +27,7 @@ export const useColumnFilterStore = (
     setRangeValues([]);
     setTypeaheadValues([]);
     setSavedFilters([]);
-    onFilterSubmit("");
+    onFilterSubmit({ filter: "" });
   };
 
   const updateFilters = useCallback(
@@ -47,7 +48,7 @@ export const useColumnFilterStore = (
 
       const query =
         combinedFilter === undefined ? "" : filterAsQuery(combinedFilter);
-      onFilterSubmit(query, combinedFilter);
+      onFilterSubmit({ filter: query, filterStruct: combinedFilter });
     },
     [selectedColumnName, onFilterSubmit, savedFilters]
   );

--- a/vuu-ui/packages/vuu-filters/src/filter-utils.ts
+++ b/vuu-ui/packages/vuu-filters/src/filter-utils.ts
@@ -248,19 +248,19 @@ export const removeFilter = (sourceFilter: Filter, filterToRemove: Filter) => {
 };
 
 export const splitFilterOnColumn = (
-  filter: Filter | null,
-  columnName: string
-): [Filter | null, Filter | null] => {
+  columnName: string,
+  filter?: Filter
+): [Filter | undefined, Filter | undefined] => {
   if (!filter) {
-    return [null, null];
+    return [undefined, undefined];
   }
   if (filter.column === columnName) {
-    return [filter, null];
+    return [filter, undefined];
   }
   if (filter.op !== AND) {
-    return [null, filter];
+    return [undefined, filter];
   }
-  const [[columnFilter = null], filters] = partition(
+  const [[columnFilter = undefined], filters] = partition(
     (filter as AndFilter).filters,
     (f) => f.column === columnName
   );

--- a/vuu-ui/packages/vuu-filters/src/local-config.ts
+++ b/vuu-ui/packages/vuu-filters/src/local-config.ts
@@ -1,0 +1,18 @@
+export const getLocalEntity = <T>(url: string): T | undefined => {
+  const data = localStorage.getItem(url);
+  return data ? JSON.parse(data) : undefined;
+};
+
+export const getAllLocalEntity = <T>(url: string): T[] =>
+  Object.entries(localStorage)
+    .filter(([key]) => key.includes(url))
+    .map(([, value]) => JSON.parse(value) as T);
+
+export const saveLocalEntity = <T>(url: string, data: T): T | undefined => {
+  try {
+    localStorage.setItem(url, JSON.stringify(data));
+    return data;
+  } catch {
+    return undefined;
+  }
+};

--- a/vuu-ui/packages/vuu-filters/src/use-filter-config.ts
+++ b/vuu-ui/packages/vuu-filters/src/use-filter-config.ts
@@ -5,15 +5,14 @@ import { useCallback, useEffect, useState } from "react";
 
 export interface FilterConfigHookProps {
   user: VuuUser;
-  defaultFilter?: NamedDataSourceFilter; // TODO: Use a default filter
   saveUrl?: string;
-  saveLocation: SaveLocation; // TODO: Make this work for "remote"
+  saveLocation: SaveLocation;
 }
 
 export const useFilterConfig = ({
   user,
-  saveUrl = "api/vui/filters", // TODO: Check this is a sensible choice
-  saveLocation,
+  saveUrl = "api/vui/filters",
+  saveLocation = "local", // TODO: "remote" is not supported yet
 }: FilterConfigHookProps) => {
   const [allFilters, setAllFilters] = useState<NamedDataSourceFilter[]>();
 

--- a/vuu-ui/packages/vuu-filters/src/use-filter-config.ts
+++ b/vuu-ui/packages/vuu-filters/src/use-filter-config.ts
@@ -1,0 +1,47 @@
+import { NamedDataSourceFilter } from "@finos/vuu-data-types";
+import { SaveLocation, VuuUser } from "@finos/vuu-shell";
+import { useRestEntityStore } from "./use-rest-config";
+import { useCallback, useEffect, useState } from "react";
+
+export interface FilterConfigHookProps {
+  user: VuuUser;
+  defaultFilter?: NamedDataSourceFilter; // TODO: Use a default filter
+  saveUrl?: string;
+  saveLocation: SaveLocation; // TODO: Make this work for "remote"
+}
+
+export const useFilterConfig = ({
+  user,
+  saveUrl = "api/vui/filters", // TODO: Check this is a sensible choice
+  saveLocation,
+}: FilterConfigHookProps) => {
+  const [allFilters, setAllFilters] = useState<NamedDataSourceFilter[]>();
+
+  const { get, getAll, save } = useRestEntityStore<NamedDataSourceFilter>({
+    baseUrl: `${saveUrl}/${user.username}`,
+    saveLocation,
+  });
+
+  const refreshAllFilters = useCallback(async () => {
+    const filters = await getAll();
+    setAllFilters(filters);
+  }, [getAll]);
+
+  useEffect(() => {
+    refreshAllFilters().catch((err) => console.error(err));
+  }, [refreshAllFilters]);
+
+  const saveFilter = useCallback(
+    async (filter: NamedDataSourceFilter) => {
+      await save(filter);
+      await refreshAllFilters();
+    },
+    [save, refreshAllFilters]
+  );
+
+  return {
+    allFilters,
+    getFilterById: get,
+    saveFilter,
+  };
+};

--- a/vuu-ui/packages/vuu-filters/src/use-rest-config.ts
+++ b/vuu-ui/packages/vuu-filters/src/use-rest-config.ts
@@ -1,0 +1,70 @@
+import { SaveLocation } from "@finos/vuu-shell";
+import { useCallback } from "react";
+import { v4 as uuidv4 } from "uuid";
+import {
+  getAllLocalEntity,
+  getLocalEntity,
+  saveLocalEntity,
+} from "./local-config";
+
+type EntityStoreProps = {
+  baseUrl: string;
+  saveLocation: SaveLocation;
+};
+
+export const useRestEntityStore = <T>({
+  baseUrl,
+  saveLocation,
+}: EntityStoreProps) => {
+  const usingLocal = saveLocation === "local";
+
+  const getAll = useCallback(async (): Promise<T[] | undefined> => {
+    if (usingLocal) return getAllLocalEntity(baseUrl);
+    try {
+      const response = await fetch(baseUrl, {});
+      if (response.ok) {
+        return await response.json();
+      }
+    } catch {
+      console.error(`Failed to load entity at ${baseUrl}`);
+    }
+  }, [baseUrl, usingLocal]);
+
+  const get = useCallback(
+    async (id: string): Promise<T | undefined> => {
+      if (usingLocal) return getLocalEntity(`${baseUrl}/${id}`);
+      try {
+        const response = await fetch(`${baseUrl}/${id}`, {});
+        if (response.ok) {
+          return await response.json();
+        }
+      } catch {
+        console.error(`Failed to load entity at ${baseUrl}/${id}`);
+      }
+    },
+    [baseUrl, usingLocal]
+  );
+
+  const save = useCallback(
+    async (data: T): Promise<T | undefined> => {
+      if (usingLocal) return saveLocalEntity(`${baseUrl}/${uuidv4()}`, data);
+      try {
+        const response = await fetch(baseUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(data),
+        });
+        if (response.ok) {
+          return await response.json();
+        }
+      } catch {
+        console.error(`Failed to save entity at ${baseUrl}`);
+      }
+    },
+    [baseUrl, usingLocal]
+  );
+
+  return { getAll, get, save };
+};

--- a/vuu-ui/packages/vuu-shell/src/layout-config/use-layout-config.ts
+++ b/vuu-ui/packages/vuu-shell/src/layout-config/use-layout-config.ts
@@ -29,17 +29,13 @@ export const useLayoutConfig = ({
   const loadConfig = usingRemote ? loadRemoteConfig : loadLocalConfig;
   const saveConfig = usingRemote ? saveRemoteConfig : saveLocalConfig;
 
-  const setLayout = (layout: LayoutJSON) => {
-    _setLayout(layout);
-  };
-
   const load = useCallback(
     async (id = "latest") => {
       try {
         const layout = await loadConfig(saveUrl, user, id);
-        setLayout(layout);
+        _setLayout(layout);
       } catch {
-        setLayout(defaultLayout);
+        _setLayout(defaultLayout);
       }
     },
     [defaultLayout, loadConfig, saveUrl, user]
@@ -56,12 +52,7 @@ export const useLayoutConfig = ({
     [saveConfig, saveUrl, user]
   );
 
-  const loadLayoutById = useCallback(
-    (id) => {
-      load(id);
-    },
-    [load]
-  );
+  const loadLayoutById = useCallback((id) => load(id), [load]);
 
   return [layout, saveData, loadLayoutById];
 };

--- a/vuu-ui/sample-apps/feature-vuu-blotter/src/VuuBlotter.tsx
+++ b/vuu-ui/sample-apps/feature-vuu-blotter/src/VuuBlotter.tsx
@@ -5,7 +5,7 @@ import {
   isVisualLinksAction,
 } from "@finos/vuu-data";
 import { GridAction } from "@finos/vuu-datagrid-types";
-import { Filter } from "@finos/vuu-filter-types";
+import { Filter, FilterState } from "@finos/vuu-filter-types";
 import {
   addFilter,
   filterAsQuery,
@@ -43,12 +43,6 @@ import "./VuuBlotter.css";
 const classBase = "vuuBlotter";
 
 const CONFIG_KEYS = ["filter", "filterQuery", "groupBy", "sort"];
-
-type FilterState = {
-  filter: Filter | undefined;
-  filterQuery: string;
-  filterName?: string;
-};
 
 type BlotterConfig = {
   columns?: KeyedColumnDescriptor[];

--- a/vuu-ui/showcase/src/examples/DataGrid/Grid.stories.tsx
+++ b/vuu-ui/showcase/src/examples/DataGrid/Grid.stories.tsx
@@ -29,6 +29,7 @@ import { ErrorDisplay, useSchemas, useTestDataSource } from "../utils";
 import { instrumentSchema } from "./columnMetaData";
 
 import "./Grid.stories.css";
+import { DataSourceFilter } from "@finos/vuu-data-types";
 
 let displaySequence = 1;
 
@@ -292,8 +293,8 @@ export const DefaultGridWithFilter = () => {
     return <ErrorDisplay>{error}</ErrorDisplay>;
   }
 
-  function handleFilterSubmit(filterQuery: string) {
-    dataSource.filter = { filter: filterQuery };
+  function handleFilterSubmit(filter: DataSourceFilter) {
+    dataSource.filter = filter;
   }
 
   return (

--- a/vuu-ui/showcase/src/examples/Filters/ColumnFilter.stories.tsx
+++ b/vuu-ui/showcase/src/examples/Filters/ColumnFilter.stories.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
-import { Filter } from "@finos/vuu-filter-types";
 import { ColumnFilter } from "@finos/vuu-filters";
 import { useSchemas, useTestDataSource } from "../utils";
+import { DataSourceFilter } from "@finos/vuu-data-types";
 
 export const DefaultColumnFilter = () => {
   const { schemas } = useSchemas();
@@ -11,9 +11,9 @@ export const DefaultColumnFilter = () => {
   });
 
   const handleFilterSubmit = useCallback(
-    (filterQuery: string, filter?: Filter) => {
-      console.log("Query:", filterQuery);
-      dataSource.filter = { filterStruct: filter, filter: filterQuery };
+    (filter: DataSourceFilter) => {
+      console.log("Query:", filter.filter);
+      dataSource.filter = filter;
     },
     [dataSource]
   );

--- a/vuu-ui/showcase/src/examples/Filters/FilterInput.stories.tsx
+++ b/vuu-ui/showcase/src/examples/Filters/FilterInput.stories.tsx
@@ -1,4 +1,4 @@
-import { Filter } from "@finos/vuu-filter-types";
+import { Filter, FilterState } from "@finos/vuu-filter-types";
 import {
   addFilter,
   filterAsQuery,
@@ -30,12 +30,6 @@ const schemaColumns = [
 ];
 
 export const DefaultFilterInput = () => {
-  type FilterState = {
-    filter: Filter | undefined;
-    filterQuery: string;
-    filterName?: string;
-  };
-
   const namedFilters = useMemo(() => new Map<string, string>(), []);
   const [filterState, setFilterState] = useState<FilterState>({
     filter: undefined,
@@ -53,7 +47,7 @@ export const DefaultFilterInput = () => {
     (
       newFilter: Filter | undefined,
       filterQuery: string,
-      mode: "and" | "or" | "replace" = "replace",
+      mode: FilterSubmissionMode = "replace",
       filterName?: string
     ) => {
       let newFilterState: FilterState;
@@ -102,15 +96,9 @@ export const DefaultFilterInput = () => {
 DefaultFilterInput.displaySequence = displaySequence++;
 
 export const FilterInputTabs = () => {
-  type FilterState = {
-    filter: Filter | undefined;
-    filterQuery: string;
-    filterName?: string;
-  };
-
-  // prettier-ignore
   const saveOptions = useMemo<FilterSaveOptions>(
-    () => ({ allowReplace: true, allowSaveAsTab: true,}), []
+    () => ({ allowReplace: true, allowSaveAsTab: true }),
+    []
   );
 
   const namedFilters = useMemo(() => new Map<string, string>(), []);

--- a/vuu-ui/showcase/src/examples/Filters/FilterInput.stories.tsx
+++ b/vuu-ui/showcase/src/examples/Filters/FilterInput.stories.tsx
@@ -4,6 +4,7 @@ import {
   filterAsQuery,
   FilterInput,
   FilterSaveOptions,
+  filterSubmissionHandler,
   FilterToolbar,
   updateFilter,
   useFilterSuggestionProvider,
@@ -14,6 +15,10 @@ import { useAutoLoginToVuuServer } from "../utils/useAutoLoginToVuuServer";
 
 import {} from "@finos/vuu-utils";
 import { FilterSubmissionMode } from "@finos/vuu-filters/src/filter-input/useFilterAutoComplete";
+import { Button } from "@salt-ds/core";
+import { useFilterConfig } from "@finos/vuu-filters/src/use-filter-config";
+import { Dropdown, SelectionChangeHandler } from "@heswell/salt-lab";
+import { NamedDataSourceFilter } from "@finos/vuu-data-types";
 
 let displaySequence = 1;
 
@@ -90,6 +95,104 @@ export const DefaultFilterInput = () => {
       <br />
       <br />
       <JsonTable source={filterState.filter} height={400} />
+    </>
+  );
+};
+DefaultFilterInput.displaySequence = displaySequence++;
+
+export const DefaultFilterInputWithPersistence = () => {
+  const user = { username: "test-user", token: "test-token" };
+  const namedFilters = useMemo(() => new Map<string, string>(), []);
+  const [filterState, setFilterState] = useState<FilterState>({
+    filter: undefined,
+    filterQuery: "",
+  });
+  const suggestionProvider = useFilterSuggestionProvider({
+    columns: schemaColumns,
+    namedFilters,
+    table,
+  });
+  const { allFilters, saveFilter } = useFilterConfig({
+    user,
+    saveLocation: "local",
+  });
+
+  useAutoLoginToVuuServer();
+
+  const handleSubmitFilter: filterSubmissionHandler = useCallback(
+    (
+      newFilter,
+      filterQuery,
+      mode: FilterSubmissionMode = "replace",
+      filterName
+    ) => {
+      let newFilterState: FilterState;
+      if (newFilter && mode === "and") {
+        const fullFilter = addFilter(filterState.filter, newFilter) as Filter;
+        newFilterState = {
+          filter: fullFilter,
+          filterQuery: filterAsQuery(fullFilter),
+          filterName,
+        };
+      } else {
+        newFilterState = {
+          filter: newFilter,
+          filterQuery,
+          filterName,
+        };
+      }
+
+      setFilterState(newFilterState);
+      if (filterName && newFilterState.filter) {
+        namedFilters.set(filterName, newFilterState.filterQuery);
+      }
+    },
+    [filterState.filter, namedFilters]
+  );
+
+  const onClick = () =>
+    saveFilter({
+      name: filterState.filterName,
+      filter: filterState.filterQuery,
+      filterStruct: filterState.filter,
+    });
+
+  const onSelectionChange: SelectionChangeHandler<NamedDataSourceFilter> = (
+    _e,
+    selected
+  ) => {
+    if (!selected) return;
+    setFilterState({
+      filter: selected.filterStruct,
+      filterQuery: selected.filter,
+      filterName: selected.name,
+    });
+  };
+
+  return (
+    <>
+      <FilterInput
+        existingFilter={filterState.filter}
+        namedFilters={namedFilters}
+        onSubmitFilter={handleSubmitFilter}
+        suggestionProvider={suggestionProvider}
+      />
+      <br />
+      <br />
+      <p>
+        {`Active filter: ${filterState.filterQuery} ${
+          filterState.filterName ? "as" : ""
+        } ${filterState.filterName}`}
+      </p>
+      <Button onClick={onClick}>Save current filter</Button>
+      <br />
+      <br />
+      <p>Use the dropdown below to select a previously saved filter</p>
+      <Dropdown<NamedDataSourceFilter>
+        source={allFilters}
+        onSelectionChange={onSelectionChange}
+        itemToString={(filter) => filter.name || "Default name"}
+      />
     </>
   );
 };


### PR DESCRIPTION
This PR addresses issue #403 

### Features:

Local persisting of filters via new `useFilterConfig` hook 
- Access previously saved filters and save new filters
- Hook is accessible from any Vuu component
- Locally persisted filters are stored using a `/api/vuu/filters/{filterId}` namespacing.
- Adds dependency for `uuid` for generating unique IDs for filters

Basic example of usage set up in the showcase
1. Enter filter as usual in filter input ![image](https://github.com/finos/vuu/assets/44348871/4fd8b15d-9f68-47c1-87e4-17a3452352eb)
2. Click on 'save current filter'
3. (Optional) Clear the current filter, refresh the page, etc
4. Select a previously saved filter from the dropdown ![image](https://github.com/finos/vuu/assets/44348871/be2d5215-9b2b-418b-9725-e8c30138b5b9)