### PR TITLE
reset datasource range on ui remount

### DIFF
--- a/vuu-ui/packages/vuu-table-extras/src/datasource-stats/DatasourceStats.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/datasource-stats/DatasourceStats.tsx
@@ -21,9 +21,12 @@ export const DataSourceStats = ({
   const [size, setSize] = useState(dataSource.size);
   useEffect(() => {
     setSize(dataSource.size);
-
     dataSource.on("resize", setSize);
     dataSource.on("range", setRange);
+    return () => {
+      dataSource.removeListener("resize", setSize);
+      dataSource.removeListener("range", setRange);
+    };
   }, [dataSource]);
 
   const className = cx(classBase, classNameProp);

--- a/vuu-ui/packages/vuu-table/src/useDataSource.ts
+++ b/vuu-ui/packages/vuu-table/src/useDataSource.ts
@@ -55,7 +55,7 @@ export const useDataSource = ({
         // TODO do we ever need to worry about missing updates here ?
         forceUpdate({});
       } else {
-        console.log(`ignore update as we're not mounted`);
+        // do nothing
       }
     },
     [dataWindow]

--- a/vuu-ui/sample-apps/feature-filter-table/src/useFilterTable.tsx
+++ b/vuu-ui/sample-apps/feature-filter-table/src/useFilterTable.tsx
@@ -272,7 +272,7 @@ export const useFilterTable = ({ tableSchema }: FilterTableFeatureProps) => {
     onAvailableColumnsChange: handleAvailableColumnsChange,
     onConfigChange: handleTableConfigChange,
     onFeatureInvocation: handleVuuFeatureInvoked,
-    renderBufferSize: 10,
+    renderBufferSize: 20,
   };
 
   // It is important that these values are not assigned in advance. They

--- a/vuu-ui/sample-apps/feature-filter-table/src/useSessionDataSource.ts
+++ b/vuu-ui/sample-apps/feature-filter-table/src/useSessionDataSource.ts
@@ -4,7 +4,7 @@ import {
   DataSourceConfig,
   TableSchema,
 } from "@finos/vuu-data-types";
-import { configChanged } from "@finos/vuu-utils";
+import { configChanged, resetRange } from "@finos/vuu-utils";
 import { useViewContext } from "@finos/vuu-layout";
 import { useCallback, useMemo } from "react";
 
@@ -43,7 +43,7 @@ export const useSessionDataSource = ({
     let ds = loadSession?.(dataSourceSessionKey) as VuuDataSource;
     if (ds) {
       console.log(
-        "%useSessionDataSource DATA SOURCE IN SESSION STATE",
+        "%cuseSessionDataSource DATA SOURCE IN SESSION STATE",
         "color:red;font-weight:bold;"
       );
 
@@ -60,6 +60,11 @@ export const useSessionDataSource = ({
         ds.applyConfig(dataSourceConfigFromState);
       }
 
+      if (ds.range.from > 0) {
+        // UI does not currently restore scroll position, so always reset to top of dataset
+        ds.range = resetRange(ds.range);
+      }
+
       return ds;
     }
 
@@ -68,8 +73,7 @@ export const useSessionDataSource = ({
       tableSchema.columns.map((col) => col.name);
 
     ds = new VuuDataSource({
-      bufferSize: 0,
-      // bufferSize: 200,
+      // bufferSize: 0,
       viewport: id,
       table: tableSchema.table,
       ...dataSourceConfigFromState,


### PR DESCRIPTION
The UI Table does not currently maintain scroll position across remount. So, if table is rendered in tabbed display and user switches to another tab, then switches back, if the user had previously scrolled away from top of table, scroll position would now be reset to top.
The dataSource DOES currently remember the viewport position, so on remount we need to reset it to top of dataset.
ALternatively (and probably better) we could restore the scroll position. Thats a bit more involved, though, so current fix will do for now.