### PR TITLE
#1074 add DatePicker & DateRangePicker components (first-cut)

### DIFF
--- a/vuu-ui/package-lock.json
+++ b/vuu-ui/package-lock.json
@@ -1999,12 +1999,27 @@
         }
       }
     },
-    "node_modules/@salt-ds/core/node_modules/@salt-ds/icons": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@salt-ds/icons/-/icons-1.9.0.tgz",
-      "integrity": "sha512-82PnI/9KStt/owSTV/+vxH5AkJaYDEKuJrBbzeC2axxipv8ydbToTaCn6usLOSTm9CQ04rzMFPNcWQSpGUHtjA==",
+    "node_modules/@salt-ds/core/node_modules/@salt-ds/styles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@salt-ds/styles/-/styles-0.2.0.tgz",
+      "integrity": "sha512-tPd/XK1PFkPkBsYwh4fhDbo997eaev6row9aaz/sPM0FpEpU8nbvQRhxtr8iA/S4Q5hCj0xrk/jGTuK40V13oQ==",
+      "peerDependencies": {
+        "@types/react": ">=16.14.0",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@salt-ds/icons": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@salt-ds/icons/-/icons-1.9.1.tgz",
+      "integrity": "sha512-ck1tL+vmBFUziFKB973pVLcLLvZIh5N1gDwS1dwm9DRKefXSS0ZtaB4KjrYvw/7LhVG8rqrcwtCSmvqo/3M4rg==",
       "dependencies": {
-        "@salt-ds/styles": "^0.2.0",
+        "@salt-ds/styles": "^0.2.1",
         "@salt-ds/window": "^0.1.1",
         "clsx": "^2.0.0"
       },
@@ -2019,10 +2034,10 @@
         }
       }
     },
-    "node_modules/@salt-ds/core/node_modules/@salt-ds/styles": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@salt-ds/styles/-/styles-0.2.0.tgz",
-      "integrity": "sha512-tPd/XK1PFkPkBsYwh4fhDbo997eaev6row9aaz/sPM0FpEpU8nbvQRhxtr8iA/S4Q5hCj0xrk/jGTuK40V13oQ==",
+    "node_modules/@salt-ds/icons/node_modules/@salt-ds/styles": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@salt-ds/styles/-/styles-0.2.1.tgz",
+      "integrity": "sha512-/GYQLY+ILzGyd2/KndCmoEfLw/t3pcYwihJn3ofe4yd6nhLYHPkvl4TXXzq6NnfD3NHmQWnWh3jQicLsYcvdXg==",
       "peerDependencies": {
         "@types/react": ">=16.14.0",
         "react": ">=16.14.0",
@@ -2057,26 +2072,6 @@
         "react-window": "^1.8.6",
         "rifm": "^0.12.0",
         "tinycolor2": "^1.4.2"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.14.0",
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@salt-ds/lab/node_modules/@salt-ds/icons": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@salt-ds/icons/-/icons-1.6.0.tgz",
-      "integrity": "sha512-/9c1L5LyU5cPxaYDyywDu8VnpvOvnaDmuLr/BWLEdyzxSzXTDfcIPtSgpaSaPadubvnnE9mhXdNknLyTqjNXZg==",
-      "dependencies": {
-        "@salt-ds/styles": "^0.1.1",
-        "@salt-ds/window": "^0.1.1",
-        "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "@types/react": ">=16.14.0",
@@ -12867,7 +12862,8 @@
         "@finos/vuu-table": "0.0.26",
         "@finos/vuu-table-types": "0.0.26",
         "@finos/vuu-utils": "0.0.26",
-        "@salt-ds/core": "1.13.2"
+        "@salt-ds/core": "1.13.2",
+        "@salt-ds/icons": "1.9.1"
       },
       "peerDependencies": {
         "clsx": "^2.0.0",
@@ -13066,6 +13062,7 @@
         "@finos/vuu-layout": "0.0.26",
         "@finos/vuu-theme": "0.0.26",
         "@finos/vuu-utils": "0.0.26",
+        "@internationalized/date": "^3.0.0",
         "@salt-ds/core": "1.13.2",
         "@salt-ds/theme": "1.7.1",
         "clsx": "^2.0.0",
@@ -13076,6 +13073,43 @@
       "devDependencies": {
         "@mdx-js/esbuild": "^2.3.0",
         "@thomaschaplin/isin-generator": "^1.0.3"
+      }
+    },
+    "showcase/node_modules/@salt-ds/core": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@salt-ds/core/-/core-1.13.3.tgz",
+      "integrity": "sha512-C/i3b74fNC87+dLqZlmvotLQIIlacV3tmZyBXW0njUtrhnHKnQ5X8lP2d5p3Y8P7xSSt9iRNs0dbpS91WDKmBw==",
+      "dependencies": {
+        "@floating-ui/react": "^0.23.0",
+        "@salt-ds/icons": "^1.9.1",
+        "@salt-ds/styles": "^0.2.1",
+        "@salt-ds/window": "^0.1.1",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "showcase/node_modules/@salt-ds/styles": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@salt-ds/styles/-/styles-0.2.1.tgz",
+      "integrity": "sha512-/GYQLY+ILzGyd2/KndCmoEfLw/t3pcYwihJn3ofe4yd6nhLYHPkvl4TXXzq6NnfD3NHmQWnWh3jQicLsYcvdXg==",
+      "peerDependencies": {
+        "@types/react": ">=16.14.0",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     }
   },
@@ -13815,6 +13849,7 @@
         "@finos/vuu-layout": "0.0.26",
         "@finos/vuu-theme": "0.0.26",
         "@finos/vuu-utils": "0.0.26",
+        "@internationalized/date": "^3.0.0",
         "@mdx-js/esbuild": "^2.3.0",
         "@salt-ds/core": "1.13.2",
         "@salt-ds/theme": "1.7.1",
@@ -13823,6 +13858,25 @@
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2",
         "react-router-dom": "^6.2.1"
+      },
+      "dependencies": {
+        "@salt-ds/core": {
+          "version": "https://registry.npmjs.org/@salt-ds/core/-/core-1.13.3.tgz",
+          "integrity": "sha512-C/i3b74fNC87+dLqZlmvotLQIIlacV3tmZyBXW0njUtrhnHKnQ5X8lP2d5p3Y8P7xSSt9iRNs0dbpS91WDKmBw==",
+          "requires": {
+            "@floating-ui/react": "^0.23.0",
+            "@salt-ds/icons": "^1.9.1",
+            "@salt-ds/styles": "^0.2.1",
+            "@salt-ds/window": "^0.1.1",
+            "clsx": "^2.0.0"
+          }
+        },
+        "@salt-ds/styles": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@salt-ds/styles/-/styles-0.2.1.tgz",
+          "integrity": "sha512-/GYQLY+ILzGyd2/KndCmoEfLw/t3pcYwihJn3ofe4yd6nhLYHPkvl4TXXzq6NnfD3NHmQWnWh3jQicLsYcvdXg==",
+          "requires": {}
+        }
       }
     },
     "@finos/vuu-codemirror": {
@@ -14046,7 +14100,8 @@
         "@finos/vuu-table": "0.0.26",
         "@finos/vuu-table-types": "0.0.26",
         "@finos/vuu-utils": "0.0.26",
-        "@salt-ds/core": "1.13.2"
+        "@salt-ds/core": "1.13.2",
+        "@salt-ds/icons": "1.9.1"
       }
     },
     "@finos/vuu-utils": {
@@ -14546,20 +14601,28 @@
         "clsx": "^2.0.0"
       },
       "dependencies": {
-        "@salt-ds/icons": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/@salt-ds/icons/-/icons-1.9.0.tgz",
-          "integrity": "sha512-82PnI/9KStt/owSTV/+vxH5AkJaYDEKuJrBbzeC2axxipv8ydbToTaCn6usLOSTm9CQ04rzMFPNcWQSpGUHtjA==",
-          "requires": {
-            "@salt-ds/styles": "^0.2.0",
-            "@salt-ds/window": "^0.1.1",
-            "clsx": "^2.0.0"
-          }
-        },
         "@salt-ds/styles": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/@salt-ds/styles/-/styles-0.2.0.tgz",
           "integrity": "sha512-tPd/XK1PFkPkBsYwh4fhDbo997eaev6row9aaz/sPM0FpEpU8nbvQRhxtr8iA/S4Q5hCj0xrk/jGTuK40V13oQ==",
+          "requires": {}
+        }
+      }
+    },
+    "@salt-ds/icons": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@salt-ds/icons/-/icons-1.9.1.tgz",
+      "integrity": "sha512-ck1tL+vmBFUziFKB973pVLcLLvZIh5N1gDwS1dwm9DRKefXSS0ZtaB4KjrYvw/7LhVG8rqrcwtCSmvqo/3M4rg==",
+      "requires": {
+        "@salt-ds/styles": "^0.2.1",
+        "@salt-ds/window": "^0.1.1",
+        "clsx": "^2.0.0"
+      },
+      "dependencies": {
+        "@salt-ds/styles": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@salt-ds/styles/-/styles-0.2.1.tgz",
+          "integrity": "sha512-/GYQLY+ILzGyd2/KndCmoEfLw/t3pcYwihJn3ofe4yd6nhLYHPkvl4TXXzq6NnfD3NHmQWnWh3jQicLsYcvdXg==",
           "requires": {}
         }
       }
@@ -14587,18 +14650,6 @@
         "react-window": "^1.8.6",
         "rifm": "^0.12.0",
         "tinycolor2": "^1.4.2"
-      },
-      "dependencies": {
-        "@salt-ds/icons": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@salt-ds/icons/-/icons-1.6.0.tgz",
-          "integrity": "sha512-/9c1L5LyU5cPxaYDyywDu8VnpvOvnaDmuLr/BWLEdyzxSzXTDfcIPtSgpaSaPadubvnnE9mhXdNknLyTqjNXZg==",
-          "requires": {
-            "@salt-ds/styles": "^0.1.1",
-            "@salt-ds/window": "^0.1.1",
-            "clsx": "^2.0.0"
-          }
-        }
       }
     },
     "@salt-ds/styles": {

--- a/vuu-ui/packages/vuu-ui-controls/package.json
+++ b/vuu-ui/packages/vuu-ui-controls/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@salt-ds/core": "1.13.2",
+    "@salt-ds/icons": "1.9.1",
     "@finos/vuu-data-types": "0.0.26",
     "@finos/vuu-table-types": "0.0.26",
     "@finos/vuu-layout": "0.0.26",

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/Calendar.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/Calendar.css
@@ -1,3 +1,7 @@
 .saltCalendar {
   width: min-content;
 }
+
+.saltCalendar .saltIcon {
+  display: inline-block;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/Calendar.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/Calendar.css
@@ -1,0 +1,3 @@
+.saltCalendar {
+  width: min-content;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/Calendar.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/Calendar.tsx
@@ -1,0 +1,84 @@
+import { forwardRef, useCallback } from "react";
+import { clsx } from "clsx";
+import { makePrefixer } from "@salt-ds/core";
+import {
+  CalendarNavigation,
+  CalendarNavigationProps,
+} from "./internal/CalendarNavigation";
+import { CalendarWeekHeader } from "./internal/CalendarWeekHeader";
+import {
+  CalendarCarousel,
+  CalendarCarouselProps,
+} from "./internal/CalendarCarousel";
+import { CalendarContext } from "./internal/CalendarContext";
+import { useCalendar, useCalendarProps } from "./useCalendar";
+
+import { useWindow } from "@salt-ds/window";
+import { useComponentCssInjection } from "@salt-ds/styles";
+
+import calendarCss from "./Calendar.css";
+
+export type CalendarProps = useCalendarProps & {
+  className?: string;
+  renderDayContents?: CalendarCarouselProps["renderDayContents"];
+  hideYearDropdown?: CalendarNavigationProps["hideYearDropdown"];
+  TooltipProps?: CalendarCarouselProps["TooltipProps"];
+  hideOutOfRangeDates?: CalendarCarouselProps["hideOutOfRangeDates"];
+};
+
+const withBaseName = makePrefixer("saltCalendar");
+
+export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
+  function Calendar(props, ref) {
+    const {
+      className,
+      renderDayContents,
+      hideYearDropdown,
+      TooltipProps,
+      ...rest
+    } = props;
+
+    const targetWindow = useWindow();
+    useComponentCssInjection({
+      testId: "salt-calendar",
+      css: calendarCss,
+      window: targetWindow,
+    });
+
+    const { state, helpers } = useCalendar({ hideYearDropdown, ...rest });
+
+    const { setCalendarFocused } = helpers;
+
+    const handleFocus = useCallback(() => {
+      setCalendarFocused(true);
+    }, [setCalendarFocused]);
+
+    const handleBlur = useCallback(() => {
+      setCalendarFocused(false);
+    }, [setCalendarFocused]);
+
+    return (
+      <CalendarContext.Provider
+        value={{
+          state,
+          helpers,
+        }}
+      >
+        <div
+          className={clsx(withBaseName(), className)}
+          role="application"
+          ref={ref}
+        >
+          <CalendarNavigation hideYearDropdown={hideYearDropdown} />
+          <CalendarWeekHeader />
+          <CalendarCarousel
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            renderDayContents={renderDayContents}
+            TooltipProps={TooltipProps}
+          />
+        </div>
+      </CalendarContext.Provider>
+    );
+  }
+);

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/Calendar.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/Calendar.tsx
@@ -13,10 +13,7 @@ import {
 import { CalendarContext } from "./internal/CalendarContext";
 import { useCalendar, useCalendarProps } from "./useCalendar";
 
-import { useWindow } from "@salt-ds/window";
-import { useComponentCssInjection } from "@salt-ds/styles";
-
-import calendarCss from "./Calendar.css";
+import "./Calendar.css";
 
 export type CalendarProps = useCalendarProps & {
   className?: string;
@@ -37,13 +34,6 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
       TooltipProps,
       ...rest
     } = props;
-
-    const targetWindow = useWindow();
-    useComponentCssInjection({
-      testId: "salt-calendar",
-      css: calendarCss,
-      window: targetWindow,
-    });
 
     const { state, helpers } = useCalendar({ hideYearDropdown, ...rest });
 

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/index.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/index.ts
@@ -1,0 +1,4 @@
+export * from "./Calendar";
+export * from "./useCalendarDay";
+export * from "./useCalendar";
+export * from "./useSelection";

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarCarousel.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarCarousel.css
@@ -1,0 +1,18 @@
+.saltCalendarCarousel-track {
+  display: grid;
+  grid-auto-flow: column;
+}
+
+.saltCalendarCarousel-track > * {
+  position: absolute;
+  left: 0;
+  width: 100%;
+}
+
+.saltCalendarCarousel-track > :nth-child(2) {
+  position: relative;
+}
+
+.saltCalendarCarousel-shouldAnimate {
+  transition: transform 200ms ease-in-out;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarCarousel.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarCarousel.tsx
@@ -13,10 +13,8 @@ import {
 } from "@salt-ds/core";
 import { useCalendarContext } from "./CalendarContext";
 
-import calendarCarouselCss from "./CalendarCarousel.css";
+import "./CalendarCarousel.css";
 import { formatDate, monthDiff } from "./utils";
-import { useWindow } from "@salt-ds/window";
-import { useComponentCssInjection } from "@salt-ds/styles";
 
 export type CalendarCarouselProps = Omit<CalendarMonthProps, "date">;
 
@@ -37,13 +35,6 @@ export const CalendarCarousel = forwardRef<
   CalendarCarouselProps
 >(function CalendarCarousel(props, ref) {
   const { ...rest } = props;
-
-  const targetWindow = useWindow();
-  useComponentCssInjection({
-    testId: "salt-calendar-carousel",
-    css: calendarCarouselCss,
-    window: targetWindow,
-  });
 
   const {
     state: { visibleMonth },

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarCarousel.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarCarousel.tsx
@@ -1,0 +1,130 @@
+import { forwardRef, useEffect, useRef, useState } from "react";
+import {
+  DateValue,
+  getLocalTimeZone,
+  isSameMonth,
+  today,
+} from "@internationalized/date";
+import { CalendarMonth, CalendarMonthProps } from "./CalendarMonth";
+import {
+  makePrefixer,
+  useIsomorphicLayoutEffect,
+  usePrevious,
+} from "@salt-ds/core";
+import { useCalendarContext } from "./CalendarContext";
+
+import calendarCarouselCss from "./CalendarCarousel.css";
+import { formatDate, monthDiff } from "./utils";
+import { useWindow } from "@salt-ds/window";
+import { useComponentCssInjection } from "@salt-ds/styles";
+
+export type CalendarCarouselProps = Omit<CalendarMonthProps, "date">;
+
+function getMonths(month: DateValue) {
+  return [month.subtract({ months: 1 }), month, month.add({ months: 1 })];
+}
+
+function usePreviousMonth(visibleMonth: DateValue) {
+  const previous = usePrevious(visibleMonth, [formatDate(visibleMonth)]);
+
+  return previous ?? today(getLocalTimeZone());
+}
+
+const withBaseName = makePrefixer("saltCalendarCarousel");
+
+export const CalendarCarousel = forwardRef<
+  HTMLDivElement,
+  CalendarCarouselProps
+>(function CalendarCarousel(props, ref) {
+  const { ...rest } = props;
+
+  const targetWindow = useWindow();
+  useComponentCssInjection({
+    testId: "salt-calendar-carousel",
+    css: calendarCarouselCss,
+    window: targetWindow,
+  });
+
+  const {
+    state: { visibleMonth },
+  } = useCalendarContext();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const diffIndex = (a: DateValue, b: DateValue) => monthDiff(a, b);
+
+  const { current: baseIndex } = useRef(visibleMonth);
+  const previousVisibleMonth = usePreviousMonth(visibleMonth);
+
+  useIsomorphicLayoutEffect(() => {
+    if (Math.abs(diffIndex(visibleMonth, previousVisibleMonth)) > 1) {
+      containerRef.current?.classList.remove(withBaseName("shouldAnimate"));
+    } else {
+      containerRef.current?.classList.add(withBaseName("shouldAnimate"));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formatDate(visibleMonth), formatDate(previousVisibleMonth)]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.style.transform = `translate3d(${
+        diffIndex(baseIndex, visibleMonth) * 100
+      }%, 0, 0)`;
+    }
+  });
+
+  const [months, setMonths] = useState(() => getMonths(visibleMonth));
+
+  useEffect(() => {
+    setMonths((oldMonths) => {
+      const newMonths = getMonths(visibleMonth).filter((month) => {
+        return !oldMonths.find((oldMonth) => isSameMonth(oldMonth, month));
+      });
+
+      return oldMonths.concat(newMonths);
+    });
+    const finishTransition = () => {
+      setMonths(getMonths(visibleMonth));
+    };
+    const container = containerRef.current;
+
+    if (
+      container &&
+      parseFloat(window.getComputedStyle(container).transitionDuration) > 0
+    ) {
+      container?.addEventListener("transitionend", finishTransition);
+
+      return () => {
+        container?.removeEventListener("transitionend", finishTransition);
+      };
+    } else {
+      finishTransition();
+    }
+
+    return undefined;
+  }, [formatDate(visibleMonth)]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div
+      className={withBaseName()}
+      style={{
+        overflowX: "hidden",
+        position: "relative",
+      }}
+      ref={ref}
+    >
+      <div className={withBaseName("track")} ref={containerRef}>
+        {months.map((date, index) => (
+          <div
+            key={formatDate(date)}
+            className={withBaseName("slide")}
+            style={{
+              transform: `translateX(${diffIndex(date, baseIndex) * 100}%)`,
+            }}
+            aria-hidden={index !== 1 ? "true" : undefined}
+          >
+            <CalendarMonth isVisible={index === 1} {...rest} date={date} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarContext.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react";
+import { useCalendar } from "../useCalendar";
+
+type CalendarState = {
+  state: ReturnType<typeof useCalendar>["state"];
+  helpers: ReturnType<typeof useCalendar>["helpers"];
+};
+
+const CalendarContext = createContext<CalendarState | null>(null);
+
+if (process.env.NODE_ENV !== "production") {
+  CalendarContext.displayName = "CalendarContext";
+}
+
+function useCalendarContext(): CalendarState {
+  const context = useContext(CalendarContext);
+
+  if (!context) {
+    throw new Error("Unexpected usage");
+  }
+
+  return context;
+}
+
+export { CalendarContext, useCalendarContext };

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarDay.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarDay.css
@@ -1,0 +1,165 @@
+/* TODO: Design need to align characteristics for CalendarDay */
+.saltCalendarDay {
+  --calendar-day-text-color: var(--salt-content-primary-foreground);
+  --calendar-day-background: var(--salt-selectable-background);
+  --calendar-day-background-hover: var(--salt-selectable-background-hover);
+  --calendar-day-text-color-hover: var(--salt-content-primary-foreground);
+  --calendar-day-outOfRange-text-color: var(--salt-content-secondary-foreground-disabled);
+  --calendar-day-blocked-text-color: var(--salt-content-primary-foreground);
+  --calendar-day-blocked-cursor: var(--salt-selectable-cursor-disabled);
+  --calendar-day-blocked-icon-color: var(--salt-status-error-foreground);
+  --calendar-day-blocked-background: var(--calendar-day-background);
+  --calendar-day-unselectable-text-color: var(--salt-content-secondary-foreground-disabled);
+  --calendar-day-unselectable-background: var(--calendar-day-background);
+  --calendar-day-unselectable-cursor: var(--salt-selectable-cursor-disabled);
+
+  --calendar-day-selected-background: var(--salt-selectable-background-selected);
+  --calendar-day-selected-text-color: var(--salt-content-primary-foreground);
+  /* --calendar-day-selected-focused-outlineColor: var(--salt-color-white); TODO: Check with design */
+
+  --calendar-day-selectedStart-background: var(--salt-selectable-background-selected);
+  --calendar-day-selectedStart-text-color: var(--salt-content-primary-foreground);
+  /* --calendar-day-selectedStart-focused-outlineColor: var(--salt-color-white);  TODO: Check with design */
+
+  --calendar-day-selectedEnd-background: var(--salt-selectable-background-selected);
+  --calendar-day-selectedEnd-text-color: var(--salt-content-primary-foreground);
+  /* --calendar-day-selectedEnd-focused-outlineColor: var(--salt-color-white);  TODO: Check with design */
+
+  --calendar-day-selectedSpan-background: var(--salt-selectable-background-blurSelected);
+  --calendar-day-selectedSpan-text-color: var(--salt-content-primary-foreground);
+
+  --calendar-day-hoveredSpan-background: var(--salt-selectable-background-hover);
+  --calendar-day-hoveredSpan-text-color: var(--salt-content-primary-foreground);
+
+  --calendar-day-hoveredOffset-background: var(--salt-selectable-background-hover);
+  --calendar-day-hoveredOffset-text-color: var(--salt-content-primary-foreground);
+
+  --calendar-day-currentDay-borderColor: var(--salt-content-primary-foreground); /* TODO should not be foreground color */
+
+  /* Focus */
+  --calendar-day-focused-outline: var(--salt-focused-outline);
+  --calendar-day-size: var(--salt-size-base);
+  --calendar-day-fontSize: var(--salt-text-fontSize);
+}
+
+.saltCalendarDay {
+  width: var(--calendar-day-size);
+  height: var(--calendar-day-size);
+  color: var(--calendar-day-text-color);
+  background-color: var(--calendar-day-background);
+  font-size: var(--calendar-day-fontSize);
+  border: 0;
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.saltCalendarDay:focus-visible {
+  outline: var(--calendar-day-focused-outline);
+  outline-offset: calc(0px - var(--salt-focused-outlineWidth));
+}
+
+.saltCalendarDay-outOfRange {
+  color: var(--calendar-day-outOfRange-text-color);
+}
+
+.saltCalendarDay:hover {
+  background: var(--calendar-day-background-hover);
+  color: var(--calendar-day-text-color-hover);
+}
+
+.saltCalendarDay-unselectableMedium,
+.saltCalendarDay-unselectableMedium:hover {
+  color: var(--calendar-day-blocked-text-color);
+  cursor: var(--calendar-day-blocked-cursor);
+  background: var(--calendar-day-blocked-background);
+}
+
+.saltCalendarDay-today {
+  border: 1px solid var(--calendar-day-currentDay-borderColor);
+}
+
+.saltCalendarDay-selectedSpan {
+  background: var(--calendar-day-selectedSpan-background);
+  color: var(--calendar-day-selectedSpan-text-color);
+}
+
+.saltCalendarDay-hoveredSpan,
+.saltCalendarDay-hoveredSpan:hover {
+  background: var(--calendar-day-hoveredSpan-background);
+  color: var(--calendar-day-hoveredSpan-text-color);
+}
+
+.saltCalendarDay-hoveredOffset,
+.saltCalendarDay-hoveredOffset:hover {
+  background: var(--calendar-day-hoveredOffset-background);
+  color: var(--calendar-day-hoveredOffset-text-color);
+}
+
+.saltCalendarDay-selected,
+.saltCalendarDay-selected:hover {
+  background: var(--calendar-day-selected-background);
+  color: var(--calendar-day-selected-text-color);
+}
+
+.saltCalendarDay-selectedStart,
+.saltCalendarDay-selectedStart:hover {
+  background: var(--calendar-day-selectedStart-background);
+  color: var(--calendar-day-selectedStart-text-color);
+}
+
+.saltCalendarDay-selectedEnd,
+.saltCalendarDay-selectedEnd:hover {
+  background: var(--calendar-day-selectedEnd-background);
+  color: var(--calendar-day-selectedEnd-text-color);
+}
+
+.saltCalendarDay-selected:focus-visible {
+  outline-color: var(--calendar-day-selected-focused-outlineColor);
+}
+
+.saltCalendarDay-selectedStart:focus-visible {
+  outline-color: var(--calendar-day-selectedStart-focused-outlineColor);
+}
+
+.saltCalendarDay-selectedEnd:focus-visible {
+  outline-color: var(--calendar-day-selectedEnd-focused-outlineColor);
+}
+
+.saltCalendarDay-unselectableLow,
+.saltCalendarDay-unselectableLow:hover {
+  color: var(--calendar-day-unselectable-text-color);
+  background: var(--calendar-day-unselectable-background);
+  cursor: var(--calendar-day-unselectable-cursor);
+  text-decoration: line-through;
+}
+
+.salt-density-high {
+  --calendar-day-blocked-icon-size: 14px;
+}
+
+.salt-density-medium {
+  --calendar-day-blocked-icon-size: 18px;
+}
+
+.salt-density-low {
+  --calendar-day-blocked-icon-size: 24px;
+}
+
+.salt-density-touch {
+  --calendar-day-blocked-icon-size: 28px;
+}
+
+.saltCalendarDay-blockedIcon {
+  fill: var(--calendar-day-blocked-icon-color);
+  position: absolute;
+  --icon-size: var(--calendar-day-blocked-icon-size);
+  pointer-events: none;
+  line-height: 1.29;
+}
+
+.saltCalendarDay-hidden {
+  visibility: hidden;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarDay.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarDay.tsx
@@ -1,14 +1,12 @@
-import { makePrefixer, Tooltip, TooltipProps } from "@salt-ds/core";
+import { makePrefixer, Tooltip, TooltipProps, useForkRef } from "@salt-ds/core";
 import { CloseIcon } from "@salt-ds/icons";
 import { clsx } from "clsx";
 import { ComponentPropsWithRef, forwardRef, ReactElement, useRef } from "react";
 import { DateValue } from "@internationalized/date";
 
 import { DayStatus, useCalendarDay } from "../useCalendarDay";
-import calendarDayCss from "./CalendarDay.css";
+import "./CalendarDay.css";
 import { formatDate } from "./utils";
-import { useWindow } from "@salt-ds/window";
-import { useComponentCssInjection } from "@salt-ds/styles";
 
 export type DateFormatter = (day: Date) => string | undefined;
 
@@ -28,14 +26,10 @@ export const CalendarDay = forwardRef<HTMLButtonElement, CalendarDayProps>(
   function CalendarDay(props, ref) {
     const { className, day, renderDayContents, month, TooltipProps, ...rest } =
       props;
-    const targetWindow = useWindow();
-    useComponentCssInjection({
-      testId: "salt-calendar-day",
-      css: calendarDayCss,
-      window: targetWindow,
-    });
 
     const dayRef = useRef<HTMLButtonElement>(null);
+    const forkedRef = useForkRef(ref, dayRef);
+
     const { status, dayProps, unselectableReason } = useCalendarDay(
       {
         date: day,
@@ -58,7 +52,7 @@ export const CalendarDay = forwardRef<HTMLButtonElement, CalendarDayProps>(
         <button
           aria-label={formatDate(day)}
           {...dayProps}
-          ref={dayRef}
+          ref={forkedRef}
           {...rest}
           className={clsx(
             withBaseName(),

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarDay.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarDay.tsx
@@ -1,0 +1,92 @@
+import { makePrefixer, Tooltip, TooltipProps } from "@salt-ds/core";
+import { CloseIcon } from "@salt-ds/icons";
+import { clsx } from "clsx";
+import { ComponentPropsWithRef, forwardRef, ReactElement, useRef } from "react";
+import { DateValue } from "@internationalized/date";
+
+import { DayStatus, useCalendarDay } from "../useCalendarDay";
+import calendarDayCss from "./CalendarDay.css";
+import { formatDate } from "./utils";
+import { useWindow } from "@salt-ds/window";
+import { useComponentCssInjection } from "@salt-ds/styles";
+
+export type DateFormatter = (day: Date) => string | undefined;
+
+export interface CalendarDayProps
+  extends Omit<ComponentPropsWithRef<"button">, "children"> {
+  day: DateValue;
+  formatDate?: DateFormatter;
+  renderDayContents?: (date: DateValue, status: DayStatus) => ReactElement;
+  status?: DayStatus;
+  month: DateValue;
+  TooltipProps?: Partial<TooltipProps>;
+}
+
+const withBaseName = makePrefixer("saltCalendarDay");
+
+export const CalendarDay = forwardRef<HTMLButtonElement, CalendarDayProps>(
+  function CalendarDay(props, ref) {
+    const { className, day, renderDayContents, month, TooltipProps, ...rest } =
+      props;
+    const targetWindow = useWindow();
+    useComponentCssInjection({
+      testId: "salt-calendar-day",
+      css: calendarDayCss,
+      window: targetWindow,
+    });
+
+    const dayRef = useRef<HTMLButtonElement>(null);
+    const { status, dayProps, unselectableReason } = useCalendarDay(
+      {
+        date: day,
+        month,
+      },
+      dayRef
+    );
+    const { outOfRange, today, unselectable, hidden } = status;
+
+    return (
+      <Tooltip
+        hideIcon
+        status="error"
+        content={unselectableReason}
+        disabled={!unselectableReason}
+        placement="top"
+        enterDelay={300}
+        {...TooltipProps}
+      >
+        <button
+          aria-label={formatDate(day)}
+          {...dayProps}
+          ref={dayRef}
+          {...rest}
+          className={clsx(
+            withBaseName(),
+            {
+              [withBaseName("hidden")]: hidden,
+              [withBaseName("outOfRange")]: outOfRange,
+              [withBaseName("today")]: today,
+              [withBaseName("unselectable")]: !!unselectable,
+              [withBaseName("unselectableLow")]: unselectable === "low",
+              [withBaseName("unselectableMedium")]: unselectable === "medium",
+            },
+            dayProps.className,
+            className
+          )}
+        >
+          {unselectable === "medium" && (
+            <CloseIcon
+              aria-hidden
+              aria-label={undefined}
+              className={withBaseName("blockedIcon")}
+            />
+          )}
+
+          {renderDayContents
+            ? renderDayContents(day, status)
+            : formatDate(day, { day: "numeric" })}
+        </button>
+      </Tooltip>
+    );
+  }
+);

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarMonth.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarMonth.css
@@ -1,0 +1,5 @@
+.saltCalendarMonth-dateGrid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarMonth.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarMonth.tsx
@@ -1,0 +1,84 @@
+import {
+  ComponentPropsWithRef,
+  forwardRef,
+  MouseEvent,
+  SyntheticEvent,
+} from "react";
+import { clsx } from "clsx";
+import { makePrefixer } from "@salt-ds/core";
+import { DateValue } from "@internationalized/date";
+import { CalendarDay, CalendarDayProps } from "./CalendarDay";
+import { formatDate, generateVisibleDays } from "./utils";
+
+import calendarMonthCss from "./CalendarMonth.css";
+import { useCalendarContext } from "./CalendarContext";
+import { useWindow } from "@salt-ds/window";
+import { useComponentCssInjection } from "@salt-ds/styles";
+
+export interface CalendarMonthProps extends ComponentPropsWithRef<"div"> {
+  date: DateValue;
+  hideOutOfRangeDates?: boolean;
+  renderDayContents?: CalendarDayProps["renderDayContents"];
+  isVisible?: boolean;
+  TooltipProps?: CalendarDayProps["TooltipProps"];
+}
+
+const withBaseName = makePrefixer("saltCalendarMonth");
+
+export const CalendarMonth = forwardRef<HTMLDivElement, CalendarMonthProps>(
+  function CalendarMonth(props, ref) {
+    const {
+      className,
+      date,
+      hideOutOfRangeDates,
+      isVisible,
+      renderDayContents,
+      onMouseLeave,
+      TooltipProps,
+      ...rest
+    } = props;
+
+    const targetWindow = useWindow();
+    useComponentCssInjection({
+      testId: "salt-calendar-month",
+      css: calendarMonthCss,
+      window: targetWindow,
+    });
+
+    const days = generateVisibleDays(date);
+    const {
+      helpers: { setHoveredDate },
+    } = useCalendarContext();
+
+    const handleMouseLeave = (event: SyntheticEvent) => {
+      setHoveredDate(event, null);
+      onMouseLeave?.(event as MouseEvent<HTMLDivElement>);
+    };
+
+    return (
+      <div
+        className={clsx(withBaseName(), className)}
+        ref={ref}
+        onMouseLeave={handleMouseLeave}
+        {...rest}
+      >
+        <div
+          data-testid="CalendarDateGrid"
+          className={withBaseName("dateGrid")}
+        >
+          {days.map((day) => {
+            return (
+              <CalendarDay
+                key={formatDate(day.date)}
+                day={day.date}
+                renderDayContents={renderDayContents}
+                month={date}
+                TooltipProps={TooltipProps}
+              />
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+);

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarMonth.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarMonth.tsx
@@ -10,10 +10,8 @@ import { DateValue } from "@internationalized/date";
 import { CalendarDay, CalendarDayProps } from "./CalendarDay";
 import { formatDate, generateVisibleDays } from "./utils";
 
-import calendarMonthCss from "./CalendarMonth.css";
+import "./CalendarMonth.css";
 import { useCalendarContext } from "./CalendarContext";
-import { useWindow } from "@salt-ds/window";
-import { useComponentCssInjection } from "@salt-ds/styles";
 
 export interface CalendarMonthProps extends ComponentPropsWithRef<"div"> {
   date: DateValue;
@@ -37,13 +35,6 @@ export const CalendarMonth = forwardRef<HTMLDivElement, CalendarMonthProps>(
       TooltipProps,
       ...rest
     } = props;
-
-    const targetWindow = useWindow();
-    useComponentCssInjection({
-      testId: "salt-calendar-month",
-      css: calendarMonthCss,
-      window: targetWindow,
-    });
 
     const days = generateVisibleDays(date);
     const {

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarNavigation.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarNavigation.css
@@ -16,6 +16,7 @@
   display: grid;
   grid-template-columns: min-content auto auto min-content;
   grid-gap: var(--calendar-navigation-gap);
+  align-items: center;
 }
 
 .saltCalendarNavigation-hideYearDropdown {

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarNavigation.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarNavigation.css
@@ -1,0 +1,23 @@
+.salt-density-medium,
+.salt-density-touch,
+.salt-density-low {
+  --calendar-navigation-gap: calc(var(--salt-size-unit) * 0.5);
+}
+
+.salt-density-high {
+  --calendar-navigation-gap: 0px;
+}
+
+.saltCalendarNavigation-hideYearDropdown {
+  --calendar-navigation-gap: calc(var(--salt-size-unit) * 2);
+}
+
+.saltCalendarNavigation {
+  display: grid;
+  grid-template-columns: min-content auto auto min-content;
+  grid-gap: var(--calendar-navigation-gap);
+}
+
+.saltCalendarNavigation-hideYearDropdown {
+  grid-template-columns: min-content auto min-content;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarNavigation.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarNavigation.tsx
@@ -1,0 +1,293 @@
+import {
+  Button,
+  ButtonProps,
+  makePrefixer,
+  Tooltip,
+  useId,
+} from "@salt-ds/core";
+import { ChevronLeftIcon, ChevronRightIcon } from "@salt-ds/icons";
+import { clsx } from "clsx";
+import {
+  ComponentPropsWithRef,
+  forwardRef,
+  MouseEventHandler,
+  SyntheticEvent,
+} from "react";
+import { Dropdown, DropdownProps } from "../../dropdown";
+import { ListItem, ListItemType } from "../../list";
+
+import { useCalendarContext } from "./CalendarContext";
+
+import calendarNavigationCss from "./CalendarNavigation.css";
+import { DateValue, isSameMonth, isSameYear } from "@internationalized/date";
+import { formatDate, monthDiff, monthsForLocale } from "./utils";
+import { SelectionChangeHandler } from "../../common-hooks";
+import { useWindow } from "@salt-ds/window";
+import { useComponentCssInjection } from "@salt-ds/styles";
+
+type DropdownItem = {
+  value: DateValue;
+  disabled?: boolean;
+};
+
+type dateDropdownProps = DropdownProps<DropdownItem>;
+
+export interface CalendarNavigationProps extends ComponentPropsWithRef<"div"> {
+  MonthDropdownProps?: dateDropdownProps;
+  YearDropdownProps?: dateDropdownProps;
+  onMonthSelect?: dateDropdownProps["onChange"];
+  onYearSelect?: dateDropdownProps["onChange"];
+  onNavigateNext?: ButtonProps["onClick"];
+  onNavigatePrevious?: ButtonProps["onClick"];
+  hideYearDropdown?: boolean;
+}
+
+const withBaseName = makePrefixer("saltCalendarNavigation");
+
+function useCalendarNavigation() {
+  const {
+    state: { visibleMonth, minDate, maxDate },
+    helpers: {
+      setVisibleMonth,
+      isDayVisible,
+      isOutsideAllowedYears,
+      isOutsideAllowedMonths,
+    },
+  } = useCalendarContext();
+
+  const moveToNextMonth = (event: SyntheticEvent) => {
+    setVisibleMonth(event, visibleMonth.add({ months: 1 }));
+  };
+
+  const moveToPreviousMonth = (event: SyntheticEvent) => {
+    setVisibleMonth(event, visibleMonth.subtract({ months: 1 }));
+  };
+
+  const moveToMonth = (event: SyntheticEvent, month: DateValue) => {
+    let newMonth = month;
+
+    if (!isOutsideAllowedYears(newMonth)) {
+      if (isOutsideAllowedMonths(newMonth)) {
+        // If month is navigable we should move to the closest navigable month
+        const navigableMonths = monthsForLocale(visibleMonth).filter(
+          (n) => !isOutsideAllowedMonths(n)
+        );
+        newMonth = navigableMonths.reduce((closestMonth, currentMonth) =>
+          Math.abs(monthDiff(currentMonth, newMonth)) <
+          Math.abs(monthDiff(closestMonth, newMonth))
+            ? currentMonth
+            : closestMonth
+        );
+      }
+      setVisibleMonth(event, newMonth);
+    }
+  };
+
+  const months = monthsForLocale(visibleMonth).map((month) => {
+    return { value: month, disabled: isOutsideAllowedMonths(month) };
+  });
+
+  const years = [-2, -1, 0, 1, 2]
+    .map((delta) => ({ value: visibleMonth.add({ years: delta }) }))
+    .filter(({ value }) => !isOutsideAllowedYears(value));
+
+  const selectedMonth = months.find((item: DropdownItem) =>
+    isSameMonth(item.value, visibleMonth)
+  );
+  const selectedYear = years.find((item: DropdownItem) =>
+    isSameYear(item.value, visibleMonth)
+  );
+
+  const canNavigatePrevious = !(minDate && isDayVisible(minDate));
+  const canNavigateNext = !(maxDate && isDayVisible(maxDate));
+
+  return {
+    moveToNextMonth,
+    moveToPreviousMonth,
+    moveToMonth,
+    visibleMonth,
+    months,
+    years,
+    canNavigateNext,
+    canNavigatePrevious,
+    selectedMonth,
+    selectedYear,
+  };
+}
+
+const ListItemWithTooltip: ListItemType<DropdownItem> = ({
+  item,
+  label,
+  ...props
+}) => (
+  <Tooltip
+    placement="right"
+    disabled={!item?.disabled}
+    content="This month is out of range"
+  >
+    <ListItem {...props}>{label}</ListItem>
+  </Tooltip>
+);
+
+export const CalendarNavigation = forwardRef<
+  HTMLDivElement,
+  CalendarNavigationProps
+>(function CalendarNavigation(props, ref) {
+  const {
+    className,
+    MonthDropdownProps,
+    YearDropdownProps,
+    hideYearDropdown,
+    ...rest
+  } = props;
+
+  const targetWindow = useWindow();
+  useComponentCssInjection({
+    testId: "salt-calendar-navigation",
+    css: calendarNavigationCss,
+    window: targetWindow,
+  });
+
+  const {
+    moveToPreviousMonth,
+    moveToNextMonth,
+    moveToMonth,
+    months,
+    years,
+    canNavigateNext,
+    canNavigatePrevious,
+    visibleMonth,
+    selectedMonth,
+    selectedYear,
+  } = useCalendarNavigation();
+
+  const handleNavigatePrevious: MouseEventHandler<HTMLButtonElement> = (
+    event
+  ) => {
+    moveToPreviousMonth(event);
+  };
+
+  const handleNavigateNext: MouseEventHandler<HTMLButtonElement> = (event) => {
+    moveToNextMonth(event);
+  };
+
+  const handleMonthSelect: SelectionChangeHandler<DropdownItem> = (
+    event,
+    month
+  ) => {
+    if (month) {
+      moveToMonth(event, month.value);
+    }
+  };
+
+  const handleYearSelect: SelectionChangeHandler<DropdownItem> = (
+    event,
+    year
+  ) => {
+    if (year) {
+      moveToMonth(event, year.value);
+    }
+  };
+
+  const monthDropdownId = useId(MonthDropdownProps?.id) || "";
+  const monthDropdownLabelledBy = clsx(
+    MonthDropdownProps?.["aria-labelledby"],
+    // TODO need a prop on Dropdown to allow buttonId to be passed, should not make assumptions about internal
+    // id assignment like this
+    `${monthDropdownId}-control`
+  );
+
+  const yearDropdownId = useId(YearDropdownProps?.id) || "";
+  const yearDropdownLabelledBy = clsx(
+    YearDropdownProps?.["aria-labelledby"],
+    `${yearDropdownId}-control`
+  );
+
+  const defaultItemToMonth = (date: DropdownItem) => {
+    if (hideYearDropdown) {
+      return formatDate(date.value, { month: "long" });
+    }
+    return formatDate(date.value, { month: "short" });
+  };
+
+  const defaultItemToYear = (date: DropdownItem) => {
+    return formatDate(date.value, { year: "numeric" });
+  };
+
+  return (
+    <div
+      className={clsx(
+        withBaseName(),
+        { [withBaseName("hideYearDropdown")]: hideYearDropdown },
+        className
+      )}
+      ref={ref}
+      {...rest}
+    >
+      <Tooltip
+        placement="top"
+        disabled={canNavigatePrevious}
+        content="Past dates are out of range"
+      >
+        <Button
+          disabled={!canNavigatePrevious}
+          variant="secondary"
+          onClick={handleNavigatePrevious}
+          className={withBaseName("previousButton")}
+          focusableWhenDisabled={true}
+        >
+          <ChevronLeftIcon
+            aria-label={`Previous Month, ${formatDate(
+              visibleMonth.subtract({ months: 1 })
+            )}`}
+          />
+        </Button>
+      </Tooltip>
+      <Dropdown<DropdownItem>
+        source={months}
+        id={monthDropdownId}
+        aria-labelledby={monthDropdownLabelledBy}
+        aria-label="Month Dropdown"
+        {...MonthDropdownProps}
+        ListItem={ListItemWithTooltip}
+        selected={selectedMonth}
+        itemToString={defaultItemToMonth}
+        onSelectionChange={handleMonthSelect}
+        fullWidth
+      />
+      {!hideYearDropdown && (
+        <Dropdown<DropdownItem>
+          source={years}
+          id={yearDropdownId}
+          aria-labelledby={yearDropdownLabelledBy}
+          aria-label="Year Dropdown"
+          {...YearDropdownProps}
+          ListItem={ListItemWithTooltip}
+          selected={selectedYear}
+          onSelectionChange={handleYearSelect}
+          itemToString={defaultItemToYear}
+          fullWidth
+        />
+      )}
+      <Tooltip
+        placement="top"
+        disabled={canNavigateNext}
+        content="Future dates are out of range"
+      >
+        <Button
+          disabled={!canNavigateNext}
+          variant="secondary"
+          onClick={handleNavigateNext}
+          className={withBaseName("nextButton")}
+          focusableWhenDisabled={true}
+        >
+          <ChevronRightIcon
+            aria-label={`Next Month, ${formatDate(
+              visibleMonth.add({ months: 1 })
+            )}`}
+          />
+        </Button>
+      </Tooltip>
+    </div>
+  );
+});

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarNavigation.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarNavigation.tsx
@@ -18,12 +18,10 @@ import { ListItem, ListItemType } from "../../list";
 
 import { useCalendarContext } from "./CalendarContext";
 
-import calendarNavigationCss from "./CalendarNavigation.css";
+import "./CalendarNavigation.css";
 import { DateValue, isSameMonth, isSameYear } from "@internationalized/date";
 import { formatDate, monthDiff, monthsForLocale } from "./utils";
-import { SelectionChangeHandler } from "../../common-hooks";
-import { useWindow } from "@salt-ds/window";
-import { useComponentCssInjection } from "@salt-ds/styles";
+import { SingleSelectionHandler } from "../../common-hooks";
 
 type DropdownItem = {
   value: DateValue;
@@ -141,13 +139,6 @@ export const CalendarNavigation = forwardRef<
     ...rest
   } = props;
 
-  const targetWindow = useWindow();
-  useComponentCssInjection({
-    testId: "salt-calendar-navigation",
-    css: calendarNavigationCss,
-    window: targetWindow,
-  });
-
   const {
     moveToPreviousMonth,
     moveToNextMonth,
@@ -171,20 +162,20 @@ export const CalendarNavigation = forwardRef<
     moveToNextMonth(event);
   };
 
-  const handleMonthSelect: SelectionChangeHandler<DropdownItem> = (
+  const handleMonthSelect: SingleSelectionHandler<DropdownItem> = (
     event,
     month
   ) => {
-    if (month) {
+    if (month && event) {
       moveToMonth(event, month.value);
     }
   };
 
-  const handleYearSelect: SelectionChangeHandler<DropdownItem> = (
+  const handleYearSelect: SingleSelectionHandler<DropdownItem> = (
     event,
     year
   ) => {
-    if (year) {
+    if (year && event) {
       moveToMonth(event, year.value);
     }
   };

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarWeekHeader.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarWeekHeader.css
@@ -1,0 +1,21 @@
+.saltCalendarWeekHeader {
+  --calendar-week-header-underline-color: var(--salt-separable-secondary-borderColor);
+  --calendar-week-header-text-color: var(--salt-content-secondary-foreground);
+  --calendar-week-header-size: var(--salt-size-base);
+  --calendar-week-header-fontSize: var(--saltCalendar-week-header-fontSize, var(--salt-text-label-fontSize));
+}
+
+.saltCalendarWeekHeader {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  box-shadow: inset 0 -1px 0 var(--calendar-week-header-underline-color);
+}
+
+.saltCalendarWeekHeader-dayOfWeek {
+  width: var(--calendar-week-header-size);
+  height: var(--calendar-week-header-size);
+  color: var(--calendar-week-header-text-color);
+  line-height: var(--calendar-week-header-size);
+  font-size: var(--calendar-week-header-fontSize);
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarWeekHeader.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarWeekHeader.tsx
@@ -3,9 +3,7 @@ import { clsx } from "clsx";
 import { makePrefixer } from "@salt-ds/core";
 import { daysForLocale } from "./utils";
 
-import calendarWeekHeaderCss from "./CalendarWeekHeader.css";
-import { useWindow } from "@salt-ds/window";
-import { useComponentCssInjection } from "@salt-ds/styles";
+import "./CalendarWeekHeader.css";
 
 export type CalendarWeekHeaderProps = ComponentPropsWithRef<"div">;
 
@@ -17,13 +15,6 @@ export const CalendarWeekHeader = forwardRef<
 >(function CalendarWeekHeader({ className, ...rest }, ref) {
   const weekdaysShort = daysForLocale("narrow");
   const weekdaysLong = daysForLocale("long");
-
-  const targetWindow = useWindow();
-  useComponentCssInjection({
-    testId: "salt-calendar",
-    css: calendarWeekHeaderCss,
-    window: targetWindow,
-  });
 
   return (
     <div

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarWeekHeader.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/CalendarWeekHeader.tsx
@@ -1,0 +1,46 @@
+import { ComponentPropsWithRef, forwardRef } from "react";
+import { clsx } from "clsx";
+import { makePrefixer } from "@salt-ds/core";
+import { daysForLocale } from "./utils";
+
+import calendarWeekHeaderCss from "./CalendarWeekHeader.css";
+import { useWindow } from "@salt-ds/window";
+import { useComponentCssInjection } from "@salt-ds/styles";
+
+export type CalendarWeekHeaderProps = ComponentPropsWithRef<"div">;
+
+const withBaseName = makePrefixer("saltCalendarWeekHeader");
+
+export const CalendarWeekHeader = forwardRef<
+  HTMLDivElement,
+  CalendarWeekHeaderProps
+>(function CalendarWeekHeader({ className, ...rest }, ref) {
+  const weekdaysShort = daysForLocale("narrow");
+  const weekdaysLong = daysForLocale("long");
+
+  const targetWindow = useWindow();
+  useComponentCssInjection({
+    testId: "salt-calendar",
+    css: calendarWeekHeaderCss,
+    window: targetWindow,
+  });
+
+  return (
+    <div
+      data-testid="CalendarWeekHeader"
+      className={clsx(withBaseName(), className)}
+      ref={ref}
+      {...rest}
+    >
+      {weekdaysShort.map((day, index) => (
+        <small
+          aria-hidden="true"
+          key={weekdaysLong[index]}
+          className={withBaseName("dayOfWeek")}
+        >
+          {day}
+        </small>
+      ))}
+    </div>
+  );
+});

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/useFocusManagement.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/useFocusManagement.ts
@@ -1,0 +1,69 @@
+import {
+  FocusEventHandler,
+  KeyboardEventHandler,
+  MouseEventHandler,
+} from "react";
+import { useCalendarContext } from "./CalendarContext";
+import { DateValue, endOfWeek, startOfWeek } from "@internationalized/date";
+import { getCurrentLocale } from "./utils";
+
+export function useFocusManagement({ date }: { date: DateValue }) {
+  const {
+    helpers: { setFocusedDate },
+  } = useCalendarContext();
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    setFocusedDate(event, date);
+  };
+
+  const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = (event) => {
+    let newDate = date;
+    switch (event.key) {
+      case "ArrowUp":
+        newDate = date.subtract({ weeks: 1 });
+        break;
+      case "ArrowDown":
+        newDate = date.add({ weeks: 1 });
+        break;
+      case "ArrowLeft":
+        newDate = date.subtract({ days: 1 });
+        break;
+      case "ArrowRight":
+        newDate = date.add({ days: 1 });
+        break;
+      case "Home":
+        newDate = startOfWeek(date, getCurrentLocale());
+        break;
+      case "End":
+        // @ts-ignore TODO bug in @internationalized/date
+        newDate = endOfWeek(date, getCurrentLocale());
+        break;
+      case "PageUp":
+        if (event.shiftKey) {
+          newDate = date.subtract({ years: 1 });
+        } else {
+          newDate = date.subtract({ months: 1 });
+        }
+        break;
+      case "PageDown":
+        if (event.shiftKey) {
+          newDate = date.add({ years: 1 });
+        } else {
+          newDate = date.add({ months: 1 });
+        }
+        break;
+      default:
+    }
+
+    setFocusedDate(event, newDate);
+  };
+
+  const handleFocus: FocusEventHandler<HTMLButtonElement> = (event) => {
+    setFocusedDate(event, date);
+  };
+
+  return {
+    handleClick,
+    handleKeyDown,
+    handleFocus,
+  };
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/useFocusManagement.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/useFocusManagement.ts
@@ -34,6 +34,7 @@ export function useFocusManagement({ date }: { date: DateValue }) {
         newDate = startOfWeek(date, getCurrentLocale());
         break;
       case "End":
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore TODO bug in @internationalized/date
         newDate = endOfWeek(date, getCurrentLocale());
         break;

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/utils.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/internal/utils.ts
@@ -1,0 +1,77 @@
+import {
+  createCalendar,
+  DateFormatter,
+  DateValue,
+  getLocalTimeZone,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+  today,
+} from "@internationalized/date";
+
+const localTimezone = getLocalTimeZone();
+
+export function getCurrentLocale() {
+  return navigator.languages[0];
+}
+
+export function getDateFormatter(options?: Intl.DateTimeFormatOptions) {
+  return new DateFormatter(getCurrentLocale(), options);
+}
+
+export function formatDate(
+  date: DateValue,
+  options?: Intl.DateTimeFormatOptions
+) {
+  const formatter = getDateFormatter(options);
+  return formatter.format(date.toDate(localTimezone));
+}
+
+export function getCalender() {
+  const calendarIdentifier = getDateFormatter().resolvedOptions().calendar;
+  return createCalendar(calendarIdentifier);
+}
+
+type WeekdayFormat = Intl.DateTimeFormatOptions["weekday"];
+
+export function daysForLocale(weekday: WeekdayFormat = "long") {
+  return [...Array(7).keys()].map((day) =>
+    formatDate(
+      startOfWeek(today(getLocalTimeZone()), getCurrentLocale()).add({
+        days: day,
+      }),
+      { weekday }
+    )
+  );
+}
+
+export function monthsForLocale(currentYear: DateValue) {
+  const calendar = getCalender();
+  return [...Array(calendar.getMonthsInYear(currentYear)).keys()].map((month) =>
+    startOfYear(currentYear).add({ months: month })
+  );
+}
+
+function mapDate(currentDate: DateValue, currentMonth: DateValue) {
+  return {
+    date: currentDate,
+    dateOfMonth: currentDate.month,
+    isCurrentMonth: isSameMonth(currentDate, currentMonth),
+  };
+}
+
+export function generateVisibleDays(currentMonth: DateValue) {
+  const totalDays = 6 * 7;
+  const currentLocale = getCurrentLocale();
+  const startDate = startOfWeek(startOfMonth(currentMonth), currentLocale);
+
+  return [...Array(totalDays).keys()].map((dayDelta) => {
+    const day = startDate.add({ days: dayDelta });
+    return mapDate(day, currentMonth);
+  });
+}
+
+export function monthDiff(a: DateValue, b: DateValue) {
+  return b.month - a.month + 12 * (b.year - a.year);
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/useCalendar.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/useCalendar.ts
@@ -1,0 +1,208 @@
+import {
+  DateValue,
+  endOfMonth,
+  endOfYear,
+  getLocalTimeZone,
+  isSameDay,
+  startOfMonth,
+  startOfYear,
+  today,
+} from "@internationalized/date";
+import { useControlled } from "@salt-ds/core";
+import { SyntheticEvent, useCallback, useEffect, useState } from "react";
+import {
+  UseMultiSelectionCalendarProps,
+  UseOffsetSelectionCalendarProps,
+  UseRangeSelectionCalendarProps,
+  useSelectionCalendar,
+  useSelectionCalendarProps,
+  UseSingleSelectionCalendarProps,
+} from "./useSelection";
+
+export type UnselectableInfo =
+  | { emphasis: "medium"; tooltip: string }
+  | { emphasis: "low"; tooltip?: string };
+
+interface BaseUseCalendarProps {
+  defaultVisibleMonth?: DateValue;
+  onVisibleMonthChange?: (
+    event: SyntheticEvent,
+    visibleMonth: DateValue
+  ) => void;
+  isDayUnselectable?: (date: DateValue) => UnselectableInfo | boolean | void;
+  visibleMonth?: DateValue;
+  hideOutOfRangeDates?: boolean;
+  hideYearDropdown?: boolean;
+  minDate?: DateValue;
+  maxDate?: DateValue;
+}
+
+export type useCalendarProps = (
+  | Omit<UseSingleSelectionCalendarProps, "isDaySelectable">
+  | Omit<UseMultiSelectionCalendarProps, "isDaySelectable">
+  | Omit<UseRangeSelectionCalendarProps, "isDaySelectable">
+  | Omit<UseOffsetSelectionCalendarProps, "isDaySelectable">
+) &
+  BaseUseCalendarProps;
+
+const defaultIsDayUnselectable = (): UnselectableInfo | false => false;
+
+export function useCalendar(props: useCalendarProps) {
+  const {
+    selectedDate,
+    defaultSelectedDate,
+    visibleMonth: visibleMonthProp,
+    hideYearDropdown,
+    hideOutOfRangeDates,
+    defaultVisibleMonth = today(getLocalTimeZone()),
+    onSelectedDateChange,
+    onVisibleMonthChange,
+    isDayUnselectable = defaultIsDayUnselectable,
+    minDate = hideYearDropdown
+      ? startOfYear(today(getLocalTimeZone()))
+      : undefined,
+    maxDate = hideYearDropdown
+      ? endOfYear(today(getLocalTimeZone()))
+      : undefined,
+    selectionVariant,
+    onHoveredDateChange,
+    hoveredDate,
+    // startDateOffset,
+    // endDateOffset,
+  } = props;
+
+  const isOutsideAllowedDates = useCallback(
+    (date: DateValue) => {
+      return (
+        (minDate != null && date.compare(minDate) < 0) ||
+        (maxDate != null && date.compare(maxDate) > 0)
+      );
+    },
+    [maxDate, minDate]
+  );
+
+  const isOutsideAllowedMonths = (date: DateValue) => {
+    return (
+      (minDate != null && endOfMonth(date).compare(minDate) < 0) ||
+      (maxDate != null && startOfMonth(date).compare(maxDate) > 0)
+    );
+  };
+
+  const isOutsideAllowedYears = (date: DateValue) => {
+    return (
+      (minDate != null && endOfYear(date).compare(minDate) < 0) ||
+      (maxDate != null && startOfYear(date).compare(maxDate) > 0)
+    );
+  };
+
+  const isDaySelectable = useCallback(
+    (date?: DateValue) =>
+      !(date && (isDayUnselectable(date) || isOutsideAllowedDates(date))),
+    [isDayUnselectable, isOutsideAllowedDates]
+  );
+
+  const selectionManager = useSelectionCalendar({
+    defaultSelectedDate: defaultSelectedDate,
+    selectedDate,
+    onSelectedDateChange,
+    startDateOffset:
+      props.selectionVariant === "offset"
+        ? props.startDateOffset
+        : (date) => date,
+    endDateOffset:
+      props.selectionVariant === "offset"
+        ? props.endDateOffset
+        : (date) => date,
+    isDaySelectable,
+    selectionVariant,
+    onHoveredDateChange,
+    hoveredDate,
+  } as useSelectionCalendarProps);
+
+  const [visibleMonth, setVisibleMonthState] = useControlled({
+    controlled: visibleMonthProp ? startOfMonth(visibleMonthProp) : undefined,
+    default: startOfMonth(defaultVisibleMonth),
+    name: "Calendar",
+    state: "visibleMonth",
+  });
+
+  const [calendarFocused, setCalendarFocused] = useState(false);
+
+  const [focusedDate, setFocusedDateState] = useState<DateValue>(
+    startOfMonth(visibleMonth)
+  );
+
+  const isDayVisible = useCallback(
+    (date: DateValue) => {
+      const startInsideDays = startOfMonth(visibleMonth);
+
+      if (date.compare(startInsideDays) < 0) return false;
+
+      const endInsideDays = endOfMonth(visibleMonth);
+
+      return !(date.compare(endInsideDays) > 0);
+    },
+    [visibleMonth]
+  );
+
+  const setVisibleMonth = useCallback(
+    (event: SyntheticEvent, newVisibleMonth: DateValue) => {
+      setVisibleMonthState(newVisibleMonth);
+      onVisibleMonthChange?.(event, newVisibleMonth);
+    },
+    [onVisibleMonthChange, setVisibleMonthState]
+  );
+
+  const setFocusedDate = useCallback(
+    (event: SyntheticEvent, date: DateValue) => {
+      if (isSameDay(date, focusedDate) || isOutsideAllowedDates(date)) return;
+
+      setFocusedDateState(date);
+
+      const shouldTransition =
+        !isDayVisible(date) &&
+        isDaySelectable(date) &&
+        !isOutsideAllowedDates(date);
+      if (shouldTransition) {
+        setVisibleMonth(event, startOfMonth(date));
+      }
+    },
+    [
+      focusedDate,
+      isDaySelectable,
+      isDayVisible,
+      isOutsideAllowedDates,
+      setVisibleMonth,
+    ]
+  );
+
+  useEffect(() => {
+    if (!isDayVisible(focusedDate)) {
+      setFocusedDateState(startOfMonth(visibleMonth));
+    }
+  }, [isDayVisible, focusedDate, visibleMonth]);
+
+  return {
+    state: {
+      visibleMonth,
+      focusedDate,
+      minDate,
+      maxDate,
+      selectionVariant,
+      hideOutOfRangeDates,
+      calendarFocused,
+      ...selectionManager.state,
+    },
+    helpers: {
+      setVisibleMonth,
+      setFocusedDate,
+      setCalendarFocused,
+      isDayUnselectable,
+      isDayVisible,
+      isOutsideAllowedDates,
+      isOutsideAllowedMonths,
+      isOutsideAllowedYears,
+      ...selectionManager.helpers,
+    },
+  };
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/useCalendarDay.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/useCalendarDay.ts
@@ -1,0 +1,112 @@
+import {
+  DateValue,
+  getLocalTimeZone,
+  isSameDay,
+  isSameMonth,
+  isToday,
+} from "@internationalized/date";
+import {
+  ComponentPropsWithoutRef,
+  FocusEventHandler,
+  KeyboardEventHandler,
+  MouseEventHandler,
+  RefObject,
+  useEffect,
+} from "react";
+import { useCalendarContext } from "./internal/CalendarContext";
+import { useFocusManagement } from "./internal/useFocusManagement";
+import { useSelectionDay } from "./useSelection";
+
+export type DayStatus = {
+  outOfRange?: boolean;
+  selected?: boolean;
+  today?: boolean;
+  unselectable?: "medium" | "low" | false;
+  focused?: boolean;
+  hidden?: boolean;
+};
+
+export interface useCalendarDayProps {
+  date: DateValue;
+  month: DateValue;
+}
+
+export function useCalendarDay(
+  { date, month }: useCalendarDayProps,
+  ref: RefObject<HTMLElement>
+) {
+  const {
+    state: { focusedDate, hideOutOfRangeDates, calendarFocused },
+    helpers: { isDayUnselectable, isOutsideAllowedMonths },
+  } = useCalendarContext();
+  const selectionManager = useSelectionDay({ date });
+  const focusManager = useFocusManagement({ date });
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    selectionManager?.handleClick(event);
+    focusManager.handleClick(event);
+  };
+
+  const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = (event) => {
+    focusManager.handleKeyDown(event);
+    selectionManager?.handleKeyDown(event);
+  };
+
+  const handleFocus: FocusEventHandler<HTMLButtonElement> = (event) => {
+    focusManager.handleFocus(event);
+  };
+
+  const handleMouseOver: MouseEventHandler<HTMLButtonElement> = (event) => {
+    selectionManager.handleMouseOver?.(event);
+  };
+
+  const eventHandlers = {
+    onClick: handleClick,
+    onKeyDown: handleKeyDown,
+    onFocus: handleFocus,
+    onMouseOver: handleMouseOver,
+  };
+
+  const outOfRange = !isSameMonth(date, month);
+  const focused =
+    isSameDay(date, focusedDate) && calendarFocused && !outOfRange;
+  const tabIndex = isSameDay(date, focusedDate) && !outOfRange ? 0 : -1;
+  const today = isToday(date, getLocalTimeZone());
+
+  const unselectableResult =
+    isDayUnselectable(date) || (outOfRange && isOutsideAllowedMonths(date));
+  const unselectableReason =
+    typeof unselectableResult !== "boolean" ? unselectableResult?.tooltip : "";
+  const unselectable =
+    typeof unselectableResult !== "boolean"
+      ? unselectableResult.emphasis
+      : unselectableResult
+      ? "low"
+      : false;
+  const hidden = hideOutOfRangeDates && outOfRange;
+
+  useEffect(() => {
+    if (focused) {
+      ref.current?.focus({ preventScroll: true });
+    }
+  }, [ref, focused]);
+
+  return {
+    status: {
+      outOfRange,
+      today,
+      unselectable,
+      focused,
+      hidden,
+      ...selectionManager.status,
+    } as DayStatus,
+    dayProps: {
+      tabIndex,
+      "aria-current": today ? "date" : undefined,
+      "aria-hidden": hidden ? "true" : undefined,
+      ...eventHandlers,
+      ...selectionManager.dayProps,
+    } as ComponentPropsWithoutRef<"button">,
+    unselectableReason,
+  };
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/useSelection.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/useSelection.ts
@@ -22,7 +22,7 @@ interface BaseUseSelectionCalendarProps<SelectionVariantType> {
 
 type SingleSelectionValueType = DateValue;
 type MultiSelectionValueType = DateValue[];
-type RangeSelectionValueType = {
+export type RangeSelectionValueType = {
   startDate?: DateValue;
   endDate?: DateValue;
 };

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/useSelection.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/useSelection.ts
@@ -1,7 +1,7 @@
 import { makePrefixer, useControlled } from "@salt-ds/core";
 import { clsx } from "clsx";
 import { KeyboardEventHandler, MouseEventHandler, SyntheticEvent } from "react";
-import { isPlainObject } from "../utils";
+import { isPlainObject } from "../common-hooks/isPlainObject";
 import { useCalendarContext } from "./internal/CalendarContext";
 import { CalendarDate, DateValue, isSameDay } from "@internationalized/date";
 
@@ -137,12 +137,13 @@ export function useSelectionCalendar(props: useSelectionCalendarProps) {
           setSelectedDateState(newSelectedDate);
           props.onSelectedDateChange?.(event, newSelectedDate);
           break;
-        case "multiselect":
+        case "multiselect": {
           const newDates = addOrRemoveFromArray(selectedDate, newSelectedDate);
           setSelectedDateState(newDates);
           props.onSelectedDateChange?.(event, newDates);
           break;
-        case "range":
+        }
+        case "range": {
           let base = selectedDate;
           if (isRangeOrOffsetSelectionValue(base)) {
             if (base?.startDate && base?.endDate) {
@@ -161,13 +162,15 @@ export function useSelectionCalendar(props: useSelectionCalendarProps) {
           setSelectedDateState(base);
           props.onSelectedDateChange?.(event, base);
           break;
-        case "offset":
+        }
+        case "offset": {
           const newRange = {
             startDate: getStartDateOffset(newSelectedDate),
             endDate: getEndDateOffset(newSelectedDate),
           };
           setSelectedDateState(newRange);
           props.onSelectedDateChange?.(event, newRange);
+        }
       }
     }
   };
@@ -368,7 +371,7 @@ export function useSelectionDay({ date }: { date: DateValue }) {
         selected || selectedEnd || selectedStart || selectedSpan
           ? "true"
           : undefined,
-      "aria-disabled": !!isDayUnselectable(date) ? "true" : undefined,
+      "aria-disabled": isDayUnselectable(date) ? "true" : undefined,
     },
   };
 }

--- a/vuu-ui/packages/vuu-ui-controls/src/calendar/useSelection.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/calendar/useSelection.ts
@@ -1,0 +1,374 @@
+import { makePrefixer, useControlled } from "@salt-ds/core";
+import { clsx } from "clsx";
+import { KeyboardEventHandler, MouseEventHandler, SyntheticEvent } from "react";
+import { isPlainObject } from "../utils";
+import { useCalendarContext } from "./internal/CalendarContext";
+import { CalendarDate, DateValue, isSameDay } from "@internationalized/date";
+
+interface BaseUseSelectionCalendarProps<SelectionVariantType> {
+  hoveredDate?: DateValue | null;
+  selectedDate?: SelectionVariantType | null;
+  defaultSelectedDate?: SelectionVariantType;
+  onSelectedDateChange?: (
+    event: SyntheticEvent,
+    selectedDate: SelectionVariantType
+  ) => void;
+  isDaySelectable: (date?: DateValue) => boolean;
+  onHoveredDateChange?: (
+    event: SyntheticEvent,
+    hoveredDate: DateValue | null
+  ) => void;
+}
+
+type SingleSelectionValueType = DateValue;
+type MultiSelectionValueType = DateValue[];
+type RangeSelectionValueType = {
+  startDate?: DateValue;
+  endDate?: DateValue;
+};
+type OffsetSelectionValueType = {
+  startDate?: DateValue;
+  endDate?: DateValue;
+};
+
+type AllSelectionValueType =
+  | SingleSelectionValueType
+  | MultiSelectionValueType
+  | RangeSelectionValueType
+  | OffsetSelectionValueType
+  | null;
+
+export interface UseOffsetSelectionCalendarProps
+  extends Omit<
+    BaseUseSelectionCalendarProps<OffsetSelectionValueType>,
+    "startDateOffset" | "endDateOffset"
+  > {
+  selectionVariant: "offset";
+  startDateOffset?: (date: DateValue) => DateValue;
+  endDateOffset?: (date: DateValue) => DateValue;
+}
+
+export interface UseRangeSelectionCalendarProps
+  extends BaseUseSelectionCalendarProps<RangeSelectionValueType> {
+  selectionVariant: "range";
+}
+
+export interface UseMultiSelectionCalendarProps
+  extends BaseUseSelectionCalendarProps<MultiSelectionValueType> {
+  selectionVariant: "multiselect";
+}
+
+export interface UseSingleSelectionCalendarProps
+  extends BaseUseSelectionCalendarProps<SingleSelectionValueType> {
+  selectionVariant: "default";
+}
+
+export type useSelectionCalendarProps =
+  | UseSingleSelectionCalendarProps
+  | UseMultiSelectionCalendarProps
+  | UseRangeSelectionCalendarProps
+  | UseOffsetSelectionCalendarProps;
+
+function addOrRemoveFromArray(
+  array: AllSelectionValueType | null = [],
+  item: DateValue
+) {
+  if (Array.isArray(array)) {
+    if (array.find((element) => isSameDay(element, item))) {
+      return array.filter((element) => !isSameDay(element, item));
+    }
+    return array.concat(item);
+  }
+  return [item];
+}
+
+const defaultOffset = (date: DateValue) => date;
+
+function isRangeOrOffsetSelectionValue(
+  selectionValue?: AllSelectionValueType
+): selectionValue is RangeSelectionValueType | OffsetSelectionValueType {
+  return selectionValue != null && isPlainObject(selectionValue);
+}
+
+const withBaseName = makePrefixer("saltCalendarDay");
+
+export function useSelectionCalendar(props: useSelectionCalendarProps) {
+  const {
+    hoveredDate: hoveredDateProp,
+    selectedDate: selectedDateProp,
+    defaultSelectedDate,
+    // onSelectedDateChange,
+    onHoveredDateChange,
+    isDaySelectable,
+    selectionVariant,
+    // startDateOffset,
+    // endDateOffset,
+  } = props;
+  const [selectedDate, setSelectedDateState] = useControlled({
+    controlled: selectedDateProp,
+    default: defaultSelectedDate,
+    name: "Calendar",
+    state: "selectedDate",
+  });
+
+  const getStartDateOffset = (date: DateValue) => {
+    if (props.selectionVariant === "offset" && props.startDateOffset) {
+      return props.startDateOffset(date);
+    } else {
+      return defaultOffset(date);
+    }
+  };
+
+  const getEndDateOffset = (date: DateValue) => {
+    if (props.selectionVariant === "offset" && props.endDateOffset) {
+      return props.endDateOffset(date);
+    } else {
+      return defaultOffset(date);
+    }
+  };
+
+  const setSelectedDate = (
+    event: SyntheticEvent<HTMLButtonElement>,
+    newSelectedDate: DateValue
+  ) => {
+    if (isDaySelectable(newSelectedDate)) {
+      switch (props.selectionVariant) {
+        case "default":
+          setSelectedDateState(newSelectedDate);
+          props.onSelectedDateChange?.(event, newSelectedDate);
+          break;
+        case "multiselect":
+          const newDates = addOrRemoveFromArray(selectedDate, newSelectedDate);
+          setSelectedDateState(newDates);
+          props.onSelectedDateChange?.(event, newDates);
+          break;
+        case "range":
+          let base = selectedDate;
+          if (isRangeOrOffsetSelectionValue(base)) {
+            if (base?.startDate && base?.endDate) {
+              base = { startDate: newSelectedDate };
+            } else if (
+              base?.startDate &&
+              newSelectedDate.compare(base.startDate) > 0
+            ) {
+              base = { ...base, endDate: newSelectedDate };
+            } else {
+              base = { startDate: newSelectedDate };
+            }
+          } else {
+            base = { startDate: newSelectedDate };
+          }
+          setSelectedDateState(base);
+          props.onSelectedDateChange?.(event, base);
+          break;
+        case "offset":
+          const newRange = {
+            startDate: getStartDateOffset(newSelectedDate),
+            endDate: getEndDateOffset(newSelectedDate),
+          };
+          setSelectedDateState(newRange);
+          props.onSelectedDateChange?.(event, newRange);
+      }
+    }
+  };
+
+  const isSelected = (date: DateValue) => {
+    switch (selectionVariant) {
+      case "default":
+        return (
+          selectedDate instanceof CalendarDate && isSameDay(selectedDate, date)
+        );
+      case "multiselect":
+        return (
+          Array.isArray(selectedDate) &&
+          !!selectedDate.find((element) => isSameDay(element, date))
+        );
+      default:
+        return false;
+    }
+  };
+
+  const [hoveredDate, setHoveredDateState] = useControlled({
+    controlled: hoveredDateProp,
+    default: undefined,
+    name: "Calendar",
+    state: "hoveredDate",
+  });
+
+  const setHoveredDate = (event: SyntheticEvent, date: DateValue | null) => {
+    setHoveredDateState(date);
+    onHoveredDateChange?.(event, date);
+  };
+
+  const isHovered = (date: DateValue) => {
+    return !!hoveredDate && isSameDay(date, hoveredDate);
+  };
+
+  const isSelectedSpan = (date: DateValue) => {
+    if (
+      (selectionVariant === "range" || selectionVariant === "offset") &&
+      isRangeOrOffsetSelectionValue(selectedDate) &&
+      selectedDate?.startDate &&
+      selectedDate?.endDate
+    ) {
+      return (
+        date.compare(selectedDate.startDate) > 0 &&
+        date.compare(selectedDate.endDate) < 0
+      );
+    }
+    return false;
+  };
+  const isHoveredSpan = (date: DateValue) => {
+    if (
+      (selectionVariant === "range" || selectionVariant === "offset") &&
+      isRangeOrOffsetSelectionValue(selectedDate) &&
+      selectedDate.startDate &&
+      !selectedDate.endDate &&
+      hoveredDate
+    ) {
+      const isForwardRange =
+        hoveredDate.compare(selectedDate.startDate) > 0 &&
+        ((date.compare(selectedDate.startDate) > 0 &&
+          date.compare(hoveredDate) < 0) ||
+          isSameDay(date, hoveredDate));
+
+      const isValidDayHovered = isDaySelectable(hoveredDate);
+
+      return isForwardRange && isValidDayHovered;
+    }
+    return false;
+  };
+
+  const isSelectedStart = (date: DateValue) => {
+    if (
+      (selectionVariant === "range" || selectionVariant === "offset") &&
+      isRangeOrOffsetSelectionValue(selectedDate) &&
+      selectedDate.startDate
+    ) {
+      return isSameDay(selectedDate.startDate, date);
+    }
+    return false;
+  };
+
+  const isSelectedEnd = (date: DateValue) => {
+    if (
+      (selectionVariant === "range" || selectionVariant === "offset") &&
+      isRangeOrOffsetSelectionValue(selectedDate) &&
+      selectedDate.endDate
+    ) {
+      return isSameDay(selectedDate.endDate, date);
+    }
+    return false;
+  };
+
+  const isHoveredOffset = (date: DateValue) => {
+    if (hoveredDate && selectionVariant === "offset") {
+      const startDate = getStartDateOffset(hoveredDate);
+      const endDate = getEndDateOffset(hoveredDate);
+
+      return (
+        date.compare(startDate) >= 0 &&
+        date.compare(endDate) <= 0 &&
+        isDaySelectable(date)
+      );
+    }
+
+    return false;
+  };
+
+  return {
+    state: {
+      selectedDate,
+      hoveredDate,
+    },
+    helpers: {
+      setSelectedDate,
+      isSelected,
+      setHoveredDate,
+      isHovered,
+      isSelectedSpan,
+      isHoveredSpan,
+      isSelectedStart,
+      isSelectedEnd,
+      isHoveredOffset,
+    },
+  };
+}
+
+export function useSelectionDay({ date }: { date: DateValue }) {
+  const {
+    helpers: {
+      setSelectedDate,
+      isSelected,
+      setHoveredDate,
+      isSelectedSpan,
+      isHoveredSpan,
+      isSelectedStart,
+      isSelectedEnd,
+      isHovered,
+      isHoveredOffset,
+      isDayUnselectable,
+    },
+  } = useCalendarContext();
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    setSelectedDate(event, date);
+  };
+
+  const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = (event) => {
+    switch (event.key) {
+      case "Space":
+      case "Enter":
+        setSelectedDate(event, date);
+        event.preventDefault();
+    }
+  };
+
+  const handleMouseOver: MouseEventHandler<HTMLButtonElement> = (event) => {
+    setHoveredDate(event, date);
+  };
+
+  const handleMouseLeave: MouseEventHandler<HTMLButtonElement> = (event) => {
+    setHoveredDate(event, null);
+  };
+
+  const selected = isSelected(date);
+  const selectedSpan = isSelectedSpan(date);
+  const hoveredSpan = isHoveredSpan(date);
+  const selectedStart = isSelectedStart(date);
+  const selectedEnd = isSelectedEnd(date);
+  const hovered = isHovered(date);
+  const hoveredOffset = isHoveredOffset(date);
+
+  return {
+    handleClick,
+    handleKeyDown,
+    handleMouseOver,
+    handleMouseLeave,
+    status: {
+      selected,
+      selectedSpan,
+      hoveredSpan,
+      selectedStart,
+      selectedEnd,
+      hovered,
+      hoveredOffset,
+    },
+    dayProps: {
+      className: clsx({
+        [withBaseName("selected")]: selected,
+        [withBaseName("selectedSpan")]: selectedSpan,
+        [withBaseName("hoveredSpan")]: hoveredSpan,
+        [withBaseName("selectedStart")]: selectedStart,
+        [withBaseName("selectedEnd")]: selectedEnd,
+        [withBaseName("hovered")]: hovered,
+        [withBaseName("hoveredOffset")]: hoveredOffset,
+      }),
+      "aria-pressed":
+        selected || selectedEnd || selectedStart || selectedSpan
+          ? "true"
+          : undefined,
+      "aria-disabled": !!isDayUnselectable(date) ? "true" : undefined,
+    },
+  };
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/common-hooks/isPlainObject.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/common-hooks/isPlainObject.ts
@@ -1,0 +1,2 @@
+export const isPlainObject = (obj: unknown) =>
+  Object.prototype.toString.call(obj) === "[object Object]";

--- a/vuu-ui/packages/vuu-ui-controls/src/common-hooks/itemToString.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/common-hooks/itemToString.ts
@@ -1,8 +1,7 @@
+import { isPlainObject } from "./isPlainObject";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ItemToStringFunction = (item: any) => string;
-
-const isPlainObject = (obj: unknown) =>
-  Object.prototype.toString.call(obj) === "[object Object]";
 
 export function itemToString(item: unknown): string {
   if (typeof item === "string") {

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/DatePicker.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/DatePicker.css
@@ -1,0 +1,11 @@
+.vuuDatePicker {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 1px;
+  padding: 0 2px;
+}
+
+.vuuDatePicker-calendar {
+  padding: 2px;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/DatePicker.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/DatePicker.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useMemo } from "react";
+import { DateValue, today, getLocalTimeZone } from "@internationalized/date";
+import { clsx } from "clsx";
+import { Calendar } from "../calendar/Calendar";
+import { DatePickerInput } from "./input/DatePickerInput";
+import { CalendarIconButton } from "./internal/CalendarIconButton";
+import { DropdownBase } from "../dropdown";
+import { useBaseDatePicker } from "./useBaseDatePicker";
+import { useBaseDatePickerDropdown } from "./useBaseDatePickerDropdown";
+import { BaseDatePickerDropdownProps, BaseDatePickerProps } from "./types";
+
+import "./DatePicker.css";
+
+const baseClass = "vuuDatePicker";
+
+export const DatePicker = (props: BaseDatePickerProps<DateValue>) => {
+  const { selectedDate, onSelectedDateChange, onBlur, className } = props;
+  const { visibleMonth, handleVisibleMonthChange, handleOnBlur } =
+    useBaseDatePicker({ variant: "default", selectedDate, onBlur });
+
+  const handleInputChange = useCallback(
+    (d: DateValue) => {
+      onSelectedDateChange(d);
+      handleVisibleMonthChange(d);
+    },
+    [onSelectedDateChange]
+  );
+
+  return (
+    <div
+      className={clsx("saltInput saltInput-primary", baseClass, className)}
+      onBlur={handleOnBlur}
+    >
+      <DatePickerInput value={selectedDate} onChange={handleInputChange} />
+      <DatePickerDropdown
+        visibleMonth={visibleMonth}
+        onVisibleMonthChange={handleVisibleMonthChange}
+        {...props}
+      />
+    </div>
+  );
+};
+
+const DatePickerDropdown = (props: BaseDatePickerDropdownProps<DateValue>) => {
+  const {
+    closeOnSelection,
+    onSelectedDateChange,
+    onVisibleMonthChange,
+    className,
+    ...rest
+  } = props;
+
+  const shouldCloseOnSelectionChange = useCallback(
+    () => !!closeOnSelection,
+    [closeOnSelection]
+  );
+
+  const {
+    triggererRef,
+    isOpen,
+    handleOpenChange,
+    handleVisibleMonthChange,
+    handleDateSelection,
+  } = useBaseDatePickerDropdown({
+    onVisibleMonthChange,
+    onSelectedDateChange,
+    shouldCloseOnSelectionChange,
+  });
+
+  const defaultSelectedDate = useMemo(() => today(getLocalTimeZone()), []);
+
+  return (
+    <DropdownBase
+      placement="below"
+      isOpen={isOpen}
+      onOpenChange={handleOpenChange}
+      className={className}
+    >
+      <CalendarIconButton ref={triggererRef} />
+      <Calendar
+        selectionVariant="default"
+        onVisibleMonthChange={handleVisibleMonthChange}
+        onSelectedDateChange={handleDateSelection}
+        defaultSelectedDate={defaultSelectedDate}
+        className={`${baseClass}-calendar`}
+        {...rest}
+      />
+    </DropdownBase>
+  );
+};

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/DateRangePicker.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/DateRangePicker.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useMemo } from "react";
+import { Calendar } from "../calendar/Calendar";
+import { today, getLocalTimeZone } from "@internationalized/date";
+import { clsx } from "clsx";
+import { DateRangePickerInput } from "./input/DateRangePickerInput";
+import { BaseDatePickerDropdownProps, BaseDatePickerProps } from "./types";
+import { RangeSelectionValueType } from "../calendar";
+import { CalendarIconButton } from "./internal/CalendarIconButton";
+import { DropdownBase } from "../dropdown";
+import { useBaseDatePicker } from "./useBaseDatePicker";
+import { useBaseDatePickerDropdown } from "./useBaseDatePickerDropdown";
+
+import "./DatePicker.css";
+
+const baseClass = "vuuDatePicker";
+
+export const DateRangePicker = (
+  props: BaseDatePickerProps<RangeSelectionValueType>
+) => {
+  const { selectedDate, onSelectedDateChange, className, onBlur } = props;
+  const { visibleMonth, handleVisibleMonthChange, handleOnBlur } =
+    useBaseDatePicker({ variant: "range", selectedDate, onBlur });
+
+  const handleInputChange = useCallback(
+    (r: RangeSelectionValueType) => {
+      onSelectedDateChange(r);
+      handleVisibleMonthChange(r.endDate ?? r.startDate);
+    },
+    [onSelectedDateChange]
+  );
+
+  return (
+    <div
+      className={clsx("saltInput saltInput-primary", baseClass, className)}
+      onBlur={handleOnBlur}
+    >
+      <DateRangePickerInput value={selectedDate} onChange={handleInputChange} />
+      <DateRangePickerDropdown
+        {...props}
+        visibleMonth={visibleMonth}
+        onVisibleMonthChange={handleVisibleMonthChange}
+      />
+    </div>
+  );
+};
+
+const DateRangePickerDropdown = (
+  props: BaseDatePickerDropdownProps<RangeSelectionValueType>
+) => {
+  const {
+    onVisibleMonthChange,
+    onSelectedDateChange,
+    closeOnSelection,
+    className,
+    ...rest
+  } = props;
+
+  const shouldCloseOnSelectionChange = useCallback(
+    (r: RangeSelectionValueType) => !!(closeOnSelection && r.endDate),
+    [closeOnSelection]
+  );
+
+  const {
+    triggererRef,
+    isOpen,
+    handleOpenChange,
+    handleVisibleMonthChange,
+    handleDateSelection,
+  } = useBaseDatePickerDropdown({
+    onVisibleMonthChange,
+    onSelectedDateChange,
+    shouldCloseOnSelectionChange,
+  });
+
+  const defaultSelectedDate = useMemo(
+    () => ({ startDate: today(getLocalTimeZone()) }),
+    []
+  );
+
+  return (
+    <DropdownBase
+      placement="below"
+      isOpen={isOpen}
+      className={className}
+      onOpenChange={handleOpenChange}
+    >
+      <CalendarIconButton ref={triggererRef} />
+      <Calendar
+        selectionVariant="range"
+        onVisibleMonthChange={handleVisibleMonthChange}
+        onSelectedDateChange={handleDateSelection}
+        defaultSelectedDate={defaultSelectedDate}
+        className={`${baseClass}-calendar`}
+        {...rest}
+      />
+    </DropdownBase>
+  );
+};

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/index.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/index.ts
@@ -1,0 +1,2 @@
+export * from "./DatePicker";
+export * from "./DateRangePicker";

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/DatePickerInput.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/DatePickerInput.css
@@ -1,0 +1,13 @@
+.vuuDatePickerInput {
+  border: none;
+  width: 100%;
+  padding-left: 0;
+}
+
+.vuuDatePickerInput:focus {
+  outline: none;
+}
+
+input[type="date"]::-webkit-calendar-picker-indicator {
+  display: none;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/DatePickerInput.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/DatePickerInput.tsx
@@ -1,0 +1,38 @@
+import React, { useCallback } from "react";
+import { DateValue, CalendarDate } from "@internationalized/date";
+import { clsx } from "clsx";
+import { BasePickerInputProps } from "./types";
+
+import "./DatePickerInput.css";
+
+const baseClass = "vuuDatePickerInput";
+
+type Props = BasePickerInputProps<DateValue>;
+
+export const DatePickerInput: React.FC<Props> = (props) => {
+  const { value, onChange, className } = props;
+
+  const onInputChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+    (e) => {
+      const v = e.target.value;
+      if (v === "") return;
+      else onChange(toCalendarDate(new Date(v)));
+    },
+    [onChange]
+  );
+
+  return (
+    <input
+      className={clsx("saltInput-input", baseClass, className)}
+      type="date"
+      value={value?.toString() ?? ""}
+      onChange={onInputChange}
+      aria-label="date-input"
+      max="9999-12-31" // without this it shows expty space on the right
+    />
+  );
+};
+
+function toCalendarDate(d: Date): CalendarDate {
+  return new CalendarDate(d.getFullYear(), d.getMonth() + 1, d.getDate());
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/DateRangePickerInput.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/DateRangePickerInput.css
@@ -1,0 +1,16 @@
+.vuuDateRangePickerInput {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5em;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.vuuDateRangePickerInput input:last-child {
+  text-align: right;
+}
+
+.vuuDateRangePickerInput span {
+  width: fit-content;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/DateRangePickerInput.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/DateRangePickerInput.tsx
@@ -1,0 +1,37 @@
+import { useCallback } from "react";
+import { DateValue } from "@internationalized/date";
+import { clsx } from "clsx";
+import { DatePickerInput } from "./DatePickerInput";
+import { BasePickerInputProps } from "./types";
+import { RangeSelectionValueType } from "../../calendar";
+
+import "./DateRangePickerInput.css";
+
+const baseClass = "vuuDateRangePickerInput";
+
+type Props = BasePickerInputProps<RangeSelectionValueType>;
+
+export const DateRangePickerInput: React.FC<Props> = (props) => {
+  const { value, onChange, className } = props;
+
+  const getHandleInputChange = useCallback(
+    (k: keyof RangeSelectionValueType) => (d: DateValue) => {
+      onChange({ ...value, [k]: d });
+    },
+    [value, onChange]
+  );
+
+  return (
+    <div className={clsx(baseClass, className)}>
+      <DatePickerInput
+        value={value?.["startDate"]}
+        onChange={getHandleInputChange("startDate")}
+      />
+      <span>—</span>
+      <DatePickerInput
+        value={value?.["endDate"]}
+        onChange={getHandleInputChange("endDate")}
+      />
+    </div>
+  );
+};

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/types.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/input/types.ts
@@ -1,0 +1,7 @@
+import { PickerSelectionType } from "../types";
+
+export interface BasePickerInputProps<T extends PickerSelectionType> {
+  onChange: (selected: T) => void;
+  value?: T;
+  className?: string;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/internal/CalendarIconButton.css
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/internal/CalendarIconButton.css
@@ -1,0 +1,8 @@
+.vuuDatePicker-calendarIconButton {
+  padding: 3px;
+}
+
+.vuuDatePicker-calendarIconButton .saltIcon {
+  display: inline-block;
+  margin: 0;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/internal/CalendarIconButton.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/internal/CalendarIconButton.tsx
@@ -1,0 +1,25 @@
+import { Button } from "@salt-ds/core";
+import { CalendarIcon } from "@salt-ds/icons";
+import { ComponentPropsWithoutRef, ForwardedRef, forwardRef } from "react";
+import clsx from "clsx";
+
+import "./CalendarIconButton.css";
+
+const baseClass = "vuuDatePicker-calendarIconButton";
+
+export const CalendarIconButton = forwardRef(function CalendarIconButton(
+  { className, ...rest }: ComponentPropsWithoutRef<typeof Button>,
+  ref: ForwardedRef<HTMLButtonElement>
+) {
+  return (
+    <Button
+      className={clsx(baseClass, className)}
+      variant={"secondary"}
+      aria-label="calendar-icon-button"
+      ref={ref}
+      {...rest}
+    >
+      <CalendarIcon />
+    </Button>
+  );
+});

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/types.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/types.ts
@@ -1,0 +1,25 @@
+import {
+  CalendarDate,
+  CalendarDateTime,
+  DateValue,
+  ZonedDateTime,
+} from "@internationalized/date";
+import { CalendarProps } from "../calendar/Calendar";
+import { RangeSelectionValueType } from "../calendar";
+
+export type PickerSelectionType = DateValue | RangeSelectionValueType;
+
+export interface BaseDatePickerProps<T = PickerSelectionType>
+  extends Pick<CalendarProps, "hideOutOfRangeDates" | "hideYearDropdown"> {
+  onSelectedDateChange: (selected: T) => void;
+  selectedDate: T | undefined;
+  closeOnSelection?: boolean;
+  onBlur?: () => void;
+  className?: string;
+}
+
+export interface BaseDatePickerDropdownProps<T = PickerSelectionType>
+  extends BaseDatePickerProps<T> {
+  visibleMonth: DateValue | undefined;
+  onVisibleMonthChange: (d: DateValue) => void;
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/useBaseDatePicker.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/useBaseDatePicker.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from "react";
+import { BaseDatePickerProps } from "./types";
+import { DateValue } from "@internationalized/date";
+import { PickerSelectionType } from "./types";
+import { RangeSelectionValueType } from "../calendar";
+
+type InheritedProps<T extends PickerSelectionType> = Pick<
+  BaseDatePickerProps<T>,
+  "onBlur" | "selectedDate"
+>;
+type Props =
+  | ({ variant: "range" } & InheritedProps<RangeSelectionValueType>)
+  | ({ variant: "default" } & InheritedProps<DateValue>);
+
+export function useBaseDatePicker(props: Props) {
+  const [visibleMonth, setVisibleMonth] = useState<DateValue | undefined>(
+    props.variant === "default"
+      ? props.selectedDate
+      : props.selectedDate?.startDate
+  );
+
+  const handleOnBlur: React.FocusEventHandler<HTMLDivElement> = useCallback(
+    (e) => {
+      if (!e.currentTarget.contains(e.relatedTarget)) {
+        props.onBlur?.();
+      }
+    },
+    [props.onBlur]
+  );
+
+  return {
+    handleOnBlur,
+    visibleMonth,
+    handleVisibleMonthChange: setVisibleMonth,
+  };
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/useBaseDatePickerDropdown.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/useBaseDatePickerDropdown.ts
@@ -1,0 +1,45 @@
+import { useCallback, useRef, useState } from "react";
+import { DateValue } from "@internationalized/date";
+import { PickerSelectionType } from "./types";
+import { BaseDatePickerDropdownProps } from "./types";
+
+type Props<T extends PickerSelectionType> = Pick<
+  BaseDatePickerDropdownProps<T>,
+  "onSelectedDateChange" | "onVisibleMonthChange"
+> & {
+  shouldCloseOnSelectionChange: (v: T) => boolean;
+};
+
+export function useBaseDatePickerDropdown<T extends PickerSelectionType>({
+  onVisibleMonthChange,
+  onSelectedDateChange,
+  shouldCloseOnSelectionChange,
+}: Props<T>) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const triggererRef = useRef<HTMLButtonElement>(null);
+
+  const handleDateSelection = useCallback(
+    (_: React.SyntheticEvent, d: T) => {
+      onSelectedDateChange(d);
+      if (shouldCloseOnSelectionChange(d)) setIsOpen(false);
+      triggererRef.current?.focus();
+    },
+    [onSelectedDateChange, shouldCloseOnSelectionChange]
+  );
+
+  const handleVisibleMonthChange = useCallback(
+    (_: React.SyntheticEvent, d: DateValue) => {
+      onVisibleMonthChange(d);
+      triggererRef.current?.focus();
+    },
+    [onVisibleMonthChange]
+  );
+
+  return {
+    isOpen,
+    handleOpenChange: setIsOpen,
+    triggererRef,
+    handleVisibleMonthChange,
+    handleDateSelection,
+  };
+}

--- a/vuu-ui/packages/vuu-ui-controls/src/index.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/index.ts
@@ -2,6 +2,7 @@ export * from "./calendar";
 export * from "./combo-box";
 export * from "./common-hooks";
 export * from "./cycle-state-button";
+export * from "./date-picker";
 export * from "./drag-drop";
 export * from "./dropdown";
 export * from "./editable";

--- a/vuu-ui/packages/vuu-ui-controls/src/index.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./calendar";
 export * from "./combo-box";
 export * from "./common-hooks";
 export * from "./cycle-state-button";

--- a/vuu-ui/showcase/package.json
+++ b/vuu-ui/showcase/package.json
@@ -25,6 +25,7 @@
     "@finos/vuu-utils": "0.0.26",
     "@salt-ds/core": "1.13.2",
     "@salt-ds/theme": "1.7.1",
+    "@internationalized/date": "^3.0.0",
     "clsx": "^2.0.0",
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2",

--- a/vuu-ui/showcase/src/examples/UiControls/Calendar.examples.tsx
+++ b/vuu-ui/showcase/src/examples/UiControls/Calendar.examples.tsx
@@ -1,0 +1,30 @@
+import { Calendar } from "@finos/vuu-ui-controls";
+import { CalendarDate, DateValue } from "@internationalized/date";
+import { useState } from "react";
+
+let displaySequence = 1;
+
+export const DefaultCalendar = () => {
+  const [date, setDate] = useState<DateValue>(new CalendarDate(2024, 1, 1));
+  const hoveredDate = new CalendarDate(2024, 1, 11);
+
+  const isDayUnselectable = (d: DateValue) => {
+    return d.compare(new CalendarDate(2024, 1, 11)) === 0;
+  };
+
+  return (
+    <div style={{ padding: "1em" }}>
+      <Calendar
+        selectionVariant="default"
+        selectedDate={date}
+        onSelectedDateChange={(_, d) => setDate(d)}
+        hoveredDate={hoveredDate}
+        onHoveredDateChange={(_, d) => console.log({ d })}
+        isDayUnselectable={isDayUnselectable}
+        hideOutOfRangeDates={true}
+      />
+    </div>
+  );
+};
+
+DefaultCalendar.displaySequence = displaySequence++;

--- a/vuu-ui/showcase/src/examples/UiControls/DatePicker.examples.tsx
+++ b/vuu-ui/showcase/src/examples/UiControls/DatePicker.examples.tsx
@@ -1,0 +1,45 @@
+import { DatePicker, DateRangePicker } from "@finos/vuu-ui-controls";
+import { CalendarDate, DateValue } from "@internationalized/date";
+import { useState } from "react";
+
+let displaySequence = 1;
+
+export const DefaultDatePicker = () => {
+  const [date, setDate] = useState<DateValue>(new CalendarDate(2024, 1, 1));
+
+  const onBlur = () => console.log("onBlur");
+
+  return (
+    <div style={{ width: 250 }}>
+      <DatePicker
+        onBlur={onBlur}
+        selectedDate={date}
+        onSelectedDateChange={setDate}
+        hideOutOfRangeDates
+        closeOnSelection
+      />
+    </div>
+  );
+};
+DefaultDatePicker.displaySequence = displaySequence++;
+
+export const DefaultDateRangePicker = () => {
+  const [date, setDate] = useState<{
+    startDate?: DateValue;
+    endDate?: DateValue;
+  }>({
+    startDate: new CalendarDate(2024, 1, 1),
+  });
+
+  return (
+    <div style={{ width: 250 }}>
+      <DateRangePicker
+        selectedDate={date}
+        onSelectedDateChange={setDate}
+        hideOutOfRangeDates
+        closeOnSelection
+      />
+    </div>
+  );
+};
+DefaultDateRangePicker.displaySequence = displaySequence++;

--- a/vuu-ui/showcase/src/examples/UiControls/index.ts
+++ b/vuu-ui/showcase/src/examples/UiControls/index.ts
@@ -1,3 +1,4 @@
+export * as Calendar from "./Calendar.examples";
 export * as ComboBox from "./Combobox.examples";
 export * as DragDrop from "./DragDrop.examples";
 export * as Dropdown from "./Dropdown.examples";

--- a/vuu-ui/showcase/src/examples/UiControls/index.ts
+++ b/vuu-ui/showcase/src/examples/UiControls/index.ts
@@ -1,5 +1,6 @@
 export * as Calendar from "./Calendar.examples";
 export * as ComboBox from "./Combobox.examples";
+export * as DatePicker from "./DatePicker.examples";
 export * as DragDrop from "./DragDrop.examples";
 export * as Dropdown from "./Dropdown.examples";
 export * as EditableLabel from "./EditableLabel.examples";


### PR DESCRIPTION
Summary of changes:
- fork /calendar dir from salt-ds to vuu-ui-controls
- make forked calendar component work with vuu
  - fixes imports that were no longer valid
  - adds missing `salt-ds/icons` package to vuu-ui-controls
  - fixes linting errors
  - fixes an alignment issue with the calendar
  - fixes issues with css module imports -> I've reverted to importing css directly and relying on classes for the styles to take effect. Same as what we do elsewhere in VUU.
- add DatePicker and DateRangePicker components