### PR TITLE
#1000 Resolved issue with calc columns not working on joined tables.

### DIFF
--- a/vuu/src/main/scala/org/finos/vuu/core/table/Column.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/Column.scala
@@ -66,7 +66,7 @@ object Columns {
 
   def aliased(table: TableDef, aliases: (String, String)*): Array[Column] = {
     val aliased = aliases.map(tuple => tuple._1 -> tuple._2).toMap
-    table.columns.filter(c => aliased.contains(c.name)) map (c => new AliasedJoinColumn(aliased.get(c.name).get, c.index, c.dataType, table, c).asInstanceOf[Column])
+    table.columns.filter(c => aliased.contains(c.name)) map (c => new AliasedJoinColumn(aliased(c.name), c.index, c.dataType, table, c).asInstanceOf[Column])
   }
 
   //def calculated(name: String, definition: String): Array[Column] = ???
@@ -123,6 +123,8 @@ class AliasedJoinColumn(name: String, index: Int, dataType: Class[_], sourceTabl
 }
 
 class JoinColumn(name: String, index: Int, dataType: Class[_], val sourceTable: TableDef, val sourceColumn: Column) extends SimpleColumn(name, index, dataType) {
+
+  override def toString: String = s"JoinColumn($name, ${sourceTable.name}:${sourceColumn.name})"
 
   override def hashCode(): Int = (sourceTable.name + "." + sourceColumn + "@" + name).hashCode
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/CalculatedColumnsViewPortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/CalculatedColumnsViewPortTest.scala
@@ -1,11 +1,16 @@
 package org.finos.vuu.viewport
 
 import org.finos.toolbox.jmx.{MetricsProvider, MetricsProviderImpl}
+import org.finos.toolbox.lifecycle.LifecycleContainer
 import org.finos.toolbox.time.{Clock, TestFriendlyClock}
+import org.finos.vuu.api.{JoinSpec, JoinTableDef, JoinTo, LeftOuterJoin, TableDef}
 import org.finos.vuu.client.messages.RequestId
 import org.finos.vuu.core.table.TableTestHelper.combineQs
-import org.finos.vuu.core.table.ViewPortColumnCreator
-import org.finos.vuu.util.table.TableAsserts.assertVpEq
+import org.finos.vuu.core.table.{Columns, TableContainer, ViewPortColumnCreator}
+import org.finos.vuu.net.ClientSessionId
+import org.finos.vuu.provider.{JoinTableProviderImpl, MockProvider, ProviderContainer}
+import org.finos.vuu.util.OutboundRowPublishQueue
+import org.finos.vuu.util.table.TableAsserts.{assertVpEq, assertVpEqWithMeta}
 import org.scalatest.GivenWhenThen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Tables.Table
@@ -36,17 +41,17 @@ class CalculatedColumnsViewPortTest extends AbstractViewPortTestCase with Matche
       //it should return a compound error
       assertVpEq(combinedUpdates) {
         Table(
-          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","logicTest"),
-          ("NYC-0000","chris"   ,"VOD.L"   ,1311544800000L,100       ,"Boo"     ),
-          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,101       ,"Boo"     ),
-          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,102       ,"Boo"     ),
-          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,103       ,"Boo"     ),
-          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,104       ,"Boo"     ),
-          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,105       ,"Boo"     ),
-          ("NYC-0006","chris"   ,"VOD.L"   ,1311544800000L,106       ,"Boo"     ),
-          ("NYC-0007","chris"   ,"VOD.L"   ,1311544800000L,107       ,"Boo"     ),
-          ("NYC-0008","chris"   ,"VOD.L"   ,1311544800000L,108       ,"Boo"     ),
-          ("NYC-0009","chris"   ,"VOD.L"   ,1311544800000L,109       ,"Boo"     )
+          ("orderId", "trader", "ric", "tradeTime", "quantity", "logicTest"),
+          ("NYC-0000", "chris", "VOD.L", 1311544800000L, 100, "Boo"),
+          ("NYC-0001", "chris", "VOD.L", 1311544800000L, 101, "Boo"),
+          ("NYC-0002", "chris", "VOD.L", 1311544800000L, 102, "Boo"),
+          ("NYC-0003", "chris", "VOD.L", 1311544800000L, 103, "Boo"),
+          ("NYC-0004", "chris", "VOD.L", 1311544800000L, 104, "Boo"),
+          ("NYC-0005", "chris", "VOD.L", 1311544800000L, 105, "Boo"),
+          ("NYC-0006", "chris", "VOD.L", 1311544800000L, 106, "Boo"),
+          ("NYC-0007", "chris", "VOD.L", 1311544800000L, 107, "Boo"),
+          ("NYC-0008", "chris", "VOD.L", 1311544800000L, 108, "Boo"),
+          ("NYC-0009", "chris", "VOD.L", 1311544800000L, 109, "Boo")
         )
       }
     }
@@ -71,17 +76,17 @@ class CalculatedColumnsViewPortTest extends AbstractViewPortTestCase with Matche
 
       assertVpEq(combinedUpdates) {
         Table(
-          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","logicTest"),
-          ("NYC-0000","chris"   ,"VOD.L"   ,1311544800000L,100       ,"Boo"     ),
-          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,101       ,"Boo"     ),
-          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,102       ,"Boo"     ),
-          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,103       ,"Boo"     ),
-          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,104       ,"Boo"     ),
-          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,105       ,"Boo"     ),
-          ("NYC-0006","chris"   ,"VOD.L"   ,1311544800000L,106       ,"Boo"     ),
-          ("NYC-0007","chris"   ,"VOD.L"   ,1311544800000L,107       ,"Boo"     ),
-          ("NYC-0008","chris"   ,"VOD.L"   ,1311544800000L,108       ,"Boo"     ),
-          ("NYC-0009","chris"   ,"VOD.L"   ,1311544800000L,109       ,"Yay"     )
+          ("orderId", "trader", "ric", "tradeTime", "quantity", "logicTest"),
+          ("NYC-0000", "chris", "VOD.L", 1311544800000L, 100, "Boo"),
+          ("NYC-0001", "chris", "VOD.L", 1311544800000L, 101, "Boo"),
+          ("NYC-0002", "chris", "VOD.L", 1311544800000L, 102, "Boo"),
+          ("NYC-0003", "chris", "VOD.L", 1311544800000L, 103, "Boo"),
+          ("NYC-0004", "chris", "VOD.L", 1311544800000L, 104, "Boo"),
+          ("NYC-0005", "chris", "VOD.L", 1311544800000L, 105, "Boo"),
+          ("NYC-0006", "chris", "VOD.L", 1311544800000L, 106, "Boo"),
+          ("NYC-0007", "chris", "VOD.L", 1311544800000L, 107, "Boo"),
+          ("NYC-0008", "chris", "VOD.L", 1311544800000L, 108, "Boo"),
+          ("NYC-0009", "chris", "VOD.L", 1311544800000L, 109, "Yay")
         )
       }
     }
@@ -105,17 +110,17 @@ class CalculatedColumnsViewPortTest extends AbstractViewPortTestCase with Matche
 
       assertVpEq(combinedUpdates) {
         Table(
-          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","quantityTimes100"),
-          ("NYC-0000","chris"   ,"VOD.L"   ,1311544800000L,100       ,10000     ),
-          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,101       ,10100     ),
-          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,102       ,10200     ),
-          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,103       ,10300     ),
-          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,104       ,10400     ),
-          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,105       ,10500     ),
-          ("NYC-0006","chris"   ,"VOD.L"   ,1311544800000L,106       ,10600     ),
-          ("NYC-0007","chris"   ,"VOD.L"   ,1311544800000L,107       ,10700     ),
-          ("NYC-0008","chris"   ,"VOD.L"   ,1311544800000L,108       ,10800     ),
-          ("NYC-0009","chris"   ,"VOD.L"   ,1311544800000L,109       ,10900     )
+          ("orderId", "trader", "ric", "tradeTime", "quantity", "quantityTimes100"),
+          ("NYC-0000", "chris", "VOD.L", 1311544800000L, 100, 10000),
+          ("NYC-0001", "chris", "VOD.L", 1311544800000L, 101, 10100),
+          ("NYC-0002", "chris", "VOD.L", 1311544800000L, 102, 10200),
+          ("NYC-0003", "chris", "VOD.L", 1311544800000L, 103, 10300),
+          ("NYC-0004", "chris", "VOD.L", 1311544800000L, 104, 10400),
+          ("NYC-0005", "chris", "VOD.L", 1311544800000L, 105, 10500),
+          ("NYC-0006", "chris", "VOD.L", 1311544800000L, 106, 10600),
+          ("NYC-0007", "chris", "VOD.L", 1311544800000L, 107, 10700),
+          ("NYC-0008", "chris", "VOD.L", 1311544800000L, 108, 10800),
+          ("NYC-0009", "chris", "VOD.L", 1311544800000L, 109, 10900)
         )
       }
 
@@ -130,17 +135,17 @@ class CalculatedColumnsViewPortTest extends AbstractViewPortTestCase with Matche
 
       assertVpEq(combinedUpdates2) {
         Table(
-          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","textConcat"),
-          ("NYC-0000","chris"   ,"VOD.L"   ,1311544800000L,100       ,"NYC-0000VOD.L"),
-          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,101       ,"NYC-0001VOD.L"),
-          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,102       ,"NYC-0002VOD.L"),
-          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,103       ,"NYC-0003VOD.L"),
-          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,104       ,"NYC-0004VOD.L"),
-          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,105       ,"NYC-0005VOD.L"),
-          ("NYC-0006","chris"   ,"VOD.L"   ,1311544800000L,106       ,"NYC-0006VOD.L"),
-          ("NYC-0007","chris"   ,"VOD.L"   ,1311544800000L,107       ,"NYC-0007VOD.L"),
-          ("NYC-0008","chris"   ,"VOD.L"   ,1311544800000L,108       ,"NYC-0008VOD.L"),
-          ("NYC-0009","chris"   ,"VOD.L"   ,1311544800000L,109       ,"NYC-0009VOD.L")
+          ("orderId", "trader", "ric", "tradeTime", "quantity", "textConcat"),
+          ("NYC-0000", "chris", "VOD.L", 1311544800000L, 100, "NYC-0000VOD.L"),
+          ("NYC-0001", "chris", "VOD.L", 1311544800000L, 101, "NYC-0001VOD.L"),
+          ("NYC-0002", "chris", "VOD.L", 1311544800000L, 102, "NYC-0002VOD.L"),
+          ("NYC-0003", "chris", "VOD.L", 1311544800000L, 103, "NYC-0003VOD.L"),
+          ("NYC-0004", "chris", "VOD.L", 1311544800000L, 104, "NYC-0004VOD.L"),
+          ("NYC-0005", "chris", "VOD.L", 1311544800000L, 105, "NYC-0005VOD.L"),
+          ("NYC-0006", "chris", "VOD.L", 1311544800000L, 106, "NYC-0006VOD.L"),
+          ("NYC-0007", "chris", "VOD.L", 1311544800000L, 107, "NYC-0007VOD.L"),
+          ("NYC-0008", "chris", "VOD.L", 1311544800000L, 108, "NYC-0008VOD.L"),
+          ("NYC-0009", "chris", "VOD.L", 1311544800000L, 109, "NYC-0009VOD.L")
         )
       }
     }
@@ -165,17 +170,17 @@ class CalculatedColumnsViewPortTest extends AbstractViewPortTestCase with Matche
 
       assertVpEq(combinedUpdates) {
         Table(
-          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity"),
-          ("NYC-0000","chris"   ,"VOD.L"   ,1311544800000L,100       ),
-          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,101       ),
-          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,102       ),
-          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,103       ),
-          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,104       ),
-          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,105       ),
-          ("NYC-0006","chris"   ,"VOD.L"   ,1311544800000L,106       ),
-          ("NYC-0007","chris"   ,"VOD.L"   ,1311544800000L,107       ),
-          ("NYC-0008","chris"   ,"VOD.L"   ,1311544800000L,108       ),
-          ("NYC-0009","chris"   ,"VOD.L"   ,1311544800000L,109       )
+          ("orderId", "trader", "ric", "tradeTime", "quantity"),
+          ("NYC-0000", "chris", "VOD.L", 1311544800000L, 100),
+          ("NYC-0001", "chris", "VOD.L", 1311544800000L, 101),
+          ("NYC-0002", "chris", "VOD.L", 1311544800000L, 102),
+          ("NYC-0003", "chris", "VOD.L", 1311544800000L, 103),
+          ("NYC-0004", "chris", "VOD.L", 1311544800000L, 104),
+          ("NYC-0005", "chris", "VOD.L", 1311544800000L, 105),
+          ("NYC-0006", "chris", "VOD.L", 1311544800000L, 106),
+          ("NYC-0007", "chris", "VOD.L", 1311544800000L, 107),
+          ("NYC-0008", "chris", "VOD.L", 1311544800000L, 108),
+          ("NYC-0009", "chris", "VOD.L", 1311544800000L, 109)
         )
       }
 
@@ -187,20 +192,96 @@ class CalculatedColumnsViewPortTest extends AbstractViewPortTestCase with Matche
 
       assertVpEq(combinedUpdates2) {
         Table(
-          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","textConcat"),
-          ("NYC-0000","chris"   ,"VOD.L"   ,1311544800000L,100       ,"NYC-0000VOD.L"),
-          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,101       ,"NYC-0001VOD.L"),
-          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,102       ,"NYC-0002VOD.L"),
-          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,103       ,"NYC-0003VOD.L"),
-          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,104       ,"NYC-0004VOD.L"),
-          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,105       ,"NYC-0005VOD.L"),
-          ("NYC-0006","chris"   ,"VOD.L"   ,1311544800000L,106       ,"NYC-0006VOD.L"),
-          ("NYC-0007","chris"   ,"VOD.L"   ,1311544800000L,107       ,"NYC-0007VOD.L"),
-          ("NYC-0008","chris"   ,"VOD.L"   ,1311544800000L,108       ,"NYC-0008VOD.L"),
-          ("NYC-0009","chris"   ,"VOD.L"   ,1311544800000L,109       ,"NYC-0009VOD.L")
+          ("orderId", "trader", "ric", "tradeTime", "quantity", "textConcat"),
+          ("NYC-0000", "chris", "VOD.L", 1311544800000L, 100, "NYC-0000VOD.L"),
+          ("NYC-0001", "chris", "VOD.L", 1311544800000L, 101, "NYC-0001VOD.L"),
+          ("NYC-0002", "chris", "VOD.L", 1311544800000L, 102, "NYC-0002VOD.L"),
+          ("NYC-0003", "chris", "VOD.L", 1311544800000L, 103, "NYC-0003VOD.L"),
+          ("NYC-0004", "chris", "VOD.L", 1311544800000L, 104, "NYC-0004VOD.L"),
+          ("NYC-0005", "chris", "VOD.L", 1311544800000L, 105, "NYC-0005VOD.L"),
+          ("NYC-0006", "chris", "VOD.L", 1311544800000L, 106, "NYC-0006VOD.L"),
+          ("NYC-0007", "chris", "VOD.L", 1311544800000L, 107, "NYC-0007VOD.L"),
+          ("NYC-0008", "chris", "VOD.L", 1311544800000L, 108, "NYC-0008VOD.L"),
+          ("NYC-0009", "chris", "VOD.L", 1311544800000L, 109, "NYC-0009VOD.L")
         )
       }
 
     }
+
+    Scenario("Check calc columns on joined tables") {
+
+      implicit val lifecycle: LifecycleContainer = new LifecycleContainer
+
+      val dateTime = 1437728400000L
+
+      val ordersDef = TableDef(
+        name = "orders",
+        keyField = "orderId",
+        columns = Columns.fromNames("orderId:String", "trader:String", "ric:String", "tradeTime:Long", "quantity:Double"),
+        joinFields = "ric", "orderId")
+
+      val pricesDef = TableDef("prices", "ric", Columns.fromNames("ric:String", "bid:Double", "ask:Double", "last:Double", "open:Double", "close:Double"), "ric")
+
+      val joinDef = JoinTableDef(
+        name = "orderPrices",
+        baseTable = ordersDef,
+        joinColumns = Columns.allFrom(ordersDef) ++ Columns.allFromExcept(pricesDef, "ric"),
+        joins =
+          JoinTo(
+            table = pricesDef,
+            joinSpec = JoinSpec(left = "ric", right = "ric", LeftOuterJoin)
+          ),
+        joinFields = Seq()
+      )
+
+      val joinProvider = JoinTableProviderImpl()
+
+      val tableContainer = new TableContainer(joinProvider)
+
+      val orders = tableContainer.createTable(ordersDef)
+      val prices = tableContainer.createTable(pricesDef)
+      val orderPrices = tableContainer.createJoinTable(joinDef)
+
+      val ordersProvider = new MockProvider(orders)
+      val pricesProvider = new MockProvider(prices)
+
+      val providerContainer = new ProviderContainer(joinProvider)
+
+      val viewPortContainer = setupViewPort(tableContainer, providerContainer)
+
+      joinProvider.start()
+
+      ordersProvider.tick("NYC-0001", Map("orderId" -> "NYC-0001", "trader" -> "chris", "tradeTime" -> dateTime, "quantity" -> 100D, "ric" -> "VOD.L"))
+      pricesProvider.tick("VOD.L", Map("ric" -> "VOD.L", "bid" -> 220.0, "ask" -> 222.0, "last" -> 30))
+
+      pricesProvider.tick("BT.L", Map("ric" -> "BT.L", "bid" -> 500.0, "ask" -> 501.0, "last" -> 40))
+      ordersProvider.tick("NYC-0002", Map("orderId" -> "NYC-0002", "trader" -> "chris", "tradeTime" -> dateTime, "quantity" -> 100D, "ric" -> "BT.L"))
+
+      joinProvider.runOnce()
+
+      val session = ClientSessionId("sess-01", "chris")
+
+      val outQueue = new OutboundRowPublishQueue()
+
+      val vpcolumns = ViewPortColumnCreator.create(orderPrices, List("orderId", "trader", "tradeTime", "quantity", "ric", "bid", "ask", "qtyBid:Double:=quantity * bid")) //.map(orderPrices.getTableDef.columnForName(_)).toList
+
+      val viewPort = viewPortContainer.create(RequestId.oneNew(), session, outQueue, orderPrices, DefaultRange, vpcolumns)
+
+      viewPortContainer.runOnce()
+
+      val combinedUpdates = combineQs(viewPort)
+
+      When("we pull rows with a calc column as array we don't get a failure")
+      val rows = combinedUpdates
+        .filter(vpu => vpu.vpUpdate == RowUpdateType)
+        .map(vpu => orderPrices.pullRowAsArray(vpu.key.key, vpcolumns).toList )
+        .toList
+
+      rows should equal(List(
+        List("NYC-0001", "chris", 1437728400000L, 100.0D, "VOD.L", 220.0D, 222.0D, 22000.0D),
+        List("NYC-0002", "chris", 1437728400000L, 100.0D, "BT.L", 500.0D, 501.0D, 50000.0D),
+      ))
+    }
   }
 }
+


### PR DESCRIPTION
Added fix for calculated columns running on join tables. Previously the pullRow and the pullRowAsArray calls were implemented differently. The pullRowAsArray call now delegates to the pullRow and transforms row into array. 

There may be slight performance impacts to this, however it resolves calculated columns on joins, which is more important. 