### PR TITLE
omit special columns from ag grid column order check

### DIFF
--- a/vuu-ui/packages/vuu-data-ag-grid/src/AgGridColumnUtils.ts
+++ b/vuu-ui/packages/vuu-data-ag-grid/src/AgGridColumnUtils.ts
@@ -32,6 +32,12 @@ const firstColIsGroup = (colDefs: { colId: string }[]) => {
   return colDefs.length > 1 && colDefs[0].colId.startsWith("ag-Grid-Auto");
 };
 
+// helps prevent a bug where the dataSource is switched on an AgGrid table
+// and the new dataSource may have one or more columns with same name as
+// previous dataSource. AgGrid seems to 'remember' the columns and they get
+// rendered before all other columns, irrespective of the column order
+// of the colDefs. Interestingly, tried making the columnNames unique to the
+// dataSource, but didn't fix issue.
 export const columnsDisordered = (
   colDefs: { colId: string }[],
   colState: AgGridColDef[]
@@ -41,7 +47,9 @@ export const columnsDisordered = (
     return true;
   }
   for (let i = 0; i < defs.length; i++) {
-    if (defs[i].colId !== colState[i].field) {
+    if (colState[i].field === undefined || colState[i].hide === true) {
+      continue;
+    } else if (defs[i].colId !== colState[i].field) {
       return true;
     }
   }


### PR DESCRIPTION
when we check column changed event in ag grid, we check that internal state is not out of sync with configured colDefs (which can happen if we switch tables)

Omit 'special' columns from this check - ones which are not actually data columns. 