### PR TITLE
add back -webkit prefix for css mask

### DIFF
--- a/vuu-ui/packages/vuu-icons/index.css
+++ b/vuu-ui/packages/vuu-icons/index.css
@@ -84,8 +84,8 @@ span[data-icon] {
   background-color: var(--vuu-icon-color, var(--saltIcon-color, var(--salt-text-secondary-foreground)));
   left: var(--vuu-icon-left, auto);
   height: var(--vuu-icon-height, var(--vuu-icon-size, 12px));
-  /* -webkit-mask: var(--vuu-icon-svg) center center/var(--vuu-icon-size) var(--vuu-icon-size); */
   mask: var(--vuu-icon-svg) center center/var(--vuu-icon-size) var(--vuu-icon-size);
+  -webkit-mask: var(--vuu-icon-svg) center center/var(--vuu-icon-size) var(--vuu-icon-size);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   position: absolute;

--- a/vuu-ui/packages/vuu-popups/src/menu/MenuList.css
+++ b/vuu-ui/packages/vuu-popups/src/menu/MenuList.css
@@ -66,6 +66,7 @@
 .vuuMenuItem[aria-haspopup='true']:after {
   content: var(--menu-item-twisty-content);
   mask: var(--vuu-svg-chevron-right) center center/8px 8px no-repeat;
+  -webkit-mask: var(--vuu-svg-chevron-right) center center/8px 8px no-repeat;
   background-color: var(--menu-item-twisty-color);
   height: 16px;
   left: var(--menu-item-twisty-left);

--- a/vuu-ui/packages/vuu-theme/css/components/checkbox.css
+++ b/vuu-ui/packages/vuu-theme/css/components/checkbox.css
@@ -43,7 +43,9 @@
     left: var(--vuu-icon-left, auto);
     height: var(--vuu-icon-height, var(--vuu-icon-size, 12px));
     mask: var(--vuu-svg-tick) center center/var(--vuu-icon-size) var(--vuu-icon-size);
+    -webkit-mask: var(--vuu-svg-tick) center center/var(--vuu-icon-size) var(--vuu-icon-size);
     mask-repeat: no-repeat;
+    -webkit-mask-repeat: no-repeat;
     position: absolute;
     top: var(--vuu-icon-top, auto);
     width: var(--vuu-icon-width, var(--vuu-icon-size, 12px));

--- a/vuu-ui/packages/vuu-theme/css/components/switch.css
+++ b/vuu-ui/packages/vuu-theme/css/components/switch.css
@@ -46,7 +46,9 @@
     left: var(--vuu-icon-left, auto);
     height: var(--vuu-icon-height, var(--vuu-icon-size, 12px));
     mask: var(--vuu-svg-tick) center center/var(--vuu-icon-size) var(--vuu-icon-size);
+    -webkit-mask: var(--vuu-svg-tick) center center/var(--vuu-icon-size) var(--vuu-icon-size);
     mask-repeat: no-repeat;
+    -webkit-mask-repeat: no-repeat;
     position: absolute;
     top: var(--vuu-icon-top, auto);
     width: var(--vuu-icon-width, var(--vuu-icon-size, 12px));


### PR DESCRIPTION
I removed the -webkit variants of css mask statements (used in icons). Latest Chrome no longer needs them.
Older versions of chrome still require these, so lets keep them a bit longer