### PR TITLE
fix issue with Dropdown cell renderer

### DIFF
--- a/vuu-ui/packages/vuu-data-react/src/hooks/useLookupValues.ts
+++ b/vuu-ui/packages/vuu-data-react/src/hooks/useLookupValues.ts
@@ -63,7 +63,7 @@ type LookupState = {
   values: ListOption[];
 };
 
-const getSelectedOption = (
+export const getSelectedOption = (
   values: ListOption[],
   selectedValue: string | number | undefined
 ) => {

--- a/vuu-ui/packages/vuu-popups/src/popup/getPositionRelativeToAnchor.ts
+++ b/vuu-ui/packages/vuu-popups/src/popup/getPositionRelativeToAnchor.ts
@@ -26,7 +26,6 @@ export const getPositionRelativeToAnchor = (
 } => {
   const { bottom, height, left, right, top, width } =
     anchorElement.getBoundingClientRect();
-  console.log({ top });
   switch (placement) {
     case "below":
       return { left: left + offsetLeft, top: bottom + offsetTop };

--- a/vuu-ui/packages/vuu-table-extras/src/cell-renderers/lookup-cell/LookupCell.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/cell-renderers/lookup-cell/LookupCell.tsx
@@ -3,8 +3,6 @@ import { TableCellRendererProps } from "@finos/vuu-table-types";
 import { dataAndColumnUnchanged, registerComponent } from "@finos/vuu-utils";
 import { memo } from "react";
 
-// const classBase = "vuuTableLookupCell";
-
 export const LookupCell = memo(function LookupCell({
   column,
   columnMap,

--- a/vuu-ui/packages/vuu-utils/src/column-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/column-utils.ts
@@ -237,6 +237,8 @@ export function projectUpdates(updates: number[]): number[] {
   return results;
 }
 
+const KEY = 6;
+
 export const metadataKeys = {
   IDX: 0,
   RENDER_IDX: 1,
@@ -244,7 +246,7 @@ export const metadataKeys = {
   IS_EXPANDED: 3,
   DEPTH: 4,
   COUNT: 5,
-  KEY: 6,
+  KEY,
   SELECTED: 7,
   count: 8,
   // TODO following only used in datamodel
@@ -1202,11 +1204,30 @@ export function applyWidthToColumns(
  * A memo compare function for cell renderers. Can be used to suppress
  * render where column and data are both unchanged. Avoids render
  * when row changes, where changes in row are unrelated to this cell.
+ * Suitabnle only for readonly cell renderers. See below for editable
+ * cell renderers.
  */
 export const dataAndColumnUnchanged = (
   p: TableCellRendererProps,
   p1: TableCellRendererProps
 ) =>
   p.column === p1.column &&
+  p.column.valueFormatter(p.row[p.columnMap[p.column.name]]) ===
+    p1.column.valueFormatter(p1.row[p1.columnMap[p1.column.name]]);
+
+/**
+ * A memo compare function for cell renderers. Can be used to suppress
+ * render where column, row key  and data are all unchanged. Avoids render
+ * when row changes, where changes in row are unrelated to this cell.
+ * Suitable for editable cells. Including key in compare is not strictly
+ * necessary for rendering, but it is important in the event that user
+ * edits data - ensures we never have a stale key.
+ */
+export const dataColumnAndKeyUnchanged = (
+  p: TableCellRendererProps,
+  p1: TableCellRendererProps
+) =>
+  p.column === p1.column &&
+  p.row[KEY] === p1.row[KEY] &&
   p.column.valueFormatter(p.row[p.columnMap[p.column.name]]) ===
     p1.column.valueFormatter(p1.row[p1.columnMap[p1.column.name]]);


### PR DESCRIPTION
subtle bug in Dropdown cell renderer. Although updates are always  sent to server, because row key is not checked in the 'should component re-render' checker, sometimes we might have a stale key from another row , when the data is same between two rows and scrolling means the cells have been re-used. In this scenario, update is sent with wrong key value.
Introduce a new checker for editable cells, which includes row key in compare.

Additionally, have removed the state held within component - up[dates applied by user will always arrive back from server - better to wait for updates to arrive that way.