### PR TITLE
#989 fix for calculating start and end index for ignite query

### DIFF
--- a/example/apache-ignite/src/main/scala/org/finos/vuu/example/ignite/query/IndexCalculator.scala
+++ b/example/apache-ignite/src/main/scala/org/finos/vuu/example/ignite/query/IndexCalculator.scala
@@ -1,0 +1,25 @@
+package org.finos.vuu.example.ignite.query
+
+import org.finos.vuu.viewport.ViewPortRange
+
+object IndexCalculator {
+  def apply(extraRowsCount : Int) : IndexCalculator =
+    new IndexCalculator(extraRowsCount)
+}
+
+class IndexCalculator(extraRowCount:Int) {
+  private val extraRowsCount = extraRowCount //fetch extra rows to reduce need to re-fetch when view port change by small amount
+  private type StartIndex = Int
+  private type EndIndex = Int
+  private type RowCount = Int
+  def calc(viewPortRange: ViewPortRange, totalSize: Int): (StartIndex, EndIndex, RowCount) = {
+
+    val startIndex = Math.max(viewPortRange.from - extraRowsCount, 0)
+    val endIndex = Math.min(viewPortRange.to + extraRowsCount, totalSize)
+    val rowCount =
+      if (startIndex == 0 && endIndex==0) 0
+      else if (endIndex == startIndex) 1
+      else endIndex - startIndex
+    (startIndex, endIndex, rowCount)
+  }
+}

--- a/example/apache-ignite/src/test/scala/org/finos/vuu/example/ignite/query/CalcIndexTest.scala
+++ b/example/apache-ignite/src/test/scala/org/finos/vuu/example/ignite/query/CalcIndexTest.scala
@@ -1,0 +1,58 @@
+package org.finos.vuu.example.ignite.query
+
+import org.finos.vuu.viewport.ViewPortRange
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.matchers.should.Matchers
+
+class CalcIndexTest extends AnyFunSuiteLike with Matchers {
+
+  test("Get index given view port range is at start") {
+    val (starIndex, endIndex, rowCount) =
+      IndexCalculator(extraRowsCount = 10)
+        .calc(ViewPortRange(from = 0, to = 100), totalSize = 1000)
+
+    starIndex shouldEqual 0
+    endIndex shouldEqual 110
+    rowCount shouldEqual 110
+  }
+
+  test("Get index given view port range is at middle") {
+    val (starIndex, endIndex, rowCount) =
+      IndexCalculator(extraRowsCount = 10)
+        .calc(ViewPortRange(from = 100, to = 200), totalSize = 1000)
+
+    starIndex shouldEqual 90
+    endIndex shouldEqual 210
+    rowCount shouldEqual 120
+  }
+
+  test("Get index given view port range is at end") {
+    val (starIndex, endIndex, rowCount) =
+      IndexCalculator(extraRowsCount = 10)
+        .calc(ViewPortRange(from = 900, to = 1000), totalSize = 1000)
+
+    starIndex shouldEqual 890
+    endIndex shouldEqual 1000
+    rowCount shouldEqual 110
+  }
+
+  test("Get single row given view port range of one") {
+    val (starIndex, endIndex, rowCount) =
+      IndexCalculator(extraRowsCount = 0)
+        .calc(ViewPortRange(from = 5, to = 5), totalSize = 1000)
+
+    starIndex shouldEqual 5
+    endIndex shouldEqual 5
+    rowCount shouldEqual 1
+  }
+
+  test("Get zero rows given view port range or zero") {
+    val (starIndex, endIndex, rowCount) =
+      IndexCalculator(extraRowsCount = 0)
+        .calc(ViewPortRange(from = 0, to = 0), totalSize = 1000)
+
+    starIndex shouldEqual 0
+    endIndex shouldEqual 0
+    rowCount shouldEqual 0
+  }
+}


### PR DESCRIPTION
refactored the index calc code to add unit testing
cap the end index by the table size