### PR TITLE
temp fix to checkboxicon (until we figure out underlying cause)

### DIFF
--- a/vuu-ui/packages/vuu-ui-controls/src/list/CheckboxIcon.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/list/CheckboxIcon.tsx
@@ -1,4 +1,6 @@
-import { HTMLAttributes } from "react";
+// TODO why do we need explicit React import - its not needed anywhere else
+// but we see a 'React is not defined' issue in showcase without it
+import React, { HTMLAttributes } from "react";
 import cx from "classnames";
 
 import "./CheckboxIcon.css";


### PR DESCRIPTION
not sure why we see a React is not defined issue in built version of showcase. Its referring to CheckboxIcon component. This issue is normally associated with JSX transform not being applied, but that should be in place and we don't see any issue with other components.
Until we get to the bottom of it, including an explicit import of React for CheckboxIcon. 