### PR TITLE
1073 enable date/time pattern selection through ColumnSettings

### DIFF
--- a/vuu-ui/cypress/pages/ShellWithNewTheme.ts
+++ b/vuu-ui/cypress/pages/ShellWithNewTheme.ts
@@ -4,7 +4,7 @@ import { SHELL_WITH_NEW_THEME_URL } from "../support/e2e/constants";
 export class ShellWithNewTheme {
   visit: () => void = () => {
     cy.visit(SHELL_WITH_NEW_THEME_URL);
-  }
+  };
 
   getContextMenuButton: () => Cypress.Chainable<JQuery<HTMLElement>> = () => {
     return cy
@@ -12,15 +12,15 @@ export class ShellWithNewTheme {
       .findAllByRole("tab")
       .first()
       .findByRole("button", { name: "context menu" });
-  }
+  };
 
   getSaveLayoutButton: () => Cypress.Chainable<JQuery<HTMLElement>> = () => {
     return cy.findByRole("menuitem", { name: "Save Layout" });
-  }
+  };
 
   getMyLayoutsButton: () => Cypress.Chainable<JQuery<HTMLElement>> = () => {
     return cy.findByRole("tab", { name: "MY LAYOUTS" });
-  }
+  };
 
   getLayoutTile: (
     layoutName: string,
@@ -33,12 +33,13 @@ export class ShellWithNewTheme {
     creator: string,
     date: Date
   ) => {
-    const layoutTileName = `${layoutName} ${creator}, ${formatDate(date)}`;
+    const formattedDate = formatDate({ date: "dd.mm.yyyy" })(date);
+    const layoutTileName = `${layoutName} ${creator}, ${formattedDate}`;
 
     return cy
       .findByRole("listbox", { name: "my layouts" })
       .findByRole("list", { name: group })
       .findByRole("listitem", { name: layoutTileName })
       .findByRole("button");
-  }
+  };
 }

--- a/vuu-ui/packages/vuu-data-test/src/simul/reference-data/instruments-extended.ts
+++ b/vuu-ui/packages/vuu-data-test/src/simul/reference-data/instruments-extended.ts
@@ -7,7 +7,7 @@ import { instrumentsData } from "./instruments";
 const instrumentsExtendedData = instrumentsData.map((row) =>
   (row as VuuRowDataItemType[])
     .slice(0, -1)
-    .concat([random(0, 1) === 1, random(0, 1) === 1])
+    .concat([random(0, 1) === 1, random(0, 1) === 1, new Date().getTime()])
 );
 
 const instrumentsExtendedTable = new Table(

--- a/vuu-ui/packages/vuu-data-test/src/simul/simul-schemas.ts
+++ b/vuu-ui/packages/vuu-data-test/src/simul/simul-schemas.ts
@@ -38,6 +38,7 @@ export const schemas: Readonly<Record<SimulTableName, Readonly<TableSchema>>> =
         { name: "ric", serverDataType: "string" },
         { name: "supported", serverDataType: "boolean" },
         { name: "wishlist", serverDataType: "boolean" },
+        { name: "lastUpdated", serverDataType: "long" },
       ],
       key: "ric",
       table: { module: "SIMUL", table: "instruments" },

--- a/vuu-ui/packages/vuu-shell/src/persistence-management/LocalPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-shell/src/persistence-management/LocalPersistenceManager.ts
@@ -32,7 +32,7 @@ export class LocalPersistenceManager implements PersistenceManager {
           const newMetadata: LayoutMetadata = {
             ...metadata,
             id,
-            created: formatDate("dd.mm.yyyy")(new Date()),
+            created: formatDate({ date: "dd.mm.yyyy" })(new Date()),
           };
 
           this.saveLayoutsWithMetadata(

--- a/vuu-ui/packages/vuu-shell/test/layout-persistence/LocalLayoutPersistenceManager.test.ts
+++ b/vuu-ui/packages/vuu-shell/test/layout-persistence/LocalLayoutPersistenceManager.test.ts
@@ -31,7 +31,7 @@ const persistenceManager = new LocalPersistenceManager();
 
 const existingId = "existing_id";
 
-const newDate = formatDate("dd.mm.yyyy")(new Date());
+const newDate = formatDate({ date: "dd.mm.yyyy" })(new Date());
 
 const existingMetadata: LayoutMetadata = {
   id: existingId,

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/BaseNumericFormattingSettings.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/BaseNumericFormattingSettings.tsx
@@ -1,5 +1,5 @@
 import { FormField, FormFieldLabel, Input, Switch } from "@salt-ds/core";
-import { ColumnDescriptor, ColumnTypeFormatting } from "@finos/vuu-table-types";
+import { ColumnTypeFormatting } from "@finos/vuu-table-types";
 import { getTypeFormattingFromColumn } from "@finos/vuu-utils";
 import {
   ChangeEvent,
@@ -12,7 +12,10 @@ import { FormattingSettingsProps } from "./types";
 
 const classBase = "vuuFormattingSettings";
 
-export const NumericFormattingSettings = ({column, onChange}: FormattingSettingsProps) => {
+export const BaseNumericFormattingSettings = ({
+  column,
+  onChangeFormatting: onChange,
+}: FormattingSettingsProps) => {
   const [formattingSettings, setFormattingSettings] =
     useState<ColumnTypeFormatting>(getTypeFormattingFromColumn(column));
 

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/ColumnFormattingPanel.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/ColumnFormattingPanel.tsx
@@ -1,7 +1,6 @@
 import {
   ColumnDescriptor,
   ColumnDescriptorCustomRenderer,
-  ColumnTypeFormatting,
   ColumnTypeRendering,
 } from "@finos/vuu-table-types";
 import { Dropdown, SingleSelectionHandler } from "@finos/vuu-ui-controls";
@@ -11,23 +10,22 @@ import {
   getCellRendererOptions,
   getConfigurationEditor,
   isColumnTypeRenderer,
-  isDateTimeColumn,
   isTypeDescriptor,
 } from "@finos/vuu-utils";
 import { FormField, FormFieldLabel } from "@salt-ds/core";
 import cx from "clsx";
 import { HTMLAttributes, useCallback, useMemo } from "react";
-import { NumericFormattingSettings } from "./NumericFormattingSettings";
-import { DateTimeFormattingSettings } from "./DateTimeFormattingSettings";
+import { BaseNumericFormattingSettings } from "./BaseNumericFormattingSettings";
+import { LongTypeFormattingSettings } from "./LongTypeFormattingSettings";
 import { FormattingSettingsProps } from "./types";
 
 const classBase = "vuuColumnFormattingPanel";
 
 export interface ColumnFormattingPanelProps
-  extends HTMLAttributes<HTMLDivElement> {
+  extends HTMLAttributes<HTMLDivElement>,
+    FormattingSettingsProps {
   availableRenderers: CellRendererDescriptor[];
   column: ColumnDescriptor;
-  onChangeFormatting: (formatting: ColumnTypeFormatting) => void;
   onChangeRendering: (renderProps: ColumnTypeRendering) => void;
 }
 
@@ -38,12 +36,14 @@ export const ColumnFormattingPanel = ({
   className,
   column,
   onChangeFormatting,
+  onChangeType,
   onChangeRendering,
   ...htmlAttributes
 }: ColumnFormattingPanelProps) => {
   const formattingSettingsForType = useMemo(
-    () => formattingSettingsByColType({ column, onChange: onChangeFormatting }),
-    [column, onChangeFormatting]
+    () =>
+      formattingSettingsByColType({ column, onChangeFormatting, onChangeType }),
+    [column, onChangeFormatting, onChangeType]
   );
 
   const ConfigEditor = useMemo<
@@ -119,15 +119,12 @@ export const ColumnFormattingPanel = ({
 function formattingSettingsByColType(props: FormattingSettingsProps) {
   const { column } = props;
 
-  if (isDateTimeColumn(column)) {
-    return <DateTimeFormattingSettings {...props} column={column} />;
-  }
-
   switch (column.serverDataType) {
     case "double":
     case "int":
+      return <BaseNumericFormattingSettings {...props} />;
     case "long":
-      return <NumericFormattingSettings {...props} />;
+      return <LongTypeFormattingSettings {...props} />;
     default:
       return null;
   }

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/DateTimeFormattingSettings.css
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/DateTimeFormattingSettings.css
@@ -1,0 +1,6 @@
+.vuuDateTimeFormattingSettings {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 6px;
+}

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/DateTimeFormattingSettings.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/DateTimeFormattingSettings.tsx
@@ -1,0 +1,123 @@
+import React, { SyntheticEvent, useCallback, useMemo, useState } from "react";
+import { Dropdown, SingleSelectionHandler } from "@finos/vuu-ui-controls";
+import {
+  DateTimePattern,
+  defaultPatternsByType,
+  fallbackDateTimePattern,
+  getTypeFormattingFromColumn,
+  supportedDateTimePatterns,
+} from "@finos/vuu-utils";
+import {
+  FormField,
+  FormFieldLabel,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@salt-ds/core";
+import { DateTimeColumnDescriptor } from "@finos/vuu-table-types";
+import { FormattingSettingsProps } from "./types";
+
+import "./DateTimeFormattingSettings.css";
+
+const classBase = "vuuDateTimeFormattingSettings";
+
+export const DateTimeFormattingSettings: React.FC<
+  FormattingSettingsProps<DateTimeColumnDescriptor>
+> = (props) => {
+  const { column, onChange } = props;
+  const formatting = getTypeFormattingFromColumn(column);
+  const { pattern = fallbackDateTimePattern } = formatting;
+  const toggleValue = useMemo(() => getToggleValue(pattern), [pattern]);
+
+  const [fallbackState, setFallbackState] = useState<Required<DateTimePattern>>(
+    {
+      time: pattern.time ?? defaultPatternsByType.time,
+      date: pattern.date ?? defaultPatternsByType.date,
+    }
+  );
+
+  const onPatternChange = useCallback(
+    (pattern: DateTimePattern) => onChange({ ...formatting, pattern }),
+    [onChange, formatting]
+  );
+
+  const onDropdownChange = useCallback<
+    <T extends keyof DateTimePattern>(
+      key: T
+    ) => SingleSelectionHandler<Required<DateTimePattern>[T]>
+  >(
+    (key) => (_, p) => {
+      const updatedPattern = { ...(pattern ?? {}), [key]: p };
+      setFallbackState((s) => ({
+        time: updatedPattern.time ?? s.time,
+        date: updatedPattern.date ?? s.date,
+      }));
+      onPatternChange(updatedPattern);
+    },
+    [onPatternChange, pattern]
+  );
+
+  const onToggleChange = useCallback(
+    (evnt: SyntheticEvent<HTMLButtonElement, Event>) => {
+      const value = evnt.currentTarget.value as ToggleValue;
+      switch (value) {
+        case "time":
+          return onPatternChange({
+            [value]: pattern[value] ?? fallbackState[value],
+          });
+        case "date":
+          return onPatternChange({
+            [value]: pattern[value] ?? fallbackState[value],
+          });
+        case "both":
+          return onPatternChange({
+            time: pattern.time ?? fallbackState.time,
+            date: pattern.date ?? fallbackState.date,
+          });
+      }
+    },
+    [onPatternChange, pattern, fallbackState]
+  );
+
+  return (
+    <div className={classBase}>
+      <FormField>
+        <FormFieldLabel>{"Date/Time pattern"}</FormFieldLabel>
+        <ToggleButtonGroup
+          className="vuuToggleButtonGroup"
+          onChange={onToggleChange}
+          value={toggleValue}
+        >
+          {toggleValues.map((v) => (
+            <ToggleButton key={v} value={v}>
+              {v.toUpperCase()}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </FormField>
+
+      {(["date", "time"] as const)
+        .filter((v) => !!pattern[v])
+        .map((v) => (
+          <FormField labelPlacement="left" key={v}>
+            <FormFieldLabel>{`${labelByType[v]}`}</FormFieldLabel>
+            <Dropdown<Required<DateTimePattern>[typeof v]>
+              onSelectionChange={onDropdownChange(v)}
+              selected={pattern[v]}
+              source={supportedDateTimePatterns[v]}
+              width="100%"
+            />
+          </FormField>
+        ))}
+    </div>
+  );
+};
+
+const labelByType = { date: "Date", time: "Time" } as const;
+
+const toggleValues = ["date", "time", "both"] as const;
+
+type ToggleValue = (typeof toggleValues)[number];
+
+function getToggleValue(pattern: DateTimePattern): ToggleValue {
+  return !pattern.time ? "date" : !pattern.date ? "time" : "both";
+}

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/DateTimeFormattingSettings.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/DateTimeFormattingSettings.tsx
@@ -16,14 +16,9 @@ import {
 import { DateTimeColumnDescriptor } from "@finos/vuu-table-types";
 import { FormattingSettingsProps } from "./types";
 
-import "./DateTimeFormattingSettings.css";
-
-const classBase = "vuuDateTimeFormattingSettings";
-
 export const DateTimeFormattingSettings: React.FC<
   FormattingSettingsProps<DateTimeColumnDescriptor>
-> = (props) => {
-  const { column, onChange } = props;
+> = ({ column, onChangeFormatting: onChange }) => {
   const formatting = getTypeFormattingFromColumn(column);
   const { pattern = fallbackDateTimePattern } = formatting;
   const toggleValue = useMemo(() => getToggleValue(pattern), [pattern]);
@@ -79,9 +74,9 @@ export const DateTimeFormattingSettings: React.FC<
   );
 
   return (
-    <div className={classBase}>
-      <FormField>
-        <FormFieldLabel>{"Date/Time pattern"}</FormFieldLabel>
+    <>
+      <FormField labelPlacement="left">
+        <FormFieldLabel>{"Display"}</FormFieldLabel>
         <ToggleButtonGroup
           className="vuuToggleButtonGroup"
           onChange={onToggleChange}
@@ -99,7 +94,7 @@ export const DateTimeFormattingSettings: React.FC<
         .filter((v) => !!pattern[v])
         .map((v) => (
           <FormField labelPlacement="left" key={v}>
-            <FormFieldLabel>{`${labelByType[v]}`}</FormFieldLabel>
+            <FormFieldLabel>{`${labelByType[v]} pattern`}</FormFieldLabel>
             <Dropdown<Required<DateTimePattern>[typeof v]>
               onSelectionChange={onDropdownChange(v)}
               selected={pattern[v]}
@@ -108,7 +103,7 @@ export const DateTimeFormattingSettings: React.FC<
             />
           </FormField>
         ))}
-    </div>
+    </>
   );
 };
 

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/LongTypeFormattingSettings.css
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/LongTypeFormattingSettings.css
@@ -1,4 +1,4 @@
-.vuuDateTimeFormattingSettings {
+.vuuLongColumnFormattingSettings {
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/LongTypeFormattingSettings.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/LongTypeFormattingSettings.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from "react";
+import {
+  FormField,
+  FormFieldLabel,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@salt-ds/core";
+import { isDateTimeColumn, isTypeDescriptor } from "@finos/vuu-utils";
+import { DateTimeFormattingSettings } from "./DateTimeFormattingSettings";
+import { BaseNumericFormattingSettings } from "./BaseNumericFormattingSettings";
+import { FormattingSettingsProps } from "./types";
+
+import "./LongTypeFormattingSettings.css";
+
+const classBase = "vuuLongColumnFormattingSettings";
+
+export const LongTypeFormattingSettings: React.FC<FormattingSettingsProps> = (
+  props
+) => {
+  const { column, onChangeType } = props;
+  const type = isTypeDescriptor(column.type) ? column.type.name : column.type;
+
+  const handleToggleChange = useCallback(
+    (event: React.SyntheticEvent<HTMLButtonElement, Event>) => {
+      const value = event.currentTarget.value as ToggleValue;
+      onChangeType(value);
+    },
+    [onChangeType]
+  );
+
+  return (
+    <div className={classBase}>
+      <FormField>
+        <FormFieldLabel>{"Type inferred as"}</FormFieldLabel>
+        <ToggleButtonGroup
+          className="vuuToggleButtonGroup"
+          onChange={handleToggleChange}
+          value={type ?? "number"}
+        >
+          {toggleValues.map((v) => (
+            <ToggleButton key={v} value={v}>
+              {v.toUpperCase()}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </FormField>
+
+      {isDateTimeColumn(column) ? (
+        <DateTimeFormattingSettings {...props} column={column} />
+      ) : (
+        <BaseNumericFormattingSettings {...props} />
+      )}
+    </div>
+  );
+};
+
+const toggleValues = ["number", "date/time"] as const;
+type ToggleValue = (typeof toggleValues)[number];

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/NumericFormattingSettings.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/NumericFormattingSettings.tsx
@@ -8,18 +8,11 @@ import {
   useCallback,
   useState,
 } from "react";
+import { FormattingSettingsProps } from "./types";
 
 const classBase = "vuuFormattingSettings";
 
-export interface NumericFormattingSettingsProps {
-  column: ColumnDescriptor;
-  onChange: (formatting: ColumnTypeFormatting) => void;
-}
-
-export const NumericFormattingSettings = ({
-  column,
-  onChange,
-}: NumericFormattingSettingsProps) => {
+export const NumericFormattingSettings = ({column, onChange}: FormattingSettingsProps) => {
   const [formattingSettings, setFormattingSettings] =
     useState<ColumnTypeFormatting>(getTypeFormattingFromColumn(column));
 

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/index.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/index.ts
@@ -1,2 +1,3 @@
 export * from "./ColumnFormattingPanel";
 export * from "./NumericFormattingSettings";
+export * from "./DateTimeFormattingSettings";

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/index.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/index.ts
@@ -1,3 +1,3 @@
 export * from "./ColumnFormattingPanel";
-export * from "./NumericFormattingSettings";
+export * from "./BaseNumericFormattingSettings";
 export * from "./DateTimeFormattingSettings";

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/types.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/types.ts
@@ -1,6 +1,13 @@
-import { ColumnDescriptor, ColumnTypeFormatting } from "@finos/vuu-table-types";
+import {
+  ColumnDescriptor,
+  ColumnTypeFormatting,
+  ColumnTypeSimple,
+} from "@finos/vuu-table-types";
 
-export interface FormattingSettingsProps<T extends ColumnDescriptor = ColumnDescriptor> {
+export interface FormattingSettingsProps<
+  T extends ColumnDescriptor = ColumnDescriptor
+> {
   column: T;
-  onChange: (formatting: ColumnTypeFormatting) => void;
+  onChangeFormatting: (formatting: ColumnTypeFormatting) => void;
+  onChangeType: (type: ColumnTypeSimple) => void;
 }

--- a/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/types.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/column-formatting-settings/types.ts
@@ -1,0 +1,6 @@
+import { ColumnDescriptor, ColumnTypeFormatting } from "@finos/vuu-table-types";
+
+export interface FormattingSettingsProps<T extends ColumnDescriptor = ColumnDescriptor> {
+  column: T;
+  onChange: (formatting: ColumnTypeFormatting) => void;
+}

--- a/vuu-ui/packages/vuu-table-extras/src/column-settings/ColumnSettingsPanel.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/column-settings/ColumnSettingsPanel.tsx
@@ -51,6 +51,7 @@ export const ColumnSettingsPanel = ({
     onChangeCalculatedColumnName,
     onChangeFormatting,
     onChangeRendering,
+    onChangeType,
     onEditCalculatedColumn,
     onInputCommit,
     onSave,
@@ -161,6 +162,7 @@ export const ColumnSettingsPanel = ({
         column={column}
         onChangeFormatting={onChangeFormatting}
         onChangeRendering={onChangeRendering}
+        onChangeType={onChangeType}
       />
 
       {editCalculatedColumn ? (

--- a/vuu-ui/packages/vuu-table-extras/src/column-settings/useColumnSettings.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/column-settings/useColumnSettings.ts
@@ -52,6 +52,10 @@ const stringCellRenderers: CellRendererDescriptor[] = [
   ...getRegisteredCellRenderers("string"),
 ];
 
+const booleanCellRenderers: CellRendererDescriptor[] = [
+  ...getRegisteredCellRenderers("boolean"),
+];
+
 const getAvailableCellRenderers = (
   column: ColumnDescriptor
 ): CellRendererDescriptor[] => {
@@ -64,6 +68,8 @@ const getAvailableCellRenderers = (
       return integerCellRenderers;
     case "double":
       return doubleCellRenderers;
+    case "boolean":
+      return booleanCellRenderers;
     default:
       return stringCellRenderers;
   }

--- a/vuu-ui/packages/vuu-table-extras/src/column-settings/useColumnSettings.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/column-settings/useColumnSettings.ts
@@ -3,6 +3,7 @@ import {
   TableConfig,
   ColumnTypeFormatting,
   ColumnSettingsProps,
+  ColumnTypeSimple,
 } from "@finos/vuu-table-types";
 
 import {
@@ -13,6 +14,7 @@ import {
   isValidPinLocation,
   setCalculatedColumnName,
   updateColumnRenderProps,
+  updateColumnFormatting,
   updateColumnType,
 } from "@finos/vuu-utils";
 import {
@@ -180,9 +182,18 @@ export const useColumnSettings = ({
 
   const handleChangeFormatting = useCallback(
     (formatting: ColumnTypeFormatting) => {
-      const newColumn: ColumnDescriptor = updateColumnType(column, formatting);
+      const newColumn = updateColumnFormatting(column, formatting);
       setColumn(newColumn);
       onConfigChange(replaceColumn(tableConfig, newColumn));
+    },
+    [column, onConfigChange, tableConfig]
+  );
+
+  const handleChangeType = useCallback(
+    (type: ColumnTypeSimple) => {
+      const updatedColumn = updateColumnType(column, type);
+      setColumn(updatedColumn);
+      onConfigChange(replaceColumn(tableConfig, updatedColumn));
     },
     [column, onConfigChange, tableConfig]
   );
@@ -247,6 +258,7 @@ export const useColumnSettings = ({
     onChangeCalculatedColumnName: handleChangeCalculatedColumnName,
     onChangeFormatting: handleChangeFormatting,
     onChangeRendering: handleChangeRendering,
+    onChangeType: handleChangeType,
     onEditCalculatedColumn: handleEditCalculatedcolumn,
     onInputCommit: handleInputCommit,
     onSave: handleSaveCalculatedColumn,

--- a/vuu-ui/packages/vuu-table-types/index.d.ts
+++ b/vuu-ui/packages/vuu-table-types/index.d.ts
@@ -9,6 +9,7 @@ import type {
 import type { VuuDataRow } from "@finos/vuu-protocol-types";
 import type { ValueFormatter } from "@finos/vuu-table";
 import type { ClientSideValidationChecker } from "@finos/vuu-ui-controls";
+import type { DateTimePattern } from "@finos/vuu-utils";
 import type { FunctionComponent, MouseEvent } from "react";
 import type { HTMLAttributes } from "react";
 
@@ -77,7 +78,7 @@ export interface GridConfig extends TableConfig {
 export declare type ColumnTypeFormatting = {
   alignOnDecimals?: boolean;
   decimals?: number;
-  pattern?: string;
+  pattern?: DateTimePattern;
   zeroPad?: boolean;
 };
 
@@ -128,7 +129,19 @@ export interface ValueListRenderer {
   values: string[];
 }
 
-export declare type DateTimeColumnTypeSimple = "date" | "time";
+export declare type DateTimeColumnTypeSimple = "date/time";
+
+type DateTimeColumnType =
+  | DateTimeColumnTypeSimple
+  | (Omit<ColumnTypeDescriptor, "name"> & { name: DateTimeColumnTypeSimple });
+
+export declare type DateTimeColumnDescriptor = Omit<
+  ColumnDescriptor,
+  "type"
+> & {
+  type: DateTimeColumnType;
+};
+
 export declare type ColumnTypeSimple =
   | "string"
   | "number"
@@ -180,9 +193,9 @@ export interface ColumnDescriptor {
   colHeaderLabelRenderer?: string;
   editable?: boolean;
   flex?: number;
-  /** 
+  /**
    Optional additional level(s) of heading to display above label.
-   May span multiple columns, if multiple adjacent columns declare 
+   May span multiple columns, if multiple adjacent columns declare
    same heading at same level.
   */
   heading?: string[];

--- a/vuu-ui/packages/vuu-table/src/cell-renderers/input-cell/InputCell.tsx
+++ b/vuu-ui/packages/vuu-table/src/cell-renderers/input-cell/InputCell.tsx
@@ -21,14 +21,10 @@ export const InputCell = ({
   row,
 }: TableCellRendererProps) => {
   const dataIdx = columnMap[column.name];
-  const {
-    align = "left",
-    clientSideEditValidationCheck,
-    valueFormatter,
-  } = column;
+  const { align = "left", clientSideEditValidationCheck } = column;
 
   const { warningMessage, ...editProps } = useEditableText({
-    initialValue: valueFormatter(row[dataIdx]),
+    initialValue: row[dataIdx],
     onCommit,
     clientSideEditValidationCheck,
   });

--- a/vuu-ui/packages/vuu-utils/src/column-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/column-utils.ts
@@ -22,7 +22,6 @@ import type {
   ColumnTypeFormatting,
   ColumnTypeRendering,
   ColumnTypeWithValidationRules,
-  DateTimeColumnTypeSimple,
   DefaultColumnConfiguration,
   GroupColumnDescriptor,
   LookupRenderer,
@@ -32,6 +31,7 @@ import type {
   TableHeading,
   TableHeadings,
   ValueListRenderer,
+  DateTimeColumnDescriptor,
 } from "@finos/vuu-table-types";
 import type { CSSProperties } from "react";
 import { moveItem } from "./array-utils";
@@ -131,22 +131,11 @@ export const isNumericColumn = ({ serverDataType, type }: ColumnDescriptor) => {
   return false;
 };
 
-type DateTimeColumnType =
-  | DateTimeColumnTypeSimple
-  | (Omit<ColumnTypeDescriptor, "name"> & { name: DateTimeColumnTypeSimple });
-
-export type DateTimeColumnDescriptor = Omit<ColumnDescriptor, "type"> & {
-  type: DateTimeColumnType;
-};
-
-export const isDateColumn = ({ type }: ColumnDescriptor) =>
-  (isTypeDescriptor(type) ? type.name : type) === "date";
-export const isTimeColumn = ({ type }: ColumnDescriptor) =>
-  (isTypeDescriptor(type) ? type.name : type) === "time";
 export const isDateTimeColumn = (
   column: ColumnDescriptor
 ): column is DateTimeColumnDescriptor =>
-  isDateColumn(column) || isTimeColumn(column);
+  (isTypeDescriptor(column.type) ? column.type.name : column.type) ===
+  "date/time";
 
 export const isPinned = (column: ColumnDescriptor) =>
   typeof column.pin === "string";

--- a/vuu-ui/packages/vuu-utils/src/date/helpers.ts
+++ b/vuu-ui/packages/vuu-utils/src/date/helpers.ts
@@ -1,11 +1,15 @@
-import { DateTimeColumnTypeSimple } from "@finos/vuu-table-types";
-import { DateTimeColumnDescriptor, isTypeDescriptor } from "../column-utils";
+import { DateTimeColumnDescriptor } from "@finos/vuu-table-types";
+import { isTypeDescriptor } from "../column-utils";
 import { DateTimePattern, isDateTimePattern } from "./types";
 
-export const defaultPatternByTypes: Record<
-  DateTimeColumnTypeSimple,
-  DateTimePattern
-> = { time: "hh:mm:ss", date: "dd.mm.yyyy" };
+export const defaultPatternsByType = {
+  time: "hh:mm:ss",
+  date: "dd.mm.yyyy",
+} as const;
+
+export const fallbackDateTimePattern: DateTimePattern = {
+  date: defaultPatternsByType["date"],
+};
 
 export function dateTimePattern(
   type: DateTimeColumnDescriptor["type"]
@@ -14,9 +18,7 @@ export function dateTimePattern(
     if (type.formatting && isDateTimePattern(type.formatting.pattern)) {
       return type.formatting.pattern;
     }
-
-    return defaultPatternByTypes[type.name];
-  } else {
-    return defaultPatternByTypes[type];
   }
+
+  return fallbackDateTimePattern;
 }

--- a/vuu-ui/packages/vuu-utils/src/date/index.ts
+++ b/vuu-ui/packages/vuu-utils/src/date/index.ts
@@ -1,2 +1,7 @@
 export * from "./formatter";
-export { isDateTimePattern, type DateTimePattern } from "./types";
+export {
+  isDateTimePattern,
+  type DateTimePattern,
+  supportedDateTimePatterns,
+} from "./types";
+export { defaultPatternsByType, fallbackDateTimePattern } from "./helpers";

--- a/vuu-ui/packages/vuu-utils/src/date/types.ts
+++ b/vuu-ui/packages/vuu-utils/src/date/types.ts
@@ -1,3 +1,5 @@
+import { ColumnTypeFormatting } from "@finos/vuu-table-types";
+
 const supportedDatePatterns = [
   "dd.mm.yyyy",
   "dd/mm/yyyy",
@@ -10,17 +12,25 @@ const supportedDatePatterns = [
 
 const supportedTimePatterns = ["hh:mm:ss", "hh:mm:ss a"] as const;
 
+export const supportedDateTimePatterns = {
+  date: supportedDatePatterns,
+  time: supportedTimePatterns,
+};
+
 export type DatePattern = (typeof supportedDatePatterns)[number];
 export type TimePattern = (typeof supportedTimePatterns)[number];
-export type DateTimePattern = DatePattern | TimePattern;
 
-const isDatePattern = (pattern: string): pattern is DatePattern =>
+export type DateTimePattern =
+  | { date?: DatePattern; time: TimePattern }
+  | { date: DatePattern; time?: TimePattern };
+
+const isDatePattern = (pattern?: string): pattern is DatePattern =>
   supportedDatePatterns.includes(pattern as DatePattern);
 
-const isTimePattern = (pattern: string): pattern is TimePattern =>
+const isTimePattern = (pattern?: string): pattern is TimePattern =>
   supportedTimePatterns.includes(pattern as TimePattern);
 
 export const isDateTimePattern = (
-  pattern?: string
+  pattern?: ColumnTypeFormatting["pattern"]
 ): pattern is DateTimePattern =>
-  pattern !== undefined && (isDatePattern(pattern) || isTimePattern(pattern));
+  isDatePattern(pattern?.date) || isTimePattern(pattern?.time);

--- a/vuu-ui/packages/vuu-utils/src/formatting-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/formatting-utils.ts
@@ -2,13 +2,13 @@ import {
   ColumnDescriptor,
   ColumnTypeValueMap,
   ColumnTypeFormatting,
+  DateTimeColumnDescriptor,
 } from "@finos/vuu-table-types";
 import { roundDecimal } from "./round-decimal";
 import {
   isDateTimeColumn,
   isTypeDescriptor,
   isMappedValueTypeRenderer,
-  DateTimeColumnDescriptor,
 } from "./column-utils";
 import { formatDate } from "./date";
 import { dateTimePattern } from "./date/helpers";

--- a/vuu-ui/packages/vuu-utils/src/index.ts
+++ b/vuu-ui/packages/vuu-utils/src/index.ts
@@ -33,6 +33,7 @@ export * from "./selection-utils";
 export * from "./sort-utils";
 export * from "./text-utils";
 export * from "./ThemeProvider";
+export * from "./ts-utils";
 export * from "./url-utils";
 export * from "./useId";
 export * from "./useLayoutEffectSkipFirst";

--- a/vuu-ui/packages/vuu-utils/src/ts-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/ts-utils.ts
@@ -1,0 +1,5 @@
+export function isNotNullOrUndefined<T extends any>(
+  value: T | undefined | null
+): value is NonNullable<T> {
+  return value !== undefined && value !== null;
+}

--- a/vuu-ui/packages/vuu-utils/test/date/formatter.test.ts
+++ b/vuu-ui/packages/vuu-utils/test/date/formatter.test.ts
@@ -6,15 +6,23 @@ const testDate = new Date(2010, 5, 12, 15, 50, 37);
 
 describe("formatDate", () => {
   it.each<{ pattern: DateTimePattern; expected: string }>([
-    { pattern: "dd.mm.yyyy", expected: "12.06.2010" },
-    { pattern: "dd/mm/yyyy", expected: "12/06/2010" },
-    { pattern: "dd MMM yyyy", expected: "12 Jun 2010" },
-    { pattern: "dd MMMM yyyy", expected: "12 June 2010" },
-    { pattern: "mm/dd/yyyy", expected: "06/12/2010" },
-    { pattern: "MMM dd, yyyy", expected: "Jun 12, 2010" },
-    { pattern: "MMMM dd, yyyy", expected: "June 12, 2010" },
-    { pattern: "hh:mm:ss", expected: "15:50:37" },
-    { pattern: "hh:mm:ss a", expected: "03:50:37 pm" },
+    { pattern: { date: "dd.mm.yyyy" }, expected: "12.06.2010" },
+    { pattern: { date: "dd/mm/yyyy" }, expected: "12/06/2010" },
+    { pattern: { date: "dd MMM yyyy" }, expected: "12 Jun 2010" },
+    { pattern: { date: "dd MMMM yyyy" }, expected: "12 June 2010" },
+    { pattern: { date: "mm/dd/yyyy" }, expected: "06/12/2010" },
+    { pattern: { date: "MMM dd, yyyy" }, expected: "Jun 12, 2010" },
+    { pattern: { date: "MMMM dd, yyyy" }, expected: "June 12, 2010" },
+    { pattern: { time: "hh:mm:ss" }, expected: "15:50:37" },
+    { pattern: { time: "hh:mm:ss a" }, expected: "03:50:37 pm" },
+    {
+      pattern: { date: "dd.mm.yyyy", time: "hh:mm:ss a" },
+      expected: "12.06.2010 03:50:37 pm",
+    },
+    {
+      pattern: { date: "MMMM dd, yyyy", time: "hh:mm:ss a" },
+      expected: "June 12, 2010 03:50:37 pm",
+    },
   ])(
     "can correctly format date with the given pattern $pattern",
     ({ pattern, expected }) => {

--- a/vuu-ui/packages/vuu-utils/test/date/helpers.test.ts
+++ b/vuu-ui/packages/vuu-utils/test/date/helpers.test.ts
@@ -1,28 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { dateTimePattern, defaultPatternByTypes } from "../../src/date/helpers";
+import {
+  dateTimePattern,
+  fallbackDateTimePattern,
+} from "../../src/date/helpers";
 import { DateTimePattern } from "../../src/date/types";
 
-const testPattern: DateTimePattern = "mm/dd/yyyy";
+const testPattern: DateTimePattern = { date: "mm/dd/yyyy" };
 
 describe("dateTimePattern", () => {
   it("returns exact pattern when found in descriptor type", () => {
     const type = {
-      name: "date" as const,
+      name: "date/time" as const,
       formatting: { pattern: testPattern },
     };
     const actualPattern = dateTimePattern(type);
     expect(actualPattern).toEqual(testPattern);
   });
 
-  it("falls back to default when pattern not found in descriptor type", () => {
-    const type = { name: "time" as const, formatting: {} };
+  it("fallback pattern when pattern not found in descriptor type", () => {
+    const type = { name: "date/time" as const, formatting: {} };
     const actualPattern = dateTimePattern(type);
-    expect(actualPattern).toEqual(defaultPatternByTypes["time"]);
+    expect(actualPattern).toEqual(fallbackDateTimePattern);
   });
 
-  it("falls back to default when simple type", () => {
-    const type = "date";
+  it("fallback pattern when simple type", () => {
+    const type = "date/time";
     const actualPattern = dateTimePattern(type);
-    expect(actualPattern).toEqual(defaultPatternByTypes["date"]);
+    expect(actualPattern).toEqual(fallbackDateTimePattern);
   });
 });

--- a/vuu-ui/packages/vuu-utils/test/date/types.test.ts
+++ b/vuu-ui/packages/vuu-utils/test/date/types.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { isDateTimePattern } from "../../src/date/types";
+import { ColumnTypeFormatting } from "@finos/vuu-table-types";
 
 describe("isDateTimePattern", () => {
-  it.each<{ pattern: string | undefined; expected: boolean }>([
-    { pattern: "dd MMM yyyy", expected: true },
-    { pattern: "not-a-date-time-pattern", expected: false },
+  it.each<{ pattern: ColumnTypeFormatting["pattern"]; expected: boolean }>([
+    { pattern: { date: "dd MMM yyyy" }, expected: true },
+    { pattern: { time: "hh:mm:ss a" }, expected: true },
+    { pattern: { date: "dd/mm/yyyy", time: "hh:mm:ss" }, expected: true },
     { pattern: undefined, expected: false },
   ])(
     "returns $expected when pattern is a DateTimePattern",

--- a/vuu-ui/packages/vuu-utils/test/date/types.test.ts
+++ b/vuu-ui/packages/vuu-utils/test/date/types.test.ts
@@ -9,7 +9,7 @@ describe("isDateTimePattern", () => {
     { pattern: { date: "dd/mm/yyyy", time: "hh:mm:ss" }, expected: true },
     { pattern: undefined, expected: false },
   ])(
-    "returns $expected when pattern is a DateTimePattern",
+    "returns true only when pattern is a DateTimePattern",
     ({ pattern, expected }) => {
       const actual = isDateTimePattern(pattern);
       expect(actual).toEqual(expected);

--- a/vuu-ui/sample-apps/app-vuu-example/src/columnMetaData.ts
+++ b/vuu-ui/sample-apps/app-vuu-example/src/columnMetaData.ts
@@ -132,7 +132,7 @@ const columnMetaData: { [key: string]: Partial<ColumnDescriptor> } = {
     label: "Created",
     name: "created",
     type: {
-      name: "time",
+      name: "date/time",
     },
   },
   currency: {
@@ -196,7 +196,7 @@ const columnMetaData: { [key: string]: Partial<ColumnDescriptor> } = {
     label: "Last Update",
     name: "lastUpdate",
     type: {
-      name: "time",
+      name: "date/time",
     },
   },
   lotSize: {

--- a/vuu-ui/showcase/src/examples/Table/SIMUL.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/SIMUL.examples.tsx
@@ -51,6 +51,8 @@ const getDefaultColumnConfig = (
           formatting: { decimals: 2, zeroPad: true },
         },
       };
+    case "wishlist":
+      return { editable: true };
   }
 };
 
@@ -103,7 +105,10 @@ export const Instruments = () => <SimulTable tableName="instruments" />;
 Instruments.displaySequence = displaySequence++;
 
 export const InstrumentsExtended = () => (
-  <SimulTable tableName="instrumentsExtended" />
+  <SimulTable
+    tableName="instrumentsExtended"
+    getDefaultColumnConfig={getDefaultColumnConfig}
+  />
 );
 InstrumentsExtended.displaySequence = displaySequence++;
 

--- a/vuu-ui/showcase/src/examples/Table/Table.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Table.examples.tsx
@@ -193,8 +193,6 @@ export const EditableTableNextArrayData = () => {
               },
             },
           };
-        case "wishlist":
-          return { editable: true };
       }
     },
     []

--- a/vuu-ui/showcase/src/examples/TableExtras/ColumnSettings/ColumnSettings.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/ColumnSettings/ColumnSettings.examples.tsx
@@ -11,7 +11,8 @@ import {
 import {
   CellRendererDescriptor,
   ColumnRenderPropsChangeHandler,
-  isTypeDescriptor,
+  updateColumnFormatting,
+  updateColumnType,
 } from "@finos/vuu-utils";
 import { useCallback, useMemo, useState } from "react";
 
@@ -55,6 +56,7 @@ export const ColumnFormattingPanelDouble = () => {
       availableRenderers={availableRenderers}
       column={column}
       onChangeFormatting={() => console.log("onChangeFormatting")}
+      onChangeType={() => console.log("onChangeType")}
       onChangeRendering={handleChangeRendering}
       style={{
         border: "solid 1px lightgray",
@@ -92,13 +94,11 @@ export const ColumnFormattingPanelDateTime = () => {
   );
 
   const onChangeFormatting = useCallback((formatting: ColumnTypeFormatting) => {
-    setColumn((col) => ({
-      ...col,
-      type: {
-        ...(isTypeDescriptor(col.type) ? col.type : { name: col.type }),
-        formatting,
-      },
-    }));
+    setColumn((col) => updateColumnFormatting(col, formatting));
+  }, []);
+
+  const onChangeType = useCallback((t) => {
+    setColumn((col) => updateColumnType(col, t));
   }, []);
 
   return (
@@ -107,6 +107,7 @@ export const ColumnFormattingPanelDateTime = () => {
       column={column}
       onChangeFormatting={onChangeFormatting}
       onChangeRendering={handleChangeRendering}
+      onChangeType={onChangeType}
       style={{
         border: "solid 1px lightgray",
         margin: 20,

--- a/vuu-ui/showcase/src/examples/TableExtras/ColumnSettings/ColumnSettings.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/ColumnSettings/ColumnSettings.examples.tsx
@@ -1,5 +1,9 @@
 import { getSchema } from "@finos/vuu-data-test";
-import { ColumnDescriptor, TableConfig } from "@finos/vuu-table-types";
+import {
+  ColumnDescriptor,
+  ColumnTypeFormatting,
+  TableConfig,
+} from "@finos/vuu-table-types";
 import {
   ColumnFormattingPanel,
   ColumnSettingsPanel,
@@ -7,6 +11,7 @@ import {
 import {
   CellRendererDescriptor,
   ColumnRenderPropsChangeHandler,
+  isTypeDescriptor,
 } from "@finos/vuu-utils";
 import { useCallback, useMemo, useState } from "react";
 
@@ -62,6 +67,57 @@ export const ColumnFormattingPanelDouble = () => {
 };
 
 ColumnFormattingPanelDouble.displaySequence = displaySequence++;
+
+export const ColumnFormattingPanelDateTime = () => {
+  const [column, setColumn] = useState<ColumnDescriptor>({
+    name: "lastUpdated",
+    label: "Last updated",
+    serverDataType: "long",
+    type: {
+      name: "date/time",
+      formatting: {
+        pattern: { date: "MMMM dd, yyyy", time: "hh:mm:ss" },
+      },
+    },
+  });
+
+  const availableRenderers = useMemo<CellRendererDescriptor[]>(
+    () => [{ name: "Default renderer (data type long)" }],
+    []
+  );
+
+  const handleChangeRendering = useCallback<ColumnRenderPropsChangeHandler>(
+    (renderer) => console.log(`handleChangeRendering`, { renderer }),
+    []
+  );
+
+  const onChangeFormatting = useCallback((formatting: ColumnTypeFormatting) => {
+    setColumn((col) => ({
+      ...col,
+      type: {
+        ...(isTypeDescriptor(col.type) ? col.type : { name: col.type }),
+        formatting,
+      },
+    }));
+  }, []);
+
+  return (
+    <ColumnFormattingPanel
+      availableRenderers={availableRenderers}
+      column={column}
+      onChangeFormatting={onChangeFormatting}
+      onChangeRendering={handleChangeRendering}
+      style={{
+        border: "solid 1px lightgray",
+        margin: 20,
+        padding: 12,
+        width: 300,
+      }}
+    />
+  );
+};
+
+ColumnFormattingPanelDateTime.displaySequence = displaySequence++;
 
 export const NewCalculatedColumnSettingsPanel = () => {
   const schema = getSchema("parentOrders");


### PR DESCRIPTION
- converges date and time column types to one unified date/time type, consistent
  with how some major programming languages handles datetime.
- date/time pattern selection is only available for columns with "date/time" type.
- changes DateTimePattern to be an object instead of strings to enable
  simultaneous selection of both date and time patterns.
- also moves DateTimeColumnDescriptor to vuu-table-types package for consistency.