### PR TITLE
#1074 fix bugs in FilterBar

### DIFF
--- a/vuu-ui/packages/vuu-filters/src/filter-bar/useFilters.ts
+++ b/vuu-ui/packages/vuu-filters/src/filter-bar/useFilters.ts
@@ -167,12 +167,12 @@ export const useFilters = ({
   );
 
   const handleChangeFilter = useCallback(
-    (filter: Filter) => {
+    (oldFilter: Filter, newFilter: Filter) => {
       let index = -1;
       const newFilters = filters.map((f, i) => {
-        if (f === filter) {
+        if (f === oldFilter) {
           index = i;
-          return filter;
+          return newFilter;
         } else {
           return f;
         }

--- a/vuu-ui/packages/vuu-filters/src/filter-clause/TextInput.tsx
+++ b/vuu-ui/packages/vuu-filters/src/filter-clause/TextInput.tsx
@@ -58,24 +58,14 @@ export const TextInput = forwardRef(function TextInput(
   const getSuggestions = suggestionProvider();
 
   const handleSingleValueSelectionChange = useCallback<SingleSelectionHandler>(
-    (evt, value) => onInputComplete(value),
+    (_, value) => onInputComplete(value),
     [onInputComplete]
   );
 
   const handleMultiValueSelectionChange = useCallback<MultiSelectionHandler>(
-    (evt, value) => {
-      if (value.length === 1) {
-        onInputComplete(value[0]);
-      } else if (value.length > 1) {
-        onInputComplete(value);
-      }
-    },
+    (_, values) => onInputComplete(values),
     [onInputComplete]
   );
-
-  useEffect(() => {
-    // setValueInputValue("");
-  }, [column]);
 
   useEffect(() => {
     if (table) {
@@ -130,7 +120,6 @@ export const TextInput = forwardRef(function TextInput(
     }
     switch (operator) {
       case "in":
-        //TODO multiselect
         return (
           <ExpandoCombobox
             InputProps={InputProps}

--- a/vuu-ui/packages/vuu-ui-controls/src/date-picker/types.ts
+++ b/vuu-ui/packages/vuu-ui-controls/src/date-picker/types.ts
@@ -1,9 +1,4 @@
-import {
-  CalendarDate,
-  CalendarDateTime,
-  DateValue,
-  ZonedDateTime,
-} from "@internationalized/date";
+import { DateValue } from "@internationalized/date";
 import { CalendarProps } from "../calendar/Calendar";
 import { RangeSelectionValueType } from "../calendar";
 


### PR DESCRIPTION
- fixes a bug that crashes the app when a user tries editing an existing filter. Cause: we try finding the edited filter in `filters state` by reference but the reference has already been changed since `editFilter` is itself a state and hence the reference changes on every set.
- adds resetting the `editingFilter.current` to `undefined` after apply save. Otherwise, crashes the app when the user has already successfully edited an existing filter and tries to add a new one.
- lastly, also fixes an issue with `TextInput`'s multiselection handling, where it was wrongly sending a single value instead of an array of length 1. Crashes the app when the user selects only a single element in a multi value filter clause.