### PR TITLE
VUU-333: Customise scrollbar styling for 'My Layouts' list

### DIFF
--- a/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.css
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.css
@@ -5,6 +5,28 @@
     flex-direction: column;
     height: 100%;
     overflow: hidden;
+    padding-right: 6px;
+
+    /* Works on Firefox */
+    scrollbar-width: thin;
+    scrollbar-color: #D9D9D9 transparent;
+
+    /* compatible with Chrome, Edge, and Safari */
+    ::-webkit-scrollbar {
+        width: 4px;
+        height: 4px;
+    }
+
+    ::-webkit-scrollbar-track {
+        background: transparent;
+        margin-top: 15px;
+        margin-bottom: 15px;
+    }
+
+    ::-webkit-scrollbar-thumb {
+        border-radius: 4px;
+        background: #D9D9D9;
+    }
 }
 
 .vuuLayoutList-header {
@@ -14,7 +36,7 @@
     letter-spacing: 0.48px;
     text-transform: uppercase;
     display: flex;
-    padding: 16px 0px;
+    padding: 16px 0;
     border-bottom: 1px solid rgba(119, 124, 148, 0.10);
     line-height: 200%;
 }
@@ -23,16 +45,23 @@
     display: flex;
     padding-top: 24px;
     color: var(--light-text-secondary, #606477);
+    font-feature-settings: 'ss02' on, 'ss01' on, 'salt' on, 'liga' off;
+    font-family: Nunito Sans;
+    font-size: 12px;
+    font-style: normal;
     font-weight: 700;
+    line-height: 24px; /* 200% */
     letter-spacing: 0.48px;
-    line-height: 200%;
+    text-transform: uppercase;
 }
 
 .vuuLayoutList-layoutContainer {
     display: flex;
     align-items: center;
+    width: 90%;
+    height: auto;
     gap: 8px;
-    padding: 8px 0px;
+    padding: 8px 0;
     flex: 1 1 auto;
     cursor: pointer;
 }

--- a/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.css
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.css
@@ -49,7 +49,7 @@
     font-size: 12px;
     font-style: normal;
     font-weight: 700;
-    line-height: 24px; /* 200% */
+    line-height: 200%;
     letter-spacing: 0.48px;
     text-transform: uppercase;
 }

--- a/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.css
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.css
@@ -1,4 +1,5 @@
 .vuuLayoutList {
+    --vuuLayoutList-width: 90%;
     --vuuMeasuredContainer-flex: 1 1 1px;
     align-self: stretch;
     display: flex;
@@ -30,20 +31,22 @@
 }
 
 .vuuLayoutList-header {
-    color: var(--light-text-primary, #15171B);
-    flex: 0 0 47px;
-    font-weight: 700;
-    letter-spacing: 0.48px;
-    text-transform: uppercase;
     display: flex;
+    flex: 0 0 47px;
+    width: var(--vuuLayoutList-width);
     padding: 16px 0;
     border-bottom: 1px solid rgba(119, 124, 148, 0.10);
+    color: var(--light-text-primary, #15171B);
+    font-weight: 700;
+    letter-spacing: 0.48px;
     line-height: 200%;
+    text-transform: uppercase;
 }
 
 .vuuLayoutList-groupName {
     display: flex;
     padding-top: 24px;
+    width: var(--vuuLayoutList-width);
     color: var(--light-text-secondary, #606477);
     font-feature-settings: 'ss02' on, 'ss01' on, 'salt' on, 'liga' off;
     font-family: Nunito Sans;

--- a/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.css
+++ b/vuu-ui/packages/vuu-shell/src/layout-management/LayoutList.css
@@ -8,10 +8,6 @@
     overflow: hidden;
     padding-right: 6px;
 
-    /* Works on Firefox */
-    scrollbar-width: thin;
-    scrollbar-color: #D9D9D9 transparent;
-
     /* compatible with Chrome, Edge, and Safari */
     ::-webkit-scrollbar {
         width: 4px;

--- a/vuu-ui/packages/vuu-shell/src/left-nav/LeftNav.css
+++ b/vuu-ui/packages/vuu-shell/src/left-nav/LeftNav.css
@@ -16,7 +16,7 @@
 
     --menu-level-2-width: 0px;
 
-    box-shadow: 3px 4px 4px 0px rgba(0, 0, 0, 0.15);
+    box-shadow: 3px 4px 4px 0 rgba(0, 0, 0, 0.15);
     display: flex;
     height: calc(100% - 4px);
     margin-bottom: 4px;
@@ -165,12 +165,12 @@
 
 .vuuLeftNav-drawer {
     display: flex;
-    padding: 40px 32px 0px 24px;
+    padding: 0 0 0 24px;
     flex-direction: column;
     align-items: flex-start;
     flex-shrink: 0;
     align-self: stretch;
     background: #FFF;
-    box-shadow: 3px 4px 4px 0px rgba(0, 0, 0, 0.15);
+    box-shadow: 3px 4px 4px 0 rgba(0, 0, 0, 0.15);
     height: 100%
 }


### PR DESCRIPTION
### Background
Brings styling of the scrollbar in the 'My Layouts' tab in line with the Figma design.

**Figma**
![image](https://github.com/ScottLogic/finos-vuu/assets/99646608/040622c0-e334-4797-948d-78cf684f1380)

### Change List

  - Hide scrollbar track (webkit and firefox)
  - Give scrollbar thumb border radius (webkit)
  - Give scrollbar thumb the correct colour (webkit and firefox)
  - Shrink vertical scrollbar width (`4px` exact on webkit, `thin` on firefox)
  - Modify padding of the layout list's container (`.vuuLeftNav-drawer` ) to position vertical scrollbar at the very edge of the drawer

### Notes

- Can't get scrollbar hover to work with webkit
- Can't make Firefox look like webkit supported browsers (Chrome/Edge)

### Before / After

**Edge**

![image](https://github.com/ScottLogic/finos-vuu/assets/99646608/64ad17d1-e169-4512-8962-7bf4cab2e290)

![image](https://github.com/ScottLogic/finos-vuu/assets/99646608/f22a78e0-1cf8-4a8c-b136-80acd0d4ee74)

**Chrome**

![image](https://github.com/ScottLogic/finos-vuu/assets/99646608/8d86abb7-81bf-44e7-9c6b-cb144da47fa4)

![image](https://github.com/ScottLogic/finos-vuu/assets/99646608/9393b68a-2929-4061-9c86-ba7d853dbe7a)
