### PR TITLE
Update cve-scanning.yml to always upload artifacts

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -25,10 +25,11 @@ jobs:
           format: 'HTML'
           out: 'reports' # this is the default, no need to specify unless you wish to override it
           args: >
-           --failOnCVSS 7
+           --failOnCVSS 5
            --enableRetired	
       - name: Upload Test results
-        uses: actions/upload-artifact@master
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
         with:
-           name: Depcheck report
-           path: ${{github.workspace}}/reports
+          name: Depcheck report
+          path: ${{ github.workspace }}/reports


### PR DESCRIPTION
Changed  ` --failOnCVSS 7` to  `--failOnCVSS 5 ` (value previously used)

If the build failed, the action will not upload artifact, adding ` if: ${{ always() }}`  will always upload artifacts even if build failed because of CVEs