### PR TITLE
enhance Tab suppoprt for popup menu

### DIFF
--- a/vuu-ui/packages/vuu-ui-controls/src/tabstrip/Tab.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/tabstrip/Tab.tsx
@@ -45,7 +45,7 @@ export const Tab = forwardRef(function Tab(
     onMenuClose,
     orientation,
     selected,
-    showMenuButton = closeable || editable,
+    showMenuButton = closeable || editable || Boolean(location),
     tabIndex,
     ...props
   }: TabProps,

--- a/vuu-ui/packages/vuu-ui-controls/src/tabstrip/TabsTypes.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/tabstrip/TabsTypes.ts
@@ -72,7 +72,7 @@ export interface TabstripProps extends HTMLAttributes<HTMLDivElement> {
   editing?: boolean;
   keyBoardActivation?: "manual" | "automatic";
   /**
-   * A custom context menu location for TabMenu
+   * A custom context menu location for TabMenu, applied to all tabs
    */
   location?: string;
   /**
@@ -108,7 +108,7 @@ export interface TabstripProps extends HTMLAttributes<HTMLDivElement> {
   promptForNewTabName?: boolean;
   /**
    * Should each tab render a popup menu. Default is false if tab is
-   * not closeable or renameable, otherwise true.
+   * not closeable, not renameable and has no tab-location , otherwise true.
    */
   showTabMenuButton?: boolean;
 }

--- a/vuu-ui/packages/vuu-ui-controls/src/tabstrip/Tabstrip.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/tabstrip/Tabstrip.tsx
@@ -72,6 +72,7 @@ export const Tabstrip = ({
             id: tabId = `${id}-tab-${index}`,
             closeable = allowCloseTab,
             editable = allowRenameTab,
+            location: tabLocation,
             showMenuButton = showTabMenuButton,
           } = child.props;
           const selected = index === activeTabIndex;
@@ -86,7 +87,7 @@ export const Tabstrip = ({
             id: tabId,
             index,
             key: index,
-            location,
+            location: cx(location, tabLocation),
             selected,
             showMenuButton,
             tabIndex: selected ? 0 : -1,


### PR DESCRIPTION
allow more precise provisioning of tab menus in Tabs. Individual tabs may have menus, whilst others do not. 
Menu location can be specified at Tabstrip level (shared across tabs) and at tab level (specific to targetted tab).