### PR TITLE
#1074 fix state updates issue in useFilterBar hook 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,7 @@
 /.idea/
 target/
 /gc.log
-/toolbox/toolbox.iml
-/example/**/*.iml
-/vuu-ui/vuu-ui.iml
-/vuu/vuu.iml
-/vuu-parent.iml
+/**/*.iml
 /vuu-book/src/.DS_Store
 .DS_Store
 

--- a/vuu-ui/packages/vuu-filters/src/filter-bar/useFilterState.ts
+++ b/vuu-ui/packages/vuu-filters/src/filter-bar/useFilterState.ts
@@ -1,0 +1,67 @@
+import { useCallback, useState } from "react";
+import { Filter } from "@finos/vuu-filter-types";
+import { useControlled } from "@finos/vuu-ui-controls";
+
+export interface FilterStateHookProps {
+  activeFilterIndex: number[];
+  applyFilter: (f?: Filter) => void;
+  defaultFilters?: Filter[];
+  filters?: Filter[];
+}
+
+export function useFilterState({
+  activeFilterIndex: activeFilterIdexProp,
+  applyFilter,
+  defaultFilters,
+  filters: filtersProp,
+}: FilterStateHookProps) {
+  const [filters, setFilters] = useControlled<Filter[]>({
+    controlled: filtersProp,
+    default: defaultFilters ?? [],
+    name: "useFilters",
+    state: "Filters",
+  });
+
+  const [activeIndices, setActiveIndices] =
+    useState<number[]>(activeFilterIdexProp);
+
+  const onApplyFilter = useCallback(
+    ({ activeIndices, filters }: FilterState) => {
+      if (activeIndices.length > 0) {
+        const activeFilters = activeIndices.map((i) => filters[i]);
+        if (activeFilters.length === 1) {
+          const [filter] = activeFilters;
+          applyFilter(filter);
+        } else {
+          applyFilter({ op: "and", filters: activeFilters });
+        }
+      } else {
+        applyFilter();
+      }
+    },
+    [applyFilter]
+  );
+
+  const onFilterStateChange = useCallback(
+    ({ filters, activeIndices }: FilterState) => {
+      setFilters(filters);
+      setActiveIndices(activeIndices);
+      onApplyFilter({ filters, activeIndices });
+    },
+    [onApplyFilter]
+  );
+
+  const handleActiveIndicesChange = useCallback(
+    (indices: number[]) =>
+      onFilterStateChange({ filters, activeIndices: indices }),
+    [filters, onFilterStateChange]
+  );
+
+  return {
+    filterState: { activeIndices, filters },
+    onActiveIndicesChange: handleActiveIndicesChange,
+    onFilterStateChange,
+  };
+}
+
+type FilterState = { filters: Filter[]; activeIndices: number[] };

--- a/vuu-ui/packages/vuu-filters/src/filter-utils.ts
+++ b/vuu-ui/packages/vuu-filters/src/filter-utils.ts
@@ -86,7 +86,6 @@ export const addClause = (
   clause: Partial<Filter>,
   { combineWith = AND }: AddFilterOptions = DEFAULT_ADD_FILTER_OPTS
 ): FilterWithPartialClause => {
-  console.log({ existingFilter, clause });
   if (
     isMultiClauseFilter(existingFilter) &&
     existingFilter.op === combineWith


### PR DESCRIPTION
#### Changes:

- fixes it by removing the use of useEffect to listen for changes
  in filters and active indices and then call onApplyFilter. Now
  I've made the calls to onApplyFilter explicit making it easier
  to maintain and read.
- with this change I've also fixed a bug in filter deletion:
  Cause: we used to delete an active filter's index from active
  filter indices array without adjusting the rest of the indices.
  Required adjustment: if a filter gets deleted from filters array
  then the index of all the filters on the right are decremented by
  1. But we weren't making this adjustment with active indices array.