### PR TITLE
#1195 enable metric tracking for each instance of session table

### DIFF
--- a/toolbox/src/main/scala/org/finos/toolbox/lifecycle/LifecycleContainer.scala
+++ b/toolbox/src/main/scala/org/finos/toolbox/lifecycle/LifecycleContainer.scala
@@ -226,7 +226,7 @@ class LifecycleContainer(implicit clock: Clock) extends StrictLogging {
   val thread = new Runner("lifeCycleJoinRunner", () => {Thread.sleep(1000)})
   thread.runInBackground()
 
-  val dependencyGraph = new DirectedAcyclicGraph[LifecycleEnabled]()
+  private val dependencyGraph = new DirectedAcyclicGraph[LifecycleEnabled]()
 
   def autoShutdownHook(): Unit = {
     val container = this
@@ -238,25 +238,6 @@ class LifecycleContainer(implicit clock: Clock) extends StrictLogging {
     }, "lcShutdownHook"))
   }
 
-  case class LifeCycleComponentContext(comp: LifecycleEnabled, container: LifecycleContainer){
-    def dependsOn(comp2: LifecycleEnabled): Unit = {
-      if(!dependencyGraph.containsEdge(comp, comp2))
-        dependencyGraph.addEdge(comp, comp2)
-      else
-        logger.warn(s"lifecycle already contains edge $comp, $comp2")
-    }
-
-    def dependsOn(comps: LifecycleEnabled*): Unit = {
-
-      comps.foreach( c => {
-        if(!dependencyGraph.containsEdge(comp, c))
-          dependencyGraph.addEdge(comp, c)
-        else
-          logger.warn(s"lifecycle already contains edge $comp, $c")
-      })
-    }
-  }
-
   def apply(comp: LifecycleEnabled): LifeCycleComponentContext = {
 
     if(!dependencyGraph.containsNode(comp))
@@ -264,7 +245,7 @@ class LifecycleContainer(implicit clock: Clock) extends StrictLogging {
     else
     logger.warn(s"lifecycle already contains component $comp")
 
-    new LifeCycleComponentContext(comp, this)
+    LifeCycleComponentContext(comp, this, dependencyGraph)
   }
 
   def add(component: LifecycleEnabled): Unit = {}
@@ -318,5 +299,25 @@ class LifecycleContainer(implicit clock: Clock) extends StrictLogging {
     startSequence.foreach( list => stopOneBucket(list) )
     startSequence.foreach( list => destroyOneBucket(list) )
     logger.debug("Shutdown lifecycle")
+  }
+}
+
+case class LifeCycleComponentContext(comp: LifecycleEnabled,
+                                     container: LifecycleContainer,
+                                     dependencyGraph:  DirectedAcyclicGraph[LifecycleEnabled]) extends StrictLogging {
+  def dependsOn(comp2: LifecycleEnabled): Unit = {
+    if (!dependencyGraph.containsEdge(comp, comp2))
+      dependencyGraph.addEdge(comp, comp2)
+    else
+      logger.warn(s"lifecycle already contains edge $comp, $comp2")
+  }
+
+  def dependsOn(comps: LifecycleEnabled*): Unit = {
+    comps.foreach(c => {
+      if (!dependencyGraph.containsEdge(comp, c))
+        dependencyGraph.addEdge(comp, c)
+      else
+        logger.warn(s"lifecycle already contains edge $comp, $c")
+    })
   }
 }

--- a/toolbox/src/main/scala/org/finos/toolbox/lifecycle/LifecycleContainer.scala
+++ b/toolbox/src/main/scala/org/finos/toolbox/lifecycle/LifecycleContainer.scala
@@ -243,7 +243,7 @@ class LifecycleContainer(implicit clock: Clock) extends StrictLogging {
     if(!dependencyGraph.containsNode(comp))
       dependencyGraph.addNode(comp)
     else
-    logger.warn(s"lifecycle already contains component $comp")
+      logger.warn(s"lifecycle already contains component $comp")
 
     LifeCycleComponentContext(comp, this, dependencyGraph)
   }

--- a/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
@@ -174,7 +174,7 @@ class CoreServerApiHandler(val viewPortContainer: ViewPortContainer,
   }
 
   override def process(msg: GetTableList)(ctx: RequestContext): Option[ViewServerMessage] = {
-    vsMsg(GetTableListResponse(tableContainer.getNonSessionTables))(ctx)
+    vsMsg(GetTableListResponse(tableContainer.getDefinedTables))(ctx)
   }
 
   override def process(msg: RpcUpdate)(ctx: RequestContext): Option[ViewServerMessage] = {

--- a/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsTableProvider.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsTableProvider.scala
@@ -7,11 +7,12 @@ import org.finos.toolbox.jmx.MetricsProvider
 import org.finos.toolbox.lifecycle.LifecycleContainer
 import org.finos.toolbox.thread.LifeCycleRunner
 import org.finos.toolbox.time.Clock
+import org.finos.vuu.viewport.ViewPortTable
 
 class MetricsTableProvider(table: DataTable, tableContainer: TableContainer)(implicit clock: Clock, lifecycleContainer: LifecycleContainer,
                                                                              metrics: MetricsProvider) extends Provider with StrictLogging {
 
-  private val runner = new LifeCycleRunner("metricsTableProvider", () => runOnce, minCycleTime = 1_000)
+  private val runner = new LifeCycleRunner("metricsTableProvider", () => runOnce(), minCycleTime = 1_000)
 
   lifecycleContainer(this).dependsOn(runner)
 
@@ -28,27 +29,25 @@ class MetricsTableProvider(table: DataTable, tableContainer: TableContainer)(imp
   override val lifecycleId: String = "metricsTableProvider"
 
   def runOnce(): Unit = {
-
     try {
-
-      val tables = tableContainer.getTables()
-
-      tables.foreach(tableDef => {
-
-        val counter = metrics.counter(tableDef.table + ".processUpdates.Counter");
-        val size = tableContainer.getTable(tableDef.table).size()
-
-        val meter = metrics.meter(tableDef.table + ".processUpdates.Meter")
-
-        val upMap = Map("table" -> (tableDef.module + "-" + tableDef.table), "updateCount" -> counter.getCount, "size" -> size, "updatesPerSecond" -> meter.getOneMinuteRate);
-
-        table.processUpdate(tableDef.table, RowWithData(tableDef.table, upMap), clock.now())
-
-      })
-
+      tableContainer.getTables().foreach(vpTable =>
+        table.processUpdate(vpTable.table, RowWithData(vpTable.table, getMetricsData(vpTable)), clock.now())
+      )
     } catch {
-      case e: Exception =>
-        logger.error("Error occured in metrics", e)
+      case e: Exception => logger.error("Error occured in metrics", e)
     }
+  }
+
+  private def getMetricsData(vpTable: ViewPortTable): Map[String, Any] = {
+    val counter = metrics.counter(vpTable.table + ".processUpdates.Counter")
+    val size = tableContainer.getTable(vpTable.table).size()
+    val meter = metrics.meter(vpTable.table + ".processUpdates.Meter")
+
+    Map(
+      "table" -> (vpTable.module + "-" + vpTable.table),
+      "updateCount" -> counter.getCount,
+      "size" -> size,
+      "updatesPerSecond" -> meter.getOneMinuteRate
+    )
   }
 }

--- a/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsTableProvider.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsTableProvider.scala
@@ -30,7 +30,7 @@ class MetricsTableProvider(table: DataTable, tableContainer: TableContainer)(imp
 
   def runOnce(): Unit = {
     try {
-      tableContainer.getTables().foreach(vpTable =>
+      tableContainer.getTables.foreach(vpTable =>
         table.processUpdate(vpTable.table, RowWithData(vpTable.table, getMetricsData(vpTable)), clock.now())
       )
     } catch {

--- a/vuu/src/main/scala/org/finos/vuu/core/table/InMemDataTable.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/InMemDataTable.scala
@@ -1,6 +1,6 @@
 package org.finos.vuu.core.table
 
-import org.finos.vuu.api.{SessionTableDef, TableDef}
+import org.finos.vuu.api.TableDef
 import org.finos.vuu.core.index._
 import org.finos.vuu.provider.{JoinTableProvider, Provider}
 import org.finos.vuu.viewport.{RowProcessor, RowSource, ViewPortColumns}
@@ -8,12 +8,10 @@ import org.finos.toolbox.collection.array.ImmutableArray
 import org.finos.toolbox.jmx.MetricsProvider
 import org.finos.toolbox.text.AsciiUtil
 import org.finos.vuu.feature.inmem.InMemTablePrimaryKeys
-import org.finos.vuu.net.ClientSessionId
 
 import java.util
 import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConverters
-import scala.jdk.CollectionConverters
 
 
 trait DataTable extends KeyedObservable[RowKeyUpdate] with RowSource {
@@ -242,7 +240,7 @@ class InMemDataTable(val tableDef: TableDef, val joinProvider: JoinTableProvider
     }
   }
 
-  def plusName(s: String): String = tableDef.name + "." + s
+  def plusName(s: String): String = name + "." + s
 
   override protected def createDataTableData(): TableData = {
     InMemDataTableData(new ConcurrentHashMap[String, RowData](), InMemTablePrimaryKeys(ImmutableArray.empty))

--- a/vuu/src/main/scala/org/finos/vuu/core/table/InMemSessionDataTable.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/InMemSessionDataTable.scala
@@ -6,11 +6,18 @@ import org.finos.vuu.api.SessionTableDef
 import org.finos.vuu.net.ClientSessionId
 import org.finos.vuu.provider.JoinTableProvider
 
-class InMemSessionDataTable(val clientSessionId: ClientSessionId, sessionTableDef: SessionTableDef, joinTableProvider: JoinTableProvider)(implicit metrics: MetricsProvider, clock: Clock) extends InMemDataTable(sessionTableDef, joinTableProvider)(metrics) with SessionTable {
+class InMemSessionDataTable private (val clientSessionId: ClientSessionId,
+                                     sessionTableDef: SessionTableDef,
+                                     joinTableProvider: JoinTableProvider,
+                                     final val creationTimestamp: Long)
+                                    (implicit metrics: MetricsProvider) extends InMemDataTable(sessionTableDef, joinTableProvider) with SessionTable {
 
-  final val createInstant = clock.now()
-  override def name: String = s"session:$clientSessionId/simple-" + sessionTableDef.name + "_" + createInstant.toString
-  def tableId: String = name + "@" + hashCode()
+  def this(clientSessionId: ClientSessionId, sessionTableDef: SessionTableDef, joinTableProvider: JoinTableProvider)
+          (implicit metrics: MetricsProvider, clock: Clock) = {
+    this(clientSessionId, sessionTableDef, joinTableProvider, creationTimestamp = clock.now())
+  }
+
+  override def name: String = s"session:$clientSessionId/simple-" + sessionTableDef.name + "_" + creationTimestamp.toString
 
   override def sessionId: ClientSessionId = clientSessionId
 

--- a/vuu/src/main/scala/org/finos/vuu/core/table/TableContainer.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/TableContainer.scala
@@ -72,7 +72,9 @@ class TableContainer(val joinTableProvider: JoinTableProvider)(implicit val metr
   def getTables(): Array[ViewPortTable] = {
     val tableList = IteratorHasAsScala(tables.values().iterator()).asScala
     tableList
-      .map(table => ViewPortTable(table.getTableDef.name, if (table.getTableDef.getModule() != null) table.getTableDef.getModule().name else "null")).toArray[ViewPortTable].sortBy(_.table)
+      .map(table => ViewPortTable(table.name, Option(table.getTableDef.getModule()).map(_.name).getOrElse("null")))
+      .toArray[ViewPortTable]
+      .sortBy(_.table)
   }
 
   def getNonSessionTables: Array[ViewPortTable] = {

--- a/vuu/src/main/scala/org/finos/vuu/core/table/TableContainer.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/TableContainer.scala
@@ -8,6 +8,7 @@ import org.finos.vuu.provider.JoinTableProvider
 import org.finos.vuu.viewport.{RowSource, ViewPortTable}
 import org.finos.toolbox.jmx.{JmxAble, MetricsProvider}
 import org.finos.toolbox.time.Clock
+import org.finos.vuu.core.table.TableContainer.{isSessionTable, isSessionTableBlueprint, moduleName}
 
 import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters._
@@ -19,7 +20,7 @@ trait TableContainerMBean {
 
   def toAsciiRange(name: String, start: Int, end: Int): String
 
-  def getTables(): Array[ViewPortTable]
+  def getTables: Array[ViewPortTable]
 
   def getSubscribedKeys(name: String): String
 }
@@ -64,31 +65,27 @@ class TableContainer(val joinTableProvider: JoinTableProvider)(implicit val metr
     IteratorHasAsScala(tables.keySet().iterator()).asScala.mkString("\n")
   }
 
-  //  override def sessionTableList: String = {
-  //    import scala.collection.JavaConversions._
-  //    sessionTables.keySet().iterator().mkString("\n")
-  //  }
-
-  def getTables(): Array[ViewPortTable] = {
-    val tableList = IteratorHasAsScala(tables.values().iterator()).asScala
-    tableList
-      .map(table => ViewPortTable(table.name, Option(table.getTableDef.getModule()).map(_.name).getOrElse("null")))
+  /**
+   * Gets actual tables excluding any blueprints.
+   */
+  def getTables: Array[ViewPortTable] = {
+    tables.asScala.values
+      .filter(!isSessionTableBlueprint(_))
+      .map(table => ViewPortTable(table.name, moduleName(table)))
       .toArray[ViewPortTable]
       .sortBy(_.table)
   }
 
-  def getNonSessionTables: Array[ViewPortTable] = {
-    val tableList = IteratorHasAsScala(tables.values().iterator()).asScala
-    tableList
-      //.filter(!isSessionTable(_))
-      .map(table => ViewPortTable(table.getTableDef.name, if (table.getTableDef.getModule() != null) table.getTableDef.getModule().name else "null")).toArray[ViewPortTable].sortBy(_.table)
+  /**
+   * Gets tables with unique definitions - excludes session tables but includes its blueprint.
+   */
+  def getDefinedTables: Array[ViewPortTable] = {
+    tables.asScala.values
+      .filter(!isSessionTable(_))
+      .map(table => ViewPortTable(table.getTableDef.name, moduleName(table)))
+      .toArray[ViewPortTable]
+      .sortBy(_.table)
   }
-
-  private def isSessionTable(table: DataTable): Boolean = {
-    table.getTableDef.isInstanceOf[SessionTableDef] || table.getTableDef.isInstanceOf[JoinSessionTableDef] ||
-      table.isInstanceOf[SessionTable]
-  }
-
 
   def getTable(name: String): DataTable = {
     tables.get(name)
@@ -161,4 +158,15 @@ class TableContainer(val joinTableProvider: JoinTableProvider)(implicit val metr
     sessionTables.foreach(sessTable => tables.remove(sessTable.name))
   }
 
+}
+
+object TableContainer {
+  private def isSessionTable(table: DataTable): Boolean = table.isInstanceOf[SessionTable]
+
+  private def isSessionTableBlueprint(table: DataTable): Boolean = {
+    !isSessionTable(table) &&
+      (table.getTableDef.isInstanceOf[SessionTableDef] || table.getTableDef.isInstanceOf[JoinSessionTableDef])
+  }
+
+  private def moduleName(table: DataTable): String = Option(table.getTableDef.getModule()).map(_.name).getOrElse("null")
 }

--- a/vuu/src/main/scala/org/finos/vuu/viewport/InMemViewPortTableCreator.scala
+++ b/vuu/src/main/scala/org/finos/vuu/viewport/InMemViewPortTableCreator.scala
@@ -1,10 +1,9 @@
 package org.finos.vuu.viewport
 
-import io.vertx.core.spi.metrics.Metrics
 import org.finos.toolbox.jmx.MetricsProvider
 import org.finos.toolbox.time.Clock
 import org.finos.vuu.api.SessionTableDef
-import org.finos.vuu.core.table.{InMemDataTable, InMemSessionDataTable, SessionTable, TableContainer}
+import org.finos.vuu.core.table.{InMemDataTable, InMemSessionDataTable, TableContainer}
 import org.finos.vuu.feature.ViewPortTableCreator
 import org.finos.vuu.net.ClientSessionId
 

--- a/vuu/src/test/scala/org/finos/vuu/core/module/metrics/MetricsTableProviderTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/module/metrics/MetricsTableProviderTest.scala
@@ -3,10 +3,8 @@ package org.finos.vuu.core.module.metrics
 import org.finos.toolbox.jmx.{MetricsProvider, MetricsProviderImpl}
 import org.finos.toolbox.lifecycle.{LifeCycleComponentContext, LifecycleContainer, LifecycleEnabled}
 import org.finos.toolbox.time.{Clock, TestFriendlyClock}
-import org.finos.vuu.api.{Indices, TableDef, VisualLinks}
-import org.finos.vuu.core.module.ModuleFactory.stringToString
-import org.finos.vuu.core.module.metrics.MetricsTableProviderTest.{createMockTable, createTestTableDef}
-import org.finos.vuu.core.table.{Column, Columns, DataTable, TableContainer}
+import org.finos.vuu.core.table.{DataTable, TableContainer}
+import org.finos.vuu.core.table.TableMockFactory._
 import org.finos.vuu.test.TestFriendlyJoinTableProvider
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.featurespec.AnyFeatureSpec
@@ -28,32 +26,18 @@ class MetricsTableProviderTest extends AnyFeatureSpec with Matchers with MockFac
 
   Feature("runOnce") {
     Scenario("can get and update expected list of tables") {
-      tableContainer.createTable(createTestTableDef(name = "instruments"))
-      tableContainer.addTable(createMockTable(tableName = "instrumentsSessionTable_1", tableDefName = "instruments"))
-      tableContainer.addTable(createMockTable(tableName = "instrumentsSessionTable_2", tableDefName = "instruments"))
-      tableContainer.createTable(createTestTableDef(name = "other"))
+      tableContainer.addTable(createMockTable(tableName = "instruments", tableDefName = "instruments", sessionDef = true)) // session table blueprint
+      tableContainer.addTable(createMockSessionTable(tableName = "instrumentsSessionTable_1", tableDefName = "instruments"))
+      tableContainer.addTable(createMockSessionTable(tableName = "instrumentsSessionTable_2", tableDefName = "instruments"))
+      tableContainer.addTable(createMockTable(tableName = "fills_table", tableDefName = "fills"))
+      tableContainer.addTable(createMockTable(tableName = "other", tableDefName = "other"))
 
       metricsTableProvider.runOnce()
 
-      (mockTable.processUpdate _).verify("instruments", *, *).once
       (mockTable.processUpdate _).verify("instrumentsSessionTable_1", *, *).once
       (mockTable.processUpdate _).verify("instrumentsSessionTable_2", *, *).once
+      (mockTable.processUpdate _).verify("fills_table", *, *).once
       (mockTable.processUpdate _).verify("other", *, *).once
     }
-  }
-}
-
-object MetricsTableProviderTest extends MockFactory {
-  private def createTestTableDef(name: String,
-                                 keyField: String = "id",
-                                 columns: Array[Column] = Columns.fromNames("id".long(), "field".string())): TableDef = {
-    new TableDef(name, keyField, columns, Seq.empty, false, VisualLinks(), Indices())
-  }
-
-  private def createMockTable(tableName: String, tableDefName: String): DataTable = {
-    val table = stub[DataTable]
-    (table.name _).when().returns(tableName)
-    (table.getTableDef _).when().returns(createTestTableDef(tableDefName))
-    table
   }
 }

--- a/vuu/src/test/scala/org/finos/vuu/core/module/metrics/MetricsTableProviderTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/module/metrics/MetricsTableProviderTest.scala
@@ -1,0 +1,59 @@
+package org.finos.vuu.core.module.metrics
+
+import org.finos.toolbox.jmx.{MetricsProvider, MetricsProviderImpl}
+import org.finos.toolbox.lifecycle.{LifeCycleComponentContext, LifecycleContainer, LifecycleEnabled}
+import org.finos.toolbox.time.{Clock, TestFriendlyClock}
+import org.finos.vuu.api.{Indices, TableDef, VisualLinks}
+import org.finos.vuu.core.module.ModuleFactory.stringToString
+import org.finos.vuu.core.module.metrics.MetricsTableProviderTest.{createMockTable, createTestTableDef}
+import org.finos.vuu.core.table.{Column, Columns, DataTable, TableContainer}
+import org.finos.vuu.test.TestFriendlyJoinTableProvider
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+
+class MetricsTableProviderTest extends AnyFeatureSpec with Matchers with MockFactory {
+  private implicit val metricsProvider: MetricsProvider = new MetricsProviderImpl()
+  private implicit val clock: Clock = new TestFriendlyClock(10001)
+  private implicit val lifecycleContainer: LifecycleContainer = stub[LifecycleContainer]
+  private val lifeCycleComponentContext = stub[LifeCycleComponentContext]
+  (lifecycleContainer.apply _).when(*).returns(lifeCycleComponentContext)
+  (lifeCycleComponentContext.dependsOn: LifecycleEnabled => Unit).when(*).returns()
+
+  private val joinProvider = new TestFriendlyJoinTableProvider()
+  private val mockTable = stub[DataTable]
+  private val tableContainer = new TableContainer(joinProvider)
+
+  private val metricsTableProvider = new MetricsTableProvider(mockTable, tableContainer)
+
+  Feature("runOnce") {
+    Scenario("can get and update expected list of tables") {
+      tableContainer.createTable(createTestTableDef(name = "instruments"))
+      tableContainer.addTable(createMockTable(tableName = "instrumentsSessionTable_1", tableDefName = "instruments"))
+      tableContainer.addTable(createMockTable(tableName = "instrumentsSessionTable_2", tableDefName = "instruments"))
+      tableContainer.createTable(createTestTableDef(name = "other"))
+
+      metricsTableProvider.runOnce()
+
+      (mockTable.processUpdate _).verify("instruments", *, *).once
+      (mockTable.processUpdate _).verify("instrumentsSessionTable_1", *, *).once
+      (mockTable.processUpdate _).verify("instrumentsSessionTable_2", *, *).once
+      (mockTable.processUpdate _).verify("other", *, *).once
+    }
+  }
+}
+
+object MetricsTableProviderTest extends MockFactory {
+  private def createTestTableDef(name: String,
+                                 keyField: String = "id",
+                                 columns: Array[Column] = Columns.fromNames("id".long(), "field".string())): TableDef = {
+    new TableDef(name, keyField, columns, Seq.empty, false, VisualLinks(), Indices())
+  }
+
+  private def createMockTable(tableName: String, tableDefName: String): DataTable = {
+    val table = stub[DataTable]
+    (table.name _).when().returns(tableName)
+    (table.getTableDef _).when().returns(createTestTableDef(tableDefName))
+    table
+  }
+}

--- a/vuu/src/test/scala/org/finos/vuu/core/table/InMemSessionDataTableTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/InMemSessionDataTableTest.scala
@@ -1,0 +1,41 @@
+package org.finos.vuu.core.table
+
+import org.finos.toolbox.jmx.{MetricsProvider, MetricsProviderImpl}
+import org.finos.toolbox.time.{Clock, DefaultClock}
+import org.finos.vuu.api.{Indices, SessionTableDef}
+import org.finos.vuu.core.module.ModuleFactory.stringToString
+import org.finos.vuu.net.ClientSessionId
+import org.finos.vuu.test.TestFriendlyJoinTableProvider
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+
+class InMemSessionDataTableTest extends AnyFeatureSpec with Matchers {
+  private implicit val metricsProvider: MetricsProvider = new MetricsProviderImpl()
+  private implicit val clock: Clock = new DefaultClock()
+  private val clientSessionId = ClientSessionId(sessionId = "sessionId", user = "user")
+  private val joinProvider = new TestFriendlyJoinTableProvider()
+
+  private val sessionTableDef: SessionTableDef = new SessionTableDef(
+    name = "test-table",
+    keyField = "id",
+    columns = Columns.fromNames("id".long(), "field".string()),
+    indices = Indices(),
+    joinFields = Seq.empty
+  )
+
+  private val inMemSessionDataTable = new InMemSessionDataTable(clientSessionId, sessionTableDef, joinProvider)
+
+  Feature("Metrics update") {
+    Scenario("Should correctly update metrics WHEN processUpdate called") {
+      inMemSessionDataTable.processUpdate("1", RowWithData("1", Map("id" -> 1, "field" -> "value1")), clock.now())
+      inMemSessionDataTable.processUpdate("2", RowWithData("2", Map("id" -> 2, "field" -> "value2")), clock.now())
+
+      val counter = metricsProvider.counter(inMemSessionDataTable.name + ".processUpdates.Counter")
+      val meter = metricsProvider.meter(inMemSessionDataTable.name + ".processUpdates.Meter")
+
+      counter.getCount shouldEqual 2
+      meter.getCount shouldEqual 2
+    }
+  }
+
+}

--- a/vuu/src/test/scala/org/finos/vuu/core/table/TableContainerTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/TableContainerTest.scala
@@ -1,0 +1,108 @@
+package org.finos.vuu.core.table
+
+import org.finos.toolbox.jmx.{MetricsProvider, MetricsProviderImpl}
+import org.finos.toolbox.time.{Clock, TestFriendlyClock}
+import org.finos.vuu.api.{Indices, SessionTableDef, TableDef, VisualLinks}
+import org.finos.vuu.core.module.ViewServerModule
+import org.finos.vuu.core.table.TableMockFactory.{createMockSessionTable, createMockTable}
+import org.finos.vuu.test.TestFriendlyJoinTableProvider
+import org.finos.vuu.viewport.ViewPortTable
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+
+class TableContainerTest extends AnyFeatureSpec with Matchers with BeforeAndAfterEach {
+  implicit val metricsProvider: MetricsProvider = new MetricsProviderImpl()
+  implicit val clock: Clock = new TestFriendlyClock(10001)
+  private var tableContainer: TableContainer = _
+
+  private final val sessionTableBlueprint = createMockTable(tableName = "blueprint", tableDefName = "blueprint-def", sessionDef = true)
+  private final val sessionTable = createMockSessionTable(tableName = "session", tableDefName = "session-def")
+  private final val dataTable = createMockTable(tableName = "datatable", tableDefName = "datatable-def", moduleName = Option("z-module"))
+  private final val dataTable2 = createMockTable(tableName = "datatable-2", tableDefName = "datatable-2-def", moduleName = Option("a-module"))
+
+  override def beforeEach(): Unit = {
+    tableContainer = new TableContainer(new TestFriendlyJoinTableProvider())
+  }
+
+  Feature("getTables") {
+    Scenario("filters out table blueprints") {
+      tableContainer.addTable(sessionTableBlueprint)
+      tableContainer.getTables shouldBe empty
+    }
+
+    Scenario("handles missing module by returning `null` as its name") {
+      tableContainer.addTable(sessionTable)
+      tableContainer.getTables shouldEqual Array(ViewPortTable(sessionTable.name, "null"))
+    }
+
+    Scenario("returns sorted result by table names including session tables and excluding blueprints") {
+      tableContainer.addTable(dataTable)
+      tableContainer.addTable(dataTable2)
+      tableContainer.addTable(sessionTable)
+      tableContainer.addTable(sessionTableBlueprint)
+
+      tableContainer.getTables shouldEqual Array(
+        ViewPortTable(dataTable.name, "z-module"),
+        ViewPortTable(dataTable2.name, "a-module"),
+        ViewPortTable(sessionTable.name, "null"),
+      )
+    }
+  }
+
+  Feature("getDefinedTables") {
+    Scenario("filters out session tables") {
+      tableContainer.addTable(sessionTable)
+      tableContainer.getDefinedTables shouldBe empty
+    }
+
+    Scenario("handles missing module by returning `null` as its name") {
+      tableContainer.addTable(sessionTableBlueprint)
+      tableContainer.getDefinedTables shouldEqual Array(ViewPortTable(table = sessionTableBlueprint.getTableDef.name, module = "null"))
+    }
+
+    Scenario("returns sorted result by tableDef names including blueprints excluding session tables") {
+      tableContainer.addTable(dataTable)
+      tableContainer.addTable(dataTable2)
+      tableContainer.addTable(sessionTable)
+      tableContainer.addTable(sessionTableBlueprint)
+
+      tableContainer.getDefinedTables shouldEqual Array(
+        ViewPortTable(sessionTableBlueprint.getTableDef.name, "null"),
+        ViewPortTable(dataTable2.getTableDef.name, "a-module"),
+        ViewPortTable(dataTable.getTableDef.name, "z-module"),
+      )
+    }
+  }
+
+}
+
+object TableMockFactory extends MockFactory {
+  private def createTestTableDef(name: String, moduleName: Option[String] = None, isSessionDef: Boolean = false): TableDef = {
+    val tableDef = if (isSessionDef) new SessionTableDef(name, "id", Array.empty, joinFields = Seq.empty, indices = Indices())
+                   else new TableDef(name, "id", Array.empty, Seq.empty, false, VisualLinks(), Indices())
+
+    if (moduleName.nonEmpty) {
+      val module = stub[ViewServerModule]
+      (module.name _).when().returns(moduleName.get)
+      tableDef.setModule(module)
+    }
+
+    tableDef
+  }
+
+  def createMockSessionTable(tableName: String, tableDefName: String): SessionTable = {
+    val table = stub[SessionTable]
+    (table.name _).when().returns(tableName)
+    (table.getTableDef _).when().returns(createTestTableDef(tableDefName, isSessionDef = true))
+    table
+  }
+
+  def createMockTable(tableName: String, tableDefName: String, moduleName: Option[String] = None, sessionDef: Boolean = false): DataTable = {
+    val table = stub[DataTable]
+    (table.name _).when().returns(tableName)
+    (table.getTableDef _).when().returns(createTestTableDef(tableDefName, moduleName, isSessionDef = sessionDef))
+    table
+  }
+}


### PR DESCRIPTION
Couple of issues that needed fixing:
  1. TableContainer.getTables() returned array where table name actually
     reflected the tableDef.name. Because of this returned session tables
     and its blueprints had same names and the metrics table only added
     one and it seemed as if we're only considering the archetype.
  2. this one was a bit more involved. First we were using tableDef.name
     to update metrics in InMemDataTable, hence, if we updated metrics for
     a session table it appeared as if we're updating for the archetype.
     Second, if we even had tried calling sessionTable.name in InMemDataTable
     to initialize the metric counters/meters it still would've not worked
     because in session table we used an instance variable `createInstant`
     (used in session-table name) which is not initialized at the time we
     call super class (InMemDataTable) constructor.

Also,
- renames getNonSessionTables to getDefinedTables since its intended
  to return unique table defs for the UI. Also, now it explicitly does that
  by filtering out session tables (i.e. non-unique table defs).
- getTables (for now) is intended to return actual tables and not the blueprints
  for MetricsTable. That's what it does now.

![Screenshot 2024-02-23 at 10 44 17 AM](https://github.com/finos/vuu/assets/62522218/3e924c6b-9d71-4a52-98e8-20ceed35576e)

