### PR TITLE
#1184 use single JsonMapper for JsonUtil object methods

### DIFF
--- a/toolbox/src/main/scala/org/finos/toolbox/json/JsonUtil.scala
+++ b/toolbox/src/main/scala/org/finos/toolbox/json/JsonUtil.scala
@@ -1,33 +1,20 @@
 package org.finos.toolbox.json
 
 import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule, JavaTypeable}
 
 object JsonUtil {
-    def toPrettyJson(o: Object): String = {
-      val mapper = new ObjectMapper()
-      mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
-      mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
-      mapper.registerModule(DefaultScalaModule)
-      mapper.writerWithDefaultPrettyPrinter().writeValueAsString(o)
-    }
-
-  def toRawJson(o: Object): String = {
-    val mapper = new ObjectMapper()
-    mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
-    mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
-    mapper.registerModule(DefaultScalaModule)
-    mapper.writer().writeValueAsString(o)
-  }
-
-  def fromJson[T: JavaTypeable](str: String): T = FromJson.mapper.readValue[T](str)
-}
-
-private object FromJson {
   val mapper: JsonMapper with ClassTagExtensions = JsonMapper
     .builder()
+    .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
+    .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
     .addModule(DefaultScalaModule)
     .build() :: ClassTagExtensions
+
+  def toPrettyJson(o: Object): String = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(o)
+
+  def toRawJson(o: Object): String = mapper.writer().writeValueAsString(o)
+
+  def fromJson[T: JavaTypeable](str: String): T = mapper.readValue[T](str)
 }

--- a/toolbox/src/test/scala/org/finos/toolbox/json/JsonUtilTest.scala
+++ b/toolbox/src/test/scala/org/finos/toolbox/json/JsonUtilTest.scala
@@ -1,8 +1,9 @@
 package org.finos.toolbox.json
 
-import org.finos.toolbox.json.JsonUtil.{fromJson, toRawJson}
+import org.finos.toolbox.json.JsonUtil.{fromJson, toPrettyJson, toRawJson}
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks.{Table, forAll}
 
 class JsonUtilTest extends AnyFeatureSpec with Matchers {
 
@@ -16,13 +17,43 @@ class JsonUtilTest extends AnyFeatureSpec with Matchers {
     }
   }
 
+  Feature("toPrettyJson") {
+    Scenario("can convert an instance of a case class to pretty json string") {
+      val dto = TestDto(name = "orange", value = 13.7, quantity = Some(5))
+
+      val result = toPrettyJson(dto)
+
+      result shouldEqual "{\n  \"name\" : \"orange\",\n  \"value\" : 13.7,\n  \"quantity\" : 5\n}"
+    }
+  }
+
   Feature("fromJson") {
-    Scenario("can create an instance of a case class from json string") {
-      val jsonAsString = """{"name": "apple", "value": 20.5, "quantity": 7}"""
+    forAll(Table(
+      ("scenario", "json-as-string"),
+      ("json with double-quotes", """{"name": "apple", "value": 20.5, "quantity": 7}"""),
+      ("json with single-quotes", """{'name': 'apple', 'value': 20.5, 'quantity': 7}"""),
+      ("json with unquoted field names", """{name: "apple", value: 20.5, quantity: 7}"""),
+      ("json with mixed single & double quotes", """{'name': "apple", "value": 20.5, 'quantity': 7}"""),
+      ("json with quoted and non-quoted field names", """{name: 'apple', "value": 20.5, 'quantity': 7}"""),
+    ))((scenario, jsonAsString) => {
+      Scenario(s"can create an instance of a case class from `$scenario`") {
+        val result = fromJson[TestDto](jsonAsString)
+        result shouldEqual TestDto(name = "apple", value = 20.5, quantity = Some(7))
+      }
+    })
 
-      val result = fromJson[TestDto](jsonAsString)
+    Scenario("can generate an array of DTOs from a json array") {
+      val jsonArray ="""[
+          |{"name": "apple", "value": 20.5, "quantity": 15},
+          |{"name": "orange", "value": 0.45, "quantity": 7}
+          |]""".stripMargin
 
-      result shouldEqual TestDto(name = "apple", value = 20.5, quantity = Some(7))
+      val result = fromJson[List[TestDto]](jsonArray)
+
+      result shouldEqual List(
+        TestDto(name = "apple", value = 20.5, quantity = Some(15)),
+        TestDto(name = "orange", value = 0.45, quantity = Some(7))
+      )
     }
 
     Scenario("falls back to `None` when an `Option` field is missing") {


### PR DESCRIPTION
### Changes
We were instantiating an ObjectMapper everytime toRawJson or toPrettyRawJson methods were being called, which is wasteful. With this change we
  1) instantiate the mapper once on JsonUtil object creation
  2) share the same mapper between all methods
  3) use JsonMapper, a JSON specific implementation of ObjectMapper