### PR TITLE
ensure basket feature tables suspend and resume at right time

### DIFF
--- a/vuu-ui/packages/vuu-data/src/inlined-worker.js
+++ b/vuu-ui/packages/vuu-data/src/inlined-worker.js
@@ -1876,11 +1876,13 @@ var ServerProxy = class {
     this.sendIfReady(request, requestId, viewport.status === "subscribed");
   }
   disableViewport(viewport) {
+    console.log("disable viewport");
     const requestId = nextRequestId();
     const request = viewport.disable(requestId);
     this.sendIfReady(request, requestId, viewport.status === "subscribed");
   }
   enableViewport(viewport) {
+    console.log("enable viewport");
     if (viewport.disabled) {
       const requestId = nextRequestId();
       const request = viewport.enable(requestId);

--- a/vuu-ui/packages/vuu-data/src/remote-data-source.ts
+++ b/vuu-ui/packages/vuu-data/src/remote-data-source.ts
@@ -238,6 +238,7 @@ export class RemoteDataSource
   }
 
   suspend() {
+    console.log(`suspend #${this.viewport}, current status ${this.#status}`);
     info?.(`suspend #${this.viewport}, current status ${this.#status}`);
     if (this.viewport) {
       this.#status = "suspended";
@@ -266,6 +267,7 @@ export class RemoteDataSource
   }
 
   disable() {
+    console.log(`disable #${this.viewport}, current status ${this.#status}`);
     info?.(`disable #${this.viewport}, current status ${this.#status}`);
     if (this.viewport) {
       this.#status = "disabling";

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -72,7 +72,6 @@ export const LayoutManagementProvider = (
 
   const saveApplicationLayout = useCallback(
     (layout: LayoutJSON) => {
-      console.log(`save application layout ${JSON.stringify(layout, null, 2)}`);
       const persistenceManager = getPersistenceManager();
       setApplicationLayout(layout, false);
       persistenceManager.saveApplicationLayout(layout);

--- a/vuu-ui/packages/vuu-table/src/table-next/useDataSource.ts
+++ b/vuu-ui/packages/vuu-table/src/table-next/useDataSource.ts
@@ -44,6 +44,7 @@ export const useDataSource = ({
 
   const setData = useCallback(
     (updates: DataSourceRow[]) => {
+      console.table(updates);
       for (const row of updates) {
         dataWindow.add(row);
       }
@@ -51,6 +52,8 @@ export const useDataSource = ({
       if (isMounted.current) {
         // TODO do we ever need to worry about missing updates here ?
         forceUpdate({});
+      } else {
+        console.log(`ignore update as we're not mounted`);
       }
     },
     [dataWindow]
@@ -84,17 +87,14 @@ export const useDataSource = ({
     return dataWindow.getSelectedRows();
   }, [dataWindow]);
 
-  useEffect(
-    () => () => {
-      isMounted.current = true;
-      // if (rafHandle.current) {
-      //   cancelAnimationFrame(rafHandle.current);
-      //   rafHandle.current = null;
-      // }
+  useEffect(() => {
+    isMounted.current = true;
+    dataSource.resume?.();
+    return () => {
       isMounted.current = false;
-    },
-    []
-  );
+      dataSource.suspend?.();
+    };
+  }, [dataSource]);
 
   // Keep until we'tre sure we don't need it for updates
   // const refreshIfUpdated = useCallback(() => {

--- a/vuu-ui/sample-apps/feature-filter-table/src/useFilterTable.tsx
+++ b/vuu-ui/sample-apps/feature-filter-table/src/useFilterTable.tsx
@@ -12,7 +12,7 @@ import { ActiveItemChangeHandler, useViewContext } from "@finos/vuu-layout";
 import { useShellContext } from "@finos/vuu-shell";
 import { applyDefaultColumnConfig } from "@finos/vuu-utils";
 import { Button } from "@salt-ds/core";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useSessionDataSource } from "./useSessionDataSource";
 import { FilterTableFeatureProps } from "./VuuFilterTableFeature";
 
@@ -160,13 +160,6 @@ export const useFilterTable = ({ tableSchema }: FilterTableFeatureProps) => {
     }),
     [load]
   );
-
-  useEffect(() => {
-    dataSource.resume?.();
-    return () => {
-      dataSource.suspend?.();
-    };
-  }, [dataSource]);
 
   const { buildViewserverMenuOptions, handleMenuAction } = useVuuMenuActions({
     dataSource,


### PR DESCRIPTION
When switching top-level application tabs, we suspend all tables from the abandoned tab, so we don't waste energy processing updates for tables that are not even on screen. 
We resume again once tab is re-opened.

The suspend/resume was previously done at the feature level , which worked for simple, single-table features like the default FilterTable feature. It doesn't work for complex Features like basket trading. We resume when the feature tab is re-opened, but there is a delay (milliseconds) before the datagrid is rendered, Thats enough time to miss the initial dataset sent by server, so by time table is rendered we only see it fill progressively as indicidual rows tick.

Solution: move suspend/resume down to individidual table level, so resume doesn't get called until table is actually rendered.