### PR TITLE
VUU-333: Add Spring Boot integration tests for valid JSON in 'definition' field of layout requests

### DIFF
--- a/layout-server/src/test/java/org/finos/vuu/layoutserver/integration/ApplicationLayoutIntegrationTest.java
+++ b/layout-server/src/test/java/org/finos/vuu/layoutserver/integration/ApplicationLayoutIntegrationTest.java
@@ -6,6 +6,7 @@ import org.finos.vuu.layoutserver.exceptions.InternalServerErrorException;
 import org.finos.vuu.layoutserver.model.ApplicationLayout;
 import org.finos.vuu.layoutserver.repository.ApplicationLayoutRepository;
 import org.finos.vuu.layoutserver.utils.DefaultApplicationLayoutLoader;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -47,6 +48,11 @@ public class ApplicationLayoutIntegrationTest {
     @MockBean
     private DefaultApplicationLayoutLoader mockLoader;
     private final DefaultApplicationLayoutLoader realLoader = new DefaultApplicationLayoutLoader();
+
+    @BeforeEach
+    public void setUp() {
+        repository.deleteAll();
+    }
 
     @Test
     public void getApplicationLayout_noLayoutExists_returns200WithDefaultLayout() throws Exception {

--- a/layout-server/src/test/java/org/finos/vuu/layoutserver/integration/LayoutIntegrationTest.java
+++ b/layout-server/src/test/java/org/finos/vuu/layoutserver/integration/LayoutIntegrationTest.java
@@ -257,7 +257,6 @@ public class LayoutIntegrationTest {
         assertThat(metadataRepository.findAll()).isEmpty();
     }
 
-
     @Test
     void createLayout_invalidRequestBodyMetadataIsNull_returns400AndDoesNotCreateLayout()
             throws Exception {

--- a/layout-server/src/test/java/org/finos/vuu/layoutserver/integration/LayoutIntegrationTest.java
+++ b/layout-server/src/test/java/org/finos/vuu/layoutserver/integration/LayoutIntegrationTest.java
@@ -228,6 +228,37 @@ public class LayoutIntegrationTest {
     }
 
     @Test
+    void createLayout_invalidRequestBodyDefinitionIsNotValidJSON_returns400AndDoesNotCreateLayout()
+        throws Exception {
+        String layoutRequestString =
+            "{\n"
+                + "  \"definition\": invalidJson,\n"
+                + "  \"metadata\": {\n"
+                + "    \"name\": \"string\",\n"
+                + "    \"group\": \"string\",\n"
+                + "    \"screenshot\": \"string\",\n"
+                + "    \"user\": \"string\"\n"
+                + "  }\n"
+                + "}";
+
+        mockMvc.perform(
+                post("/layouts").content(layoutRequestString).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.messages", iterableWithSize(1)))
+            .andExpect(jsonPath("$.messages", contains(
+                "JSON parse error: Unrecognized token 'invalidJson': was expecting (JSON String, "
+                    + "Number, Array, Object or token 'null', 'true' or 'false'); nested "
+                    + "exception is com.fasterxml.jackson.core.JsonParseException: Unrecognized "
+                    + "token 'invalidJson': was expecting (JSON String, Number, Array, Object or "
+                    + "token 'null', 'true' or 'false')\n at [Source: (org.springframework.util"
+                    + ".StreamUtils$NonClosingInputStream); line: 2, column: 29]")));
+
+        assertThat(layoutRepository.findAll()).isEmpty();
+        assertThat(metadataRepository.findAll()).isEmpty();
+    }
+
+
+    @Test
     void createLayout_invalidRequestBodyMetadataIsNull_returns400AndDoesNotCreateLayout()
             throws Exception {
         LayoutRequestDto layoutRequest = createValidLayoutRequest();
@@ -316,6 +347,36 @@ public class LayoutIntegrationTest {
                 .andExpect(jsonPath("$.messages", contains("definition: Definition must not be null")));
 
         assertThat(layoutRepository.findById(layout.getId()).orElseThrow()).isEqualTo(layout);
+    }
+
+    @Test
+    void updateLayout_invalidRequestBodyDefinitionIsNotValidJSON_returns400AndDoesNotUpdateLayout()
+        throws Exception {
+        String layoutRequestString =
+            "{\n"
+                + "  \"definition\": invalidJson,\n"
+                + "  \"metadata\": {\n"
+                + "    \"name\": \"string\",\n"
+                + "    \"group\": \"string\",\n"
+                + "    \"screenshot\": \"string\",\n"
+                + "    \"user\": \"string\"\n"
+                + "  }\n"
+                + "}";
+
+        mockMvc.perform(put("/layouts/{id}", DEFAULT_LAYOUT_ID).content(layoutRequestString)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.messages", iterableWithSize(1)))
+            .andExpect(jsonPath("$.messages", contains(
+                "JSON parse error: Unrecognized token 'invalidJson': was expecting (JSON String, "
+                    + "Number, Array, Object or token 'null', 'true' or 'false'); nested "
+                    + "exception is com.fasterxml.jackson.core.JsonParseException: Unrecognized "
+                    + "token 'invalidJson': was expecting (JSON String, Number, Array, Object or "
+                    + "token 'null', 'true' or 'false')\n at [Source: (org.springframework.util"
+                    + ".StreamUtils$NonClosingInputStream); line: 2, column: 29]")));
+
+        assertThat(layoutRepository.findAll()).isEmpty();
+        assertThat(metadataRepository.findAll()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Description
[SL Ticket](https://github.com/ScottLogic/finos-vuu/issues/81)
[SL PR](https://github.com/ScottLogic/finos-vuu/pull/119)

[SLVUU81](https://github.com/ScottLogic/finos-vuu/issues/81) refactored the type of `LayoutRequestDTO.definition` to `ObjectNode` to enforce a valid JSON constraint. Tests to ensure this enforcement is successful are missing. This PR adds those tests.

## Change List
- LayoutIntegrationTest & ApplicationIntegrationTest: Add tests for the creation and updating of layouts when the definition is not valid JSON 