### PR TITLE
#989 add support of remaining ops for ignite filters

### DIFF
--- a/plugin/ignite-plugin/src/main/scala/org/finos/vuu/feature/ignite/filter/IgniteSqlFilterClause.scala
+++ b/plugin/ignite-plugin/src/main/scala/org/finos/vuu/feature/ignite/filter/IgniteSqlFilterClause.scala
@@ -1,39 +1,91 @@
 package org.finos.vuu.feature.ignite.filter
 
+import com.typesafe.scalalogging.StrictLogging
 import org.finos.vuu.api.TableDef
-import org.finos.vuu.core.table.DataType.StringDataType
+import org.finos.vuu.core.table.DataType.{CharDataType, StringDataType}
+import org.finos.vuu.feature.ignite.filter.IgniteSqlFilterClause.EMPTY_SQL
+
+private object IgniteSqlFilterClause {
+  val EMPTY_SQL = ""
+}
 
 trait IgniteSqlFilterClause {
   def toSql(tableDef: TableDef): String
 }
 
-case class OrIgniteSqlFilterClause(clauses:List[IgniteSqlFilterClause]) extends IgniteSqlFilterClause{
+case class OrIgniteSqlFilterClause(clauses:List[IgniteSqlFilterClause]) extends IgniteSqlFilterClause {
   override def toSql(tableDef: TableDef): String = {
-    clauses.head.toSql(tableDef) //todo implement properly. just making it work as root clause for now
+    val sql = clauses.map(c => c.toSql(tableDef)).mkString(" OR ")
+    if (clauses.length > 1) s"($sql)" else sql
   }
 }
 
-case class AndIgniteSqlFilterClause(clauses:List[IgniteSqlFilterClause]) extends IgniteSqlFilterClause{
+case class AndIgniteSqlFilterClause(clauses:List[IgniteSqlFilterClause]) extends IgniteSqlFilterClause {
   override def toSql(tableDef: TableDef): String = {
-    var sql: String = clauses.head.toSql(tableDef)
-    clauses.tail.map(clause =>
-      sql+= s" AND ${clause.toSql(tableDef)}"
-    )
-    sql
+    val sql = clauses.map(c => c.toSql(tableDef)).mkString(" AND ")
+    if (clauses.length > 1) s"($sql)" else sql
   }
 }
-case class EqIgniteSqlFilterClause(columnName: String, value: String) extends IgniteSqlFilterClause{
-  override def toSql(tableDef: TableDef): String = {
 
-    tableDef.columnForName(columnName).dataType match {
-      case StringDataType => s"$columnName=\'$value\'"
-      case _ => s"$columnName=$value"
+case class EqIgniteSqlFilterClause(columnName: String, value: String) extends IgniteSqlFilterClause {
+  override def toSql(tableDef: TableDef): String = {
+    val processedVal = tableDef.columnForName(columnName).dataType match {
+      case CharDataType | StringDataType => quotedString(value)
+      case _ => value
     }
-    //s"$columnName=\'$value\'"
+    s"$columnName = $processedVal"
+  }
+}
+
+case class NeqIgniteSqlFilterClause(columnName: String, value: String) extends IgniteSqlFilterClause {
+  override def toSql(tableDef: TableDef): String = {
+    val processedVal = tableDef.columnForName(columnName).dataType match {
+      case CharDataType | StringDataType => quotedString(value)
+      case _ => value
+    }
+    s"$columnName != $processedVal"
   }
 }
 
 //todo why is number cast double? need to cast back to original type?
-case class GreaterThanIgniteSqlFilterClause(columnName: String, value: Double) extends IgniteSqlFilterClause{
+case class GtIgniteSqlFilterClause(columnName: String, value: Double) extends IgniteSqlFilterClause {
   override def toSql(tableDef: TableDef): String = s"$columnName > $value"
+}
+
+case class LtIgniteSqlFilterClause(columnName: String, value: Double) extends IgniteSqlFilterClause {
+  override def toSql(tableDef: TableDef): String = s"$columnName < $value"
+}
+
+case class StartsIgniteSqlFilterClause(columnName: String, value: String) extends IgniteSqlFilterClause with StrictLogging {
+  override def toSql(tableDef: TableDef): String =
+    tableDef.columnForName(columnName).dataType match {
+      case StringDataType => s"$columnName LIKE '$value%'"
+      case _ =>
+        logger.error(s"`Starts` clause unsupported for non string column: `$columnName`")
+        EMPTY_SQL
+    }
+}
+
+case class EndsIgniteSqlFilterClause(columnName: String, value: String) extends IgniteSqlFilterClause with StrictLogging {
+  override def toSql(tableDef: TableDef): String =
+    tableDef.columnForName(columnName).dataType match {
+      case StringDataType => s"$columnName LIKE '%$value'"
+      case _ =>
+        logger.error(s"`Ends` clause unsupported for non string column: `$columnName`")
+        EMPTY_SQL
+    }
+}
+
+case class InIgniteSqlFilterClause(columnName: String, values: List[String]) extends IgniteSqlFilterClause with StrictLogging {
+  override def toSql(tableDef: TableDef): String = {
+    val processedValues = tableDef.columnForName(columnName).dataType match {
+      case CharDataType | StringDataType => values.map(quotedString(_))
+      case _ => values
+    }
+    s"$columnName IN (${processedValues.mkString(",")})"
+  }
+}
+
+private object quotedString {
+  def apply(s: String) = s"'$s'"
 }

--- a/plugin/ignite-plugin/src/main/scala/org/finos/vuu/feature/ignite/filter/IgniteSqlFilterTreeVisitor.scala
+++ b/plugin/ignite-plugin/src/main/scala/org/finos/vuu/feature/ignite/filter/IgniteSqlFilterTreeVisitor.scala
@@ -1,7 +1,9 @@
 package org.finos.vuu.feature.ignite.filter
 
+import org.finos.vuu.core.filter.FilterTreeVisitor
 import org.finos.vuu.grammar.FilterBaseVisitor
 import org.finos.vuu.grammar.FilterParser._
+
 import scala.jdk.CollectionConverters._
 
 class IgniteSqlFilterTreeVisitor extends FilterBaseVisitor[IgniteSqlFilterClause] {
@@ -15,10 +17,28 @@ class IgniteSqlFilterTreeVisitor extends FilterBaseVisitor[IgniteSqlFilterClause
   override def visitAndExpression(ctx: AndExpressionContext): IgniteSqlFilterClause =
     AndIgniteSqlFilterClause(ctx.term().asScala.map(visit).toList)
 
+  override def visitSubexpression(ctx: SubexpressionContext): IgniteSqlFilterClause =
+    visitOrExpression(ctx.orExpression())
+
   override def visitOperationEq(ctx: OperationEqContext): IgniteSqlFilterClause =
     EqIgniteSqlFilterClause(ctx.ID().getText, ctx.scalar().getText)
 
-  override def visitOperationGt(ctx: OperationGtContext): IgniteSqlFilterClause =
-    GreaterThanIgniteSqlFilterClause(ctx.ID().getText, ctx.NUMBER().getText.toDouble)
+  override def visitOperationNeq(ctx: OperationNeqContext): IgniteSqlFilterClause =
+    NeqIgniteSqlFilterClause(ctx.ID().getText, ctx.scalar().getText)
 
+  override def visitOperationGt(ctx: OperationGtContext): IgniteSqlFilterClause =
+    GtIgniteSqlFilterClause(ctx.ID().getText, ctx.NUMBER().getText.toDouble)
+
+  override def visitOperationLt(ctx: OperationLtContext): IgniteSqlFilterClause =
+    LtIgniteSqlFilterClause(ctx.ID().getText, ctx.NUMBER().getText.toDouble)
+
+  override def visitOperationStarts(ctx: OperationStartsContext): IgniteSqlFilterClause =
+    StartsIgniteSqlFilterClause(ctx.ID().getText, ctx.STRING().getText)
+
+  override def visitOperationEnds(ctx: OperationEndsContext): IgniteSqlFilterClause =
+    EndsIgniteSqlFilterClause(ctx.ID().getText, ctx.STRING().getText)
+
+  override def visitOperationIn(ctx: OperationInContext): IgniteSqlFilterClause = {
+    InIgniteSqlFilterClause(ctx.ID().getText, FilterTreeVisitor.operationInValues(ctx))
+  }
 }

--- a/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/IgniteTestStore.scala
+++ b/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/IgniteTestStore.scala
@@ -61,6 +61,7 @@ object IgniteTestStore {
     fields.put("ric", classOf[String].getName)
     fields.put("price", classOf[Double].getName)
     fields.put("quantity", classOf[Int].getName)
+    fields.put("rating", classOf[Char].getName)
     fields
   }
 
@@ -79,6 +80,8 @@ class IgniteTestStore (private val orderCache: IgniteCache[Int, TestOrderEntity]
 
   def get(key: Int): TestOrderEntity =
     orderCache.get(key)
+
+  def clear(): Unit = orderCache.clear()
 
   def getFilteredBy(filterQueryCriteria: List[IndexQueryCriterion]): Iterable[TestOrderEntity] = {
     //  val filter: IgniteBiPredicate[Int, TestOrder]  = (key, p) => p.filledQty > 0

--- a/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/IgniteTestsBase.scala
+++ b/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/IgniteTestsBase.scala
@@ -1,15 +1,16 @@
 package org.finos.vuu.feature.ignite
 
-import org.scalatest.BeforeAndAfter
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
 
-class IgniteTestsBase extends AnyFeatureSpec with BeforeAndAfter with Matchers {
+class IgniteTestsBase extends AnyFeatureSpec with BeforeAndAfterEach with Matchers {
 
-  protected var igniteTestStore: IgniteTestStore = _
+  protected val igniteTestStore: IgniteTestStore = IgniteTestStore()
 
-  before {
-    igniteTestStore = IgniteTestStore()
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    igniteTestStore.clear()
   }
 
   def givenOrderExistInIgnite(existingData: TestOrderEntity*): Unit = {

--- a/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/TestInput.scala
+++ b/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/TestInput.scala
@@ -1,6 +1,6 @@
 package org.finos.vuu.feature.ignite
 
 object TestInput {
-  def createTestOrderEntity(id: Int, ric: String, parentId: Int = 1, price: Double = 10.4, quantity: Int = 100): TestOrderEntity =
-    TestOrderEntity(parentId = parentId, id = id, ric = ric, price = price, quantity = quantity)
+  def createTestOrderEntity(id: Int, ric: String, parentId: Int = 1, price: Double = 10.4, quantity: Int = 100, rating: Char = 'A'): TestOrderEntity =
+    TestOrderEntity(parentId = parentId, id = id, ric = ric, price = price, quantity = quantity, rating = rating)
 }

--- a/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/TestOrderEntity.scala
+++ b/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/TestOrderEntity.scala
@@ -5,7 +5,8 @@ case class TestOrderEntity(
                       id: Int,
                       ric: String,
                       price: Double,
-                      quantity: Int){
+                      quantity: Int,
+                      rating: Char){
 
 }
 
@@ -17,6 +18,7 @@ object TestOrderEntity{
       ric = cols.get(2).asInstanceOf[String],
       price = cols.get(3).asInstanceOf[Double],
       quantity = cols.get(4).asInstanceOf[Int],
+      rating = cols.get(5).asInstanceOf[Char]
     )
   }
 }
@@ -31,6 +33,7 @@ object ColumnMap {
     "price" -> "price",
     "quantity" -> "quantity",
     "parentOrderId" -> "parentId",
+    "rating" -> "rating",
   )
   def toIgniteColumn(tableColumn: String): Option[String] =
     orderMap.get(tableColumn)

--- a/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/filter/IgniteSqlFilteringTest.scala
+++ b/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/filter/IgniteSqlFilteringTest.scala
@@ -27,46 +27,31 @@ class IgniteSqlFilteringTest extends IgniteTestsBase {
   )
 
   Feature("Parse and apply GREATER THAN filter") {
+    val testOrder1 = createTestOrderEntity(id = 1, ric = "VOD.L", price = 10.0, quantity = 600)
+    val testOrder2 = createTestOrderEntity(id = 2, ric = "AAPL.L", price = 50.5, quantity = 200)
+    val testOrder3 = createTestOrderEntity(id = 3, ric = "AAPL.L", price = 100.0, quantity = 1000)
+
     Scenario("Support comparison to INT") {
-      givenOrderExistInIgnite(
-        createTestOrderEntity(id = 1, ric = "VOD.L", quantity = 600),
-        createTestOrderEntity(id = 2, ric = "AAPL.L", quantity = 200),
-        createTestOrderEntity(id = 3, ric = "AAPL.GA", quantity = 1000),
-      )
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
 
       val filterResult = applyFilter("quantity > 500")
 
-      assertEquavalent(
-        filterResult.toArray,
-        Array(
-          createTestOrderEntity(id = 1, ric = "VOD.L", quantity = 600),
-          createTestOrderEntity(id = 3, ric = "AAPL.GA", quantity = 1000),
-        )
-      )
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder3))
     }
 
-    Scenario("AND clause for two conditions") {
-      givenOrderExistInIgnite(
-        createTestOrderEntity(id = 1, ric = "VOD.L", quantity = 1000),
-        createTestOrderEntity(id = 2, ric = "AAPL.L", quantity = 200),
-        createTestOrderEntity(id = 3, ric = "AAPL.L", quantity = 1000),
-      )
+    Scenario("Support comparison to DOUBLE") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
 
-      val filterResult = applyFilter("ric = \"AAPL.L\" and quantity > 500")
+      val filterResult = applyFilter("price > 50.0")
 
-      assertEquavalent(
-        filterResult.toArray,
-        Array(
-          createTestOrderEntity(id = 3, ric = "AAPL.L",  quantity = 1000),
-        )
-      )
+      assertEquavalent(filterResult.toArray, Array(testOrder2, testOrder3))
     }
   }
 
   Feature("Parse and apply LESSER THAN filter") {
     val testOrder1 = createTestOrderEntity(id = 1, ric = "VOD.L", price = 10.0, quantity = 600)
     val testOrder2 = createTestOrderEntity(id = 2, ric = "AAPL.L", price = 50.0, quantity = 200)
-    val testOrder3 = createTestOrderEntity(id = 3, ric = "AAPL.L", price = 250.0, quantity = 1000)
+    val testOrder3 = createTestOrderEntity(id = 3, ric = "AAPL.L", price = 100.5, quantity = 1000)
 
     Scenario("Support comparison to INT") {
       givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
@@ -79,7 +64,7 @@ class IgniteSqlFilteringTest extends IgniteTestsBase {
     Scenario("Support comparison to DOUBLE") {
       givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
 
-      val filterResult = applyFilter("price < 100.0")
+      val filterResult = applyFilter("price < 50.1")
 
       assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder2))
     }

--- a/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/filter/IgniteSqlFilteringTest.scala
+++ b/plugin/ignite-plugin/src/test/scala/org/finos/vuu/feature/ignite/filter/IgniteSqlFilteringTest.scala
@@ -13,7 +13,17 @@ class IgniteSqlFilteringTest extends IgniteTestsBase {
   private val tableDef = TableDef(
     name = "bigOrders",
     keyField = "orderId",
-    Columns.fromNames("id".int(), "parentId".string(), "ric".string(), "quantity".int(), "price".double(), "side".string(), "strategy".string(), "parentOrderId".int())
+    Columns.fromNames(
+      "id".int(),
+      "parentId".string(),
+      "ric".string(),
+      "quantity".int(),
+      "price".double(),
+      "side".string(),
+      "strategy".string(),
+      "parentOrderId".int(),
+      "rating".char()
+    )
   )
 
   Feature("Parse and apply GREATER THAN filter") {
@@ -52,57 +62,105 @@ class IgniteSqlFilteringTest extends IgniteTestsBase {
       )
     }
   }
-  Feature("Parse and apply EQUALITY filter") {
-    Scenario("Support comparison to STRING") {
-      givenOrderExistInIgnite(
-        createTestOrderEntity(id = 1, ric = "VOD.L"),
-        createTestOrderEntity(id = 2, ric = "AAPL.L"),
-        createTestOrderEntity(id = 3, ric = "AAPL.GA"),
-      )
 
-      val filterResult = applyFilter("ric = \"AAPL.L\"")
-
-      assertEquavalent(
-        filterResult.toArray,
-        Array(createTestOrderEntity(id = 2, ric = "AAPL.L"))
-      )
-    }
+  Feature("Parse and apply LESSER THAN filter") {
+    val testOrder1 = createTestOrderEntity(id = 1, ric = "VOD.L", price = 10.0, quantity = 600)
+    val testOrder2 = createTestOrderEntity(id = 2, ric = "AAPL.L", price = 50.0, quantity = 200)
+    val testOrder3 = createTestOrderEntity(id = 3, ric = "AAPL.L", price = 250.0, quantity = 1000)
 
     Scenario("Support comparison to INT") {
-      givenOrderExistInIgnite(
-        createTestOrderEntity(id = 1, ric = "VOD.L", parentId = 10),
-        createTestOrderEntity(id = 2, ric = "AAPL.L", parentId = 11),
-        createTestOrderEntity(id = 3, ric = "AAPL.GA", parentId = 10),
-      )
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
 
-      val filterResult = applyFilter("parentId = 10")
+      val filterResult = applyFilter("quantity < 500")
 
-      assertEquavalent(
-        filterResult.toArray,
-        Array(
-          createTestOrderEntity(id = 1, ric = "VOD.L", parentId = 10),
-          createTestOrderEntity(id = 3, ric = "AAPL.GA", parentId = 10),
-        )
-      )
+      assertEquavalent(filterResult.toArray, Array(testOrder2))
     }
 
     Scenario("Support comparison to DOUBLE") {
-      givenOrderExistInIgnite(
-        createTestOrderEntity(id = 1, ric = "VOD.L", price = 10.1),
-        createTestOrderEntity(id = 2, ric = "AAPL.L", price = 10.15),
-        createTestOrderEntity(id = 3, ric = "AAPL.GA", price = 11),
-      )
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("price < 100.0")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder2))
+    }
+  }
+
+  Feature("Parse and apply EQUAL filter") {
+    val testOrder1 = createTestOrderEntity(id = 1, ric = "VOD.L", rating = 'D', price = 10.1, parentId = 10)
+    val testOrder2 = createTestOrderEntity(id = 2, ric = "AAPL.L", rating = 'B', price = 10.15, parentId = 11)
+    val testOrder3 = createTestOrderEntity(id = 3, ric = "AAPL.GA", rating = 'C', price = 11, parentId = 10)
+
+    Scenario("Support comparison to STRING") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("ric = \"AAPL.L\"")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder2))
+    }
+
+    Scenario("Support comparison to CHAR") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("rating = \"B\"")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder2))
+    }
+
+    Scenario("Support comparison to INT") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("parentId = 10")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder3))
+    }
+
+    Scenario("Support comparison to DOUBLE") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
 
       val filterResult = applyFilter("price = 10.1")
 
-      assertEquavalent(
-        filterResult.toArray,
-        Array(
-          createTestOrderEntity(id = 1, ric = "VOD.L", price = 10.1),
-        )
-      )
+      assertEquavalent(filterResult.toArray, Array(testOrder1))
     }
   }
+
+  Feature("Parse and apply NOT-EQUAL filter") {
+    val testOrder1 = createTestOrderEntity(id = 1, ric = "VOD.L", rating = 'D', price = 10.1, parentId = 10)
+    val testOrder2 = createTestOrderEntity(id = 2, ric = "AAPL.L", rating = 'B', price = 10.15, parentId = 11)
+    val testOrder3 = createTestOrderEntity(id = 3, ric = "AAPL.GA", rating = 'C', price = 11, parentId = 10)
+
+    Scenario("Support comparison to STRING") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("ric != \"AAPL.L\"")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder3))
+    }
+
+    Scenario("Support comparison to CHAR") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("rating != \"B\"")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder3))
+    }
+
+    Scenario("Support comparison to INT") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("parentId != 10")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder2))
+    }
+
+    Scenario("Support comparison to DOUBLE") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("price != 10.1")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder2, testOrder3))
+    }
+  }
+
   Feature("Parse and apply AND filter") {
     //todo assert exception or handle error
     ignore("Support one clause") {
@@ -141,11 +199,146 @@ class IgniteSqlFilteringTest extends IgniteTestsBase {
     }
   }
 
+  Feature("Parse and apply OR filter") {
+    Scenario("Support two clauses") {
+      givenOrderExistInIgnite(
+        createTestOrderEntity(id = 1, ric = "VOD.L", quantity = 150),
+        createTestOrderEntity(id = 2, ric = "VOD.L", quantity = 200),
+        createTestOrderEntity(id = 3, ric = "AAPL.L", quantity = 150),
+      )
+
+      val filterResult = applyFilter("ric = \"AAPL.L\" or quantity > 180")
+
+      assertEquavalent(
+        filterResult.toArray,
+        Array(
+          createTestOrderEntity(id = 2, ric = "VOD.L", quantity = 200),
+          createTestOrderEntity(id = 3, ric = "AAPL.L", quantity = 150),
+        )
+      )
+    }
+  }
+
+  Feature("Parse and apply nested AND/OR filters") {
+    val testOrder1 = createTestOrderEntity(id = 1, ric = "VOD.L", price = 11.0, quantity = 200)
+    val testOrder2 = createTestOrderEntity(id = 2, ric = "VOD.L", price = 4.0, quantity = 175)
+    val testOrder3 = createTestOrderEntity(id = 3, ric = "AAPL.L", price = 5.0, quantity = 150)
+    val testOrder4 = createTestOrderEntity(id = 4, ric = "AAPL.L", price = 7.0, quantity = 90)
+    val testOrder5 = createTestOrderEntity(id = 5, ric = "ABC.L", price = 7.0, quantity = 150)
+
+    Scenario("One level nesting - outer OR and nested AND") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("ric = \"AAPL.L\" or (ric = \"VOD.L\" and quantity = 200)")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder3))
+    }
+
+    Scenario("One level nesting - nested OR and outer AND") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("(ric = \"AAPL.L\" or ric = \"VOD.L\") and quantity = 200")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1))
+    }
+
+    Scenario("Multilevel nesting") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3, testOrder4, testOrder5)
+
+      val filterResult = applyFilter("(ric = \"AAPL.L\" and quantity = 90) or (quantity > 100 and (price < 5 or price > 10))")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder2, testOrder4))
+    }
+  }
+
+  Feature("Parse and apply STARTS filter") {
+    val testOrder1 = createTestOrderEntity(id = 1, ric = "VOD.L")
+    val testOrder2 = createTestOrderEntity(id = 2, ric = "VAD.L")
+    val testOrder3 = createTestOrderEntity(id = 3, ric = "NVD.L")
+
+    Scenario("supports String column type") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("ric starts \"V\"")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder2))
+    }
+
+    Scenario("empty filter for non-string column types") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("id starts \"1\"")
+
+      filterResult.size shouldEqual 3
+    }
+  }
+
+  Feature("Parse and apply ENDS filter") {
+    val testOrder1 = createTestOrderEntity(id = 1, ric = "VOD.HK")
+    val testOrder2 = createTestOrderEntity(id = 2, ric = "VAD.DDN")
+    val testOrder3 = createTestOrderEntity(id = 3, ric = "NVD.LDN")
+
+    Scenario("supports String column type") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("ric ends \"DN\"")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder2, testOrder3))
+    }
+
+    Scenario("empty filter for non-string column types") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("id ends \"1\"")
+
+      filterResult.size shouldEqual 3
+    }
+  }
+
+  Feature("Parse and apply IN filter") {
+    val testOrder1 = createTestOrderEntity(id = 1, ric = "BABA.HK", rating = 'B', price = 10.5)
+    val testOrder2 = createTestOrderEntity(id = 2, ric = "VAD.DDN", rating = 'C', price = 5.0)
+    val testOrder3 = createTestOrderEntity(id = 3, ric = "NVD.LDN", rating = 'D', price = 3)
+
+    Scenario("supports String column type") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("ric in [\"VAD.DDN\", \"NVD.LDN\"]")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder3, testOrder2))
+    }
+
+    Scenario("supports Char column type") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("rating in [\"B\", \"C\"]")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder2))
+    }
+
+    Scenario("supports Int column type") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("id in [1, 3]")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder3))
+    }
+
+    Scenario("supports Double column type") {
+      givenOrderExistInIgnite(testOrder1, testOrder2, testOrder3)
+
+      val filterResult = applyFilter("price in [10.5, 3]")
+
+      assertEquavalent(filterResult.toArray, Array(testOrder1, testOrder3))
+    }
+  }
+
   private def applyFilter(filter: String): Iterable[TestOrderEntity] = {
     info(s"FILTER: $filter")
     val clause = FilterSpecParser.parse[IgniteSqlFilterClause](filter, filterTreeVisitor)
+    info(s"CLAUSE: $clause")
     val criteria = clause.toSql(tableDef)
-    info(s"SQL WHERE: $filter")
+    info(s"SQL WHERE: $criteria")
     igniteTestStore.getFilteredBy(criteria)
   }
 

--- a/vuu/src/main/scala/org/finos/vuu/api/TableDef.scala
+++ b/vuu/src/main/scala/org/finos/vuu/api/TableDef.scala
@@ -1,11 +1,9 @@
 package org.finos.vuu.api
 
-import org.finos.vuu.core.VuuServer
 import org.finos.vuu.core.auths.RowPermissionChecker
 import org.finos.vuu.core.module.ViewServerModule
 import org.finos.vuu.core.table._
 import org.finos.vuu.feature.inmem.VuuInMemPluginLocator
-import org.finos.vuu.net.ClientSessionId
 import org.finos.vuu.viewport.ViewPort
 
 object Fields {
@@ -145,15 +143,11 @@ class TableDef(val name: String,
   def deleteColumnName() = s"$name._isDeleted"
 
   def columnForName(name: String): Column = {
-    val column = columns.find(c => c.name == name)
-    if (column.isEmpty)
-      null
-    else
-      column.get
+    columns.find(c => c.name == name).orNull
   }
 
   def columnExists(name: String): Boolean = {
-    columns.find(_.name == name).isDefined
+    columns.exists(_.name == name)
   }
 
   def fullyQuallifiedColumnName(column: String): String = s"$name.$column"

--- a/vuu/src/main/scala/org/finos/vuu/core/filter/FilterTreeVisitor.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/filter/FilterTreeVisitor.scala
@@ -36,13 +36,17 @@ class FilterTreeVisitor extends FilterBaseVisitor[FilterClause] {
     EndsClause(ctx.ID().getText, ctx.STRING().getText)
 
   override def visitOperationIn(ctx: OperationInContext): FilterClause = {
-    val setElements = Option(ctx.set().NUMBER()) #::  Option(ctx.set().STRING()) #:: LazyList.empty
-    val scalarList = setElements
+    InClause(ctx.ID().getText, FilterTreeVisitor.operationInValues(ctx))
+  }
+}
+
+object FilterTreeVisitor {
+  def operationInValues(ctx: OperationInContext): List[String] = {
+    val setElements = Option(ctx.set().NUMBER()) #:: Option(ctx.set().STRING()) #:: LazyList.empty
+    setElements
       .flatten
       .flatMap(_.asScala)
       .map(_.getText)
       .toList
-
-    InClause(ctx.ID().getText, scalarList)
   }
 }

--- a/vuu/src/main/scala/org/finos/vuu/core/sort/SortCompares.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/sort/SortCompares.scala
@@ -14,7 +14,7 @@ object SortCompares {
 
     val compareValue = if(activeColumn.dataType.equals(DataType.StringDataType)){
         compareString(o1, o2, activeColumn, direction)
-    }else if(activeColumn.dataType.equals(DataType.charDataType)){
+    }else if(activeColumn.dataType.equals(DataType.CharDataType)){
         compareChar(o1, o2, activeColumn, direction)
     } else if (activeColumn.dataType.equals(DataType.IntegerDataType)) {
       compareInt(o1, o2, activeColumn, direction)

--- a/vuu/src/main/scala/org/finos/vuu/core/table/Column.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/Column.scala
@@ -5,7 +5,7 @@ import org.finos.vuu.core.table.column.CalculatedColumnClause
 
 object DataType {
 
-  final val charDataType: Class[Char] = classOf[Char]
+  final val CharDataType: Class[Char] = classOf[Char]
   final val StringDataType: Class[String] = classOf[String]
   final val BooleanDataType: Class[Boolean] = classOf[Boolean]
   final val IntegerDataType: Class[Int] = classOf[Int]
@@ -15,7 +15,7 @@ object DataType {
 
   def fromString(s: String): Class[_] = {
     s.trim.toLowerCase match {
-      case "char" => charDataType
+      case "char" => CharDataType
       case "string" => StringDataType
       case "double" => DoubleDataType
       case "boolean" => BooleanDataType


### PR DESCRIPTION
#989 extend Ignite SQL filters to support other ops

- adds support for In, Starts, Ends, Not Equal, and Lesser Than
  operations.
- uses `(` & `)` for OR/AND clause to make sure that the filters
  are parsed and applied as intended and their order is preserved
  as (A OR B) AND C != A OR (B AND C).
- adds support for CharDataType columns where it made sense
  (i.e. using chars with Starts/Ends doesn't make sense)