### PR TITLE
VUU-333: Include username in local storage layout key

### DIFF
--- a/vuu-ui/packages/vuu-shell/src/layout-management/SaveLayoutPanel.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/SaveLayoutPanel.tsx
@@ -3,6 +3,7 @@ import { takeScreenshot } from "./screenshot-utils";
 import { Button, FormField, FormFieldLabel, Input, Text } from "@salt-ds/core";
 import { ChangeEvent, useEffect, useMemo, useState } from "react";
 import { LayoutMetadataDto } from "./layoutTypes";
+import { getAuthDetailsFromCookies } from "../login";
 
 import "./SaveLayoutPanel.css";
 
@@ -35,6 +36,7 @@ export const SaveLayoutPanel = (props: SaveLayoutPanelProps) => {
   const [screenshotErrorMessage, setScreenshotErrorMessage] = useState<
     string | undefined
   >();
+  const [username] = getAuthDetailsFromCookies();
 
   useEffect(() => {
     if (componentId) {
@@ -53,7 +55,7 @@ export const SaveLayoutPanel = (props: SaveLayoutPanelProps) => {
       name: layoutName,
       group,
       screenshot: screenshot ?? "",
-      user: "User",
+      user: username,
     });
   };
 

--- a/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/useLayoutManager.tsx
@@ -239,7 +239,7 @@ export const LayoutManagementProvider = (
       getPersistenceManager()
         .loadLayout(id)
         .then((layoutJson) => {
-          const { layout: currentLayout } = applicationJSONRef.current;
+         const { layout: currentLayout } = applicationJSONRef.current;
           setApplicationLayout({
             ...currentLayout,
             children: (currentLayout.children || []).concat(layoutJson),

--- a/vuu-ui/packages/vuu-shell/src/persistence-management/LocalPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-shell/src/persistence-management/LocalPersistenceManager.ts
@@ -186,7 +186,7 @@ export class LocalPersistenceManager implements PersistenceManager {
   ) => {
     return new Promise((resolve, reject) => {
       const loadFunc =
-        dataType === "metadata" ? this.loadMetadata : this.loadLayouts;
+        dataType === "metadata" ? () => this.loadMetadata() : () => this.loadLayouts();
 
       loadFunc().then((array: WithId[]) => {
         const count = array.filter((element) => element.id === id).length;

--- a/vuu-ui/packages/vuu-shell/src/persistence-management/LocalPersistenceManager.ts
+++ b/vuu-ui/packages/vuu-shell/src/persistence-management/LocalPersistenceManager.ts
@@ -139,27 +139,24 @@ export class LocalPersistenceManager implements PersistenceManager {
     });
   }
 
-  loadLayouts: () => Promise<Layout[]> = () => {
+  loadLayouts = (): Promise<Layout[]> => {
     return new Promise((resolve) => {
       const layouts = getLocalEntity<Layout[]>(this.layoutsSaveLocation);
       resolve(layouts || []);
     });
   }
 
-  saveLayoutsWithMetadata: (
+  saveLayoutsWithMetadata = (
     layouts: Layout[],
     metadata: LayoutMetadata[]
-  ) => void = (
-    layouts: Layout[],
-    metadata: LayoutMetadata[]
-  ) => {
+  ): void => {
     saveLocalEntity<Layout[]>(this.layoutsSaveLocation, layouts);
     saveLocalEntity<LayoutMetadata[]>(this.metadataSaveLocation, metadata);
   }
 
   // Ensures that there is exactly one Layout entry and exactly one Metadata
   // entry in local storage corresponding to the provided ID.
-  validateIds: (id: string) => Promise<void> = async (id: string) => {
+  validateIds = async (id: string): Promise<void> => {
     return Promise.all([
       this.validateId(id, "metadata").catch((error) => error.message),
       this.validateId(id, "layout").catch((error) => error.message),
@@ -177,13 +174,10 @@ export class LocalPersistenceManager implements PersistenceManager {
 
   // Ensures that there is exactly one element (Layout or Metadata) in local
   // storage corresponding to the provided ID.
-  validateId: (
+  validateId = (
     id: string,
     dataType: "metadata" | "layout"
-  ) => Promise<void> = (
-    id: string,
-    dataType: "metadata" | "layout"
-  ) => {
+  ): Promise<void> => {
     return new Promise((resolve, reject) => {
       const loadFunc =
         dataType === "metadata" ? () => this.loadMetadata() : () => this.loadLayouts();

--- a/vuu-ui/packages/vuu-shell/src/persistence-management/RemotePersistenceManager.ts
+++ b/vuu-ui/packages/vuu-shell/src/persistence-management/RemotePersistenceManager.ts
@@ -1,3 +1,4 @@
+import { getAuthDetailsFromCookies } from "@finos/vuu-shell";
 import { PersistenceManager } from "./PersistenceManager";
 import {
   ApplicationJSON,
@@ -15,6 +16,8 @@ export type GetLayoutResponseDto = { definition: LayoutJSON };
 export type GetApplicationResponseDto = { definition: ApplicationJSON };
 
 export class RemotePersistenceManager implements PersistenceManager {
+  username: string = getAuthDetailsFromCookies()[0];
+
   createLayout(
     metadata: LayoutMetadataDto,
     layout: LayoutJSON
@@ -139,7 +142,7 @@ export class RemotePersistenceManager implements PersistenceManager {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          username: "vuu-user",
+          username: this.username,
         },
         body: JSON.stringify(applicationJSON),
       })
@@ -160,7 +163,7 @@ export class RemotePersistenceManager implements PersistenceManager {
       fetch(`${baseURL}/${applicationLayoutsSaveLocation}`, {
         method: "GET",
         headers: {
-          username: "vuu-user",
+          username: this.username,
         },
       })
         .then((response) => {

--- a/vuu-ui/packages/vuu-shell/test/layout-persistence/LocalLayoutPersistenceManager.test.ts
+++ b/vuu-ui/packages/vuu-shell/test/layout-persistence/LocalLayoutPersistenceManager.test.ts
@@ -27,6 +27,16 @@ vi.mock("@finos/vuu-filters", async () => {
   };
 });
 
+const username = "vuu user";
+
+vi.mock("@finos/vuu-shell", async () => {
+  return {
+    getAuthDetailsFromCookies: (): [string, string] => {
+      return [username, "token"];
+        },
+  };
+});
+
 const persistenceManager = new LocalPersistenceManager();
 
 const existingId = "existing_id";
@@ -38,7 +48,7 @@ const existingMetadata: LayoutMetadata = {
   name: "Existing Layout",
   group: "Group 1",
   screenshot: "screenshot",
-  user: "vuu user",
+  user: username,
   created: newDate,
 };
 
@@ -51,14 +61,14 @@ const metadataToAdd: LayoutMetadataDto = {
   name: "New Layout",
   group: "Group 1",
   screenshot: "screenshot",
-  user: "vuu user",
+  user: username,
 };
 
 const metadataToUpdate: Omit<LayoutMetadata, "id"> = {
   name: "New Layout",
   group: "Group 1",
   screenshot: "screenshot",
-  user: "vuu user",
+  user: username,
   created: newDate,
 };
 
@@ -66,8 +76,8 @@ const layoutToAdd: LayoutJSON = {
   type: "t",
 };
 
-const metadataSaveLocation = "layouts/metadata";
-const layoutsSaveLocation = "layouts/layouts";
+const metadataSaveLocation = `layouts/metadata/${username}`;
+const layoutsSaveLocation = `layouts/layouts/${username}`;
 
 afterEach(() => {
   localStorage.clear();

--- a/vuu-ui/packages/vuu-shell/test/layout-persistence/RemoteLayoutPersistenceManager.test.ts
+++ b/vuu-ui/packages/vuu-shell/test/layout-persistence/RemoteLayoutPersistenceManager.test.ts
@@ -9,17 +9,28 @@ import { LayoutJSON } from "@finos/vuu-layout";
 import { v4 as uuidv4 } from "uuid";
 import { expectPromiseRejectsWithError } from "@finos/vuu-utils/test/utils";
 
-const persistence = new RemotePersistenceManager();
 const mockFetch = vi.fn();
 
 global.fetch = mockFetch;
+
+const username = "vuu user";
+
+vi.mock("@finos/vuu-shell", async () => {
+  return {
+    getAuthDetailsFromCookies: (): [string, string] => {
+      return [username, "token"];
+        },
+  };
+});
+
+const persistence = new RemotePersistenceManager();
 
 const metadata: LayoutMetadata = {
   id: "0001",
   name: "layout 1",
   group: "group 1",
   screenshot: "screenshot",
-  user: "username",
+  user: username,
   created: "01.01.2000",
 };
 
@@ -27,7 +38,7 @@ const metadataToAdd: LayoutMetadataDto = {
   name: "layout 1",
   group: "group 1",
   screenshot: "screenshot",
-  user: "username",
+  user: username,
 };
 
 const layout: LayoutJSON = {
@@ -44,7 +55,7 @@ type FetchResponse<T> = {
   statusText?: string;
 };
 
-describe("RemoteLayoutPersistenceManager", () => {
+describe("RemotePersistenceManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/NewTheme.examples.tsx
@@ -156,6 +156,8 @@ const ShellWithNewTheme = () => {
 };
 
 export const ShellWithNewThemeAndLayoutManagement = () => {
+  document.cookie = `vuu-username=${user.username}`;
+  
   return (
     <NotificationsProvider>
       <LayoutManagementProvider>


### PR DESCRIPTION
### Description
When using the local implementation of layout management, the relevant information is saved to local storage under the keys `layouts/layouts`, `layouts/metadata` and `api/vui`. This can cause problems once a second user is introduced, so we change the keys here to include a username. We also add the username to cookies for the `NewTheme` showcase example, matching the behaviour of the sample app.

### Change List
- Add username to local storage keys (application layout, layout and metadata)
- Convert private functions in `LocalLayoutPersistenceManager` to arrow functions
- Get actual username from cookies
- Add username to cookies for showcase example

### Testing
Saving and loading layouts tested using local and remote implementations, from both showcase and sample app.