### PR TITLE
explicitly use salt theme for sample app, avoid global css declarations

### DIFF
--- a/vuu-ui/packages/vuu-popups/src/dialog/Dialog.css
+++ b/vuu-ui/packages/vuu-popups/src/dialog/Dialog.css
@@ -33,7 +33,6 @@
   align-items: flex-start;
   align-self: stretch;
   color: var(--light-text-primary, #15171B);
-  font-family: Nunito Sans Regular;
   font-feature-settings: 'ss02' on, 'ss01' on, 'salt' on, 'liga' off;
   font-size: 16px;
   font-weight: 600;

--- a/vuu-ui/packages/vuu-shell/src/layout-management/SaveLayoutPanel.css
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/SaveLayoutPanel.css
@@ -1,14 +1,11 @@
-* {
+.saveLayoutPanel {
   --salt-selectable-foreground-hover: #6d18bdc3;
   --salt-selectable-foreground-selected: #6D18BD;
   --salt-selectable-borderColor-selected: #6D18BD;
-  --saltInputLegacy-fontFamily: Nunito Sans;
-  --salt-text-fontFamily: Nunito Sans;
   --saltInputLegacy-fontSize: 12px;
   --salt-text-label-fontSize: 10px;
   --saltFormFieldLegacy-label-paddingLeft: 0;
   --saltFormField-label-fontWeight: 400;
-  font-family: Nunito Sans Regular;
 }
 
 .saveLayoutPanel-panelContainer {

--- a/vuu-ui/packages/vuu-shell/src/theme-provider/ThemeProvider.tsx
+++ b/vuu-ui/packages/vuu-shell/src/theme-provider/ThemeProvider.tsx
@@ -41,7 +41,7 @@ export const useThemeAttributes = (): [string, string, string] => {
   if (context) {
     return [
       `${context.theme}-theme`,
-      `vuu-density-${context.density}`,
+      `${context.theme}-density-${context.density}`,
       context.themeMode,
     ];
   }

--- a/vuu-ui/sample-apps/app-vuu-example/src/App.tsx
+++ b/vuu-ui/sample-apps/app-vuu-example/src/App.tsx
@@ -7,6 +7,7 @@ import {
   SessionEditingForm,
   Shell,
   ShellContextProvider,
+  ThemeProvider,
   VuuUser,
 } from "@finos/vuu-shell";
 import { ReactElement, useCallback, useRef, useState } from "react";
@@ -115,23 +116,25 @@ export const App = ({ user }: { user: VuuUser }) => {
   // TODO get Context from Shell
   return (
     <ShellContextProvider value={{ getDefaultColumnConfig, handleRpcResponse }}>
-      <Shell
-        className="App"
-        defaultLayout={defaultLayout}
-        leftSidePanel={<AppSidePanel features={features} tables={tables} />}
-        serverUrl={serverUrl}
-        user={user}
-      >
-        <Dialog
-          className="vuDialog"
-          isOpen={dialogContent !== undefined}
-          onClose={handleClose}
-          style={{ maxHeight: 500 }}
-          title={dialogTitleRef.current}
+      <ThemeProvider theme="salt">
+        <Shell
+          className="App"
+          defaultLayout={defaultLayout}
+          leftSidePanel={<AppSidePanel features={features} tables={tables} />}
+          serverUrl={serverUrl}
+          user={user}
         >
-          {dialogContent}
-        </Dialog>
-      </Shell>
+          <Dialog
+            className="vuDialog"
+            isOpen={dialogContent !== undefined}
+            onClose={handleClose}
+            style={{ maxHeight: 500 }}
+            title={dialogTitleRef.current}
+          >
+            {dialogContent}
+          </Dialog>
+        </Shell>
+      </ThemeProvider>
     </ShellContextProvider>
   );
 };


### PR DESCRIPTION
we have some style regressions in sample app. Mainly because theme has switched default to new vuu theme. 
Speficy salt theme explicitly for sample app.
ALso have a few global style declarations that have crept in, setting salt characteristics. These will apply under any theme.