### PR TITLE
fix package dependencies

### DIFF
--- a/vuu-ui/package-lock.json
+++ b/vuu-ui/package-lock.json
@@ -11369,6 +11369,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@finos/vuu-filter-parser": "0.0.26",
+        "@finos/vuu-layout": "0.0.26",
+        "@finos/vuu-table-extras": "0.0.26",
+        "@finos/vuu-ui-controls": "0.0.26",
         "@finos/vuu-utils": "0.0.26"
       },
       "devDependencies": {
@@ -12691,7 +12694,10 @@
         "@finos/vuu-datagrid-types": "0.0.26",
         "@finos/vuu-filter-parser": "0.0.26",
         "@finos/vuu-filter-types": "0.0.26",
+        "@finos/vuu-layout": "0.0.26",
         "@finos/vuu-protocol-types": "0.0.26",
+        "@finos/vuu-table-extras": "0.0.26",
+        "@finos/vuu-ui-controls": "0.0.26",
         "@finos/vuu-utils": "0.0.26"
       }
     },

--- a/vuu-ui/packages/vuu-datatable/package.json
+++ b/vuu-ui/packages/vuu-datatable/package.json
@@ -11,9 +11,12 @@
   "dependencies": {
     "@finos/vuu-data": "0.0.26",
     "@finos/vuu-datagrid-types": "0.0.26",
+    "@finos/vuu-filters": "0.0.26",
+    "@finos/vuu-layout": "0.0.26",
     "@finos/vuu-popups": "0.0.26",
     "@finos/vuu-table": "0.0.26",
     "@finos/vuu-table-extras": "0.0.26",
+    "@finos/vuu-ui-controls": "0.0.26",
     "@finos/vuu-utils": "0.0.26"
   },
   "peerDependencies": {

--- a/vuu-ui/packages/vuu-layout/package.json
+++ b/vuu-ui/packages/vuu-layout/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "@salt-ds/core": "1.8.0",
     "@finos/vuu-popups": "0.0.26",
+    "@finos/vuu-table": "0.0.26",
+    "@finos/vuu-table-extras": "0.0.26",
+    "@finos/vuu-ui-controls": "0.0.26",
     "@finos/vuu-utils": "0.0.26"
   },
   "peerDependencies": {

--- a/vuu-ui/packages/vuu-popups/package.json
+++ b/vuu-ui/packages/vuu-popups/package.json
@@ -13,8 +13,12 @@
     "@salt-ds/core": "1.8.0",
     "@salt-ds/icons": "1.5.1",
     "@salt-ds/lab": "1.0.0-alpha.15",
+    "@finos/vuu-data": "0.0.26",
     "@finos/vuu-data-types": "0.0.26",
-    "@finos/vuu-utils": "0.0.26"
+    "@finos/vuu-layout": "0.0.26",
+    "@finos/vuu-shell": "0.0.26",
+    "@finos/vuu-utils": "0.0.26",
+    "@finos/vuu-ui-controls": "0.0.26"
   },
   "peerDependencies": {
     "classnames": "^2.2.6",

--- a/vuu-ui/packages/vuu-shell/package.json
+++ b/vuu-ui/packages/vuu-shell/package.json
@@ -14,7 +14,11 @@
     "@salt-ds/icons": "1.5.1",
     "@salt-ds/lab": "1.0.0-alpha.15",
     "@finos/vuu-data": "0.0.26",
+    "@finos/vuu-filters": "0.0.26",
     "@finos/vuu-layout": "0.0.26",
+    "@finos/vuu-table": "0.0.26",
+    "@finos/vuu-table-extras": "0.0.26",
+    "@finos/vuu-ui-controls": "0.0.26",
     "@finos/vuu-utils": "0.0.26"
   },
   "peerDependencies": {

--- a/vuu-ui/packages/vuu-table/package.json
+++ b/vuu-ui/packages/vuu-table/package.json
@@ -13,8 +13,12 @@
     "@salt-ds/icons": "1.5.1",
     "@salt-ds/lab": "1.0.0-alpha.15",
     "@finos/vuu-data": "0.0.26",
+    "@finos/vuu-data-react": "0.0.26",
     "@finos/vuu-data-types": "0.0.26",
+    "@finos/vuu-layout": "0.0.26",
     "@finos/vuu-popups": "0.0.26",
+    "@finos/vuu-table-extras": "0.0.26",
+    "@finos/vuu-ui-controls": "0.0.26",
     "@finos/vuu-utils": "0.0.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
there were a number of missing dependencies on vuu packages, causing unnecessary re-bundling. All dependencies are now declared . Some of these look   suspicious and can probably be optimised. At least dependencies now correctly reflect code usage within packages.