### PR TITLE
1203 add config option to disable ssl

### DIFF
--- a/example/main/src/main/resources/application.conf
+++ b/example/main/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 vuu.webroot="vuu-ui/deployed_apps/app-vuu-example"
 vuu.certPath="example/main/src/main/resources/certs/cert.pem"
 vuu.keyPath="example/main/src/main/resources/certs/key.pem"
+vuu.ssl=true
 
 vuu.restModule.instrumentServiceUrl="some-instrument-service-url"

--- a/vuu-ui/package.json
+++ b/vuu-ui/package.json
@@ -21,6 +21,7 @@
     "format": "prettier --write './**/*.{js,,mjs,jsx,css,md,json}' --config ./.prettierrc",
     "build": "node ./scripts/build-all.mjs",
     "build:app": "cd sample-apps/app-vuu-example && node scripts/build.mjs",
+    "build:app:insecure": "npm run build:app -- --insecure",
     "build:table": "cd sample-apps/standalone-table && node scripts/build.mjs",
     "build:packages": "npm run build -- --cjs --license && npm run type-defs",
     "build:packages:debug": "npm run build -- --cjs --debug && npm run type-defs -- --debug",

--- a/vuu-ui/packages/vuu-data-remote/src/websocket-connection.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/websocket-connection.ts
@@ -21,10 +21,6 @@ const { debug, debugEnabled, error, info, infoEnabled, warn } = logger(
   "websocket-connection"
 );
 
-const WS = "ws"; // to stop semGrep complaining
-const isWebsocketUrl = (url: string) =>
-  url.startsWith(WS + "://") || url.startsWith(WS + "s://");
-
 type ConnectionTracking = {
   [key: string]: {
     connect: {
@@ -150,15 +146,11 @@ const makeConnectionIn = (
   });
 
 const createWebsocket = (
-  connectionString: string,
+  websocketUrl: string,
   protocol: WebSocketProtocol
 ): Promise<WebSocket> =>
   new Promise((resolve, reject) => {
     //TODO add timeout
-    const websocketUrl = isWebsocketUrl(connectionString)
-      ? connectionString
-      : `wss://${connectionString}`;
-
     if (infoEnabled && protocol !== undefined) {
       info(`WebSocket Protocol ${protocol?.toString()}`);
     }

--- a/vuu-ui/packages/vuu-shell/src/shellTypes.ts
+++ b/vuu-ui/packages/vuu-shell/src/shellTypes.ts
@@ -27,6 +27,7 @@ export interface VuuConfig {
   features: Features;
   authUrl?: string;
   websocketUrl: string;
+  ssl: boolean;
 }
 
 export const isWildcardSchema = (schema?: "*" | VuuTable): schema is "*" =>

--- a/vuu-ui/sample-apps/app-vuu-example/src/App.tsx
+++ b/vuu-ui/sample-apps/app-vuu-example/src/App.tsx
@@ -32,9 +32,12 @@ const layoutProps: ShellProps["LayoutProps"] = {
   pathToDropTarget: "#main-tabs.ACTIVE_CHILD",
 };
 
-const defaultWebsocketUrl = `wss://${location.hostname}:8090/websocket`;
+const defaultWebsocketUrl = (ssl: boolean) =>
+  `${ssl ? "wss" : "ws"}://${location.hostname}:8090/websocket`;
+
 const {
-  websocketUrl: serverUrl = defaultWebsocketUrl,
+  ssl,
+  websocketUrl: serverUrl = defaultWebsocketUrl(ssl),
   features: configuredFeatures,
 } =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
@@ -1,5 +1,5 @@
-
 package org.finos.vuu.core
+
 import org.finos.vuu.core.module.ViewServerModule
 import org.finos.vuu.net.auth.AlwaysHappyAuthenticator
 import org.finos.vuu.net.http.{VuuHttp2ServerOptions, VuuSecurityOptions}
@@ -30,6 +30,7 @@ trait VuuWebSocketOptions {
   def wsPort: Int
   def uri: String
   def bindAddress: String
+  def wssEnabled: Boolean
   def certPath: String
   def keyPath: String
   def passPhrase: Option[String]
@@ -51,13 +52,13 @@ case class VuuSecurityOptionsImpl(authenticator: Authenticator, loginTokenValida
   override def withLoginValidator(tokenValidator: LoginTokenValidator): VuuSecurityOptions = this.copy(authenticator = authenticator)
 }
 
-case class VuuWebSocketOptionsImpl(wsPort: Int, uri: String, bindAddress: String, certPath: String = "", keyPath: String = "", passPhrase: Option[String] = None) extends VuuWebSocketOptions {
+case class VuuWebSocketOptionsImpl(wsPort: Int, uri: String, bindAddress: String, wssEnabled: Boolean = false, certPath: String = "", keyPath: String = "", passPhrase: Option[String] = None) extends VuuWebSocketOptions {
   override def withWsPort(port: Int): VuuWebSocketOptions = this.copy(wsPort = port)
   override def withUri(uri: String): VuuWebSocketOptions = this.copy(uri = uri)
   override def withBindAddress(address: String): VuuWebSocketOptions = this.copy(bindAddress = bindAddress)
 
-  override def withWss(certPath: String, keyPath: String, passphrase: Option[String] = None): VuuWebSocketOptions = this.copy(certPath = certPath, keyPath = keyPath, passPhrase = passphrase)
-
+  override def withWss(certPath: String, keyPath: String, passphrase: Option[String] = None): VuuWebSocketOptions =
+    this.copy(wssEnabled = true, certPath = certPath, keyPath = keyPath, passPhrase = passphrase)
 }
 
 case class VuuThreadingOptionsImpl(viewPortThreads: Int = 1, treeViewPortThreads: Int = 1) extends VuuThreadingOptions {

--- a/vuu/src/main/scala/org/finos/vuu/net/http/VuuHttp2ServerOptions.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/http/VuuHttp2ServerOptions.scala
@@ -11,23 +11,16 @@ trait VuuSecurityOptions {
 
 trait VuuHttp2ServerOptions {
   def allowDirectoryListings: Boolean
-
+  def sslEnabled: Boolean
   def certPath: String
-
   def keyPath: String
-
   def webRoot: String
-
   def port: Int
   def bindAddress: String
   def withSsl(certPath: String, keyPath: String): VuuHttp2ServerOptions
-
   def withWebRoot(webRoot: String): VuuHttp2ServerOptions
-
   def withDirectoryListings(allow: Boolean): VuuHttp2ServerOptions
-
   def withPort(port: Int): VuuHttp2ServerOptions
-
   def withBindAddress(bindAddress: String): VuuHttp2ServerOptions
 }
 
@@ -37,19 +30,18 @@ object VuuHttp2ServerOptions {
   }
 }
 
-case class VuuHttp2ServerOptionsImpl(useSsl: Boolean = false,
+case class VuuHttp2ServerOptionsImpl(sslEnabled: Boolean = false,
                                      certPath: String = "",
                                      keyPath: String = "", webRoot: String = "",
                                      port: Int,
                                      allowDirectoryListings: Boolean, bindAddress: String = "") extends VuuHttp2ServerOptions {
-
 
   def withPort(port: Int): VuuHttp2ServerOptions = {
     this.copy(port = port)
   }
 
   def withSsl(certPath: String, keyPath: String): VuuHttp2ServerOptions = {
-    this.copy(certPath = certPath, keyPath = keyPath, useSsl = true)
+    this.copy(certPath = certPath, keyPath = keyPath, sslEnabled = true)
   }
 
   def withWebRoot(webRoot: String): VuuHttp2ServerOptions = {

--- a/vuu/src/main/scala/org/finos/vuu/net/ws/WebSocketServer.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/ws/WebSocketServer.scala
@@ -75,7 +75,7 @@ class WebSocketServer(options: VuuWebSocketOptions, factory: ViewServerHandlerFa
   }
 
   override def doInitialize(): Unit = {
-    val sslContext = createSslContext()
+    val sslContext = Option.when(options.wssEnabled)(createSslContext())
 
     b.group(bossGroup, workerGroup)
       .channel(classOf[NioServerSocketChannel])

--- a/vuu/src/main/scala/org/finos/vuu/net/ws/WebSocketServerHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/ws/WebSocketServerHandler.scala
@@ -16,7 +16,8 @@ import org.finos.vuu.net.ViewServerHandler
 /**
  * Handles handshakes and messages
  */
-class WebSocketServerHandler(handler: ViewServerHandler) extends SimpleChannelInboundHandler[Object] with StrictLogging {
+class WebSocketServerHandler(handler: ViewServerHandler,
+                             withSsl: Boolean) extends SimpleChannelInboundHandler[Object] with StrictLogging {
 
   private final val WEBSOCKET_PATH = "/websocket";
   private var handshaker: WebSocketServerHandshaker = _
@@ -124,9 +125,13 @@ class WebSocketServerHandler(handler: ViewServerHandler) extends SimpleChannelIn
     ctx.close();
   }
 
-  def getWebSocketLocation(req: FullHttpRequest): String = {
-    val location = req.headers().get(HOST) + WEBSOCKET_PATH;
-    return "wss://" + location;
+  private val protocol = {
+    val ws = "ws" // workaround semgrep error
+    ws.concat(if (withSsl) "s" else "").concat("://")
   }
 
+  private def getWebSocketLocation(req: FullHttpRequest): String = {
+    val location = req.headers().get(HOST) + WEBSOCKET_PATH
+    protocol + location
+  }
 }

--- a/vuu/src/main/scala/org/finos/vuu/net/ws/WebSocketServerInitializer.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/ws/WebSocketServerInitializer.scala
@@ -9,15 +9,15 @@ import org.finos.vuu.net.ViewServerHandlerFactory;
 
 /**
  */
-class WebSocketServerInitializer(val factory: ViewServerHandlerFactory, val sslCtx: SslContext) extends ChannelInitializer[SocketChannel] {
+class WebSocketServerInitializer(val factory: ViewServerHandlerFactory, val sslCtx: Option[SslContext]) extends ChannelInitializer[SocketChannel] {
 
   @Override
   override def initChannel(ch: SocketChannel) = {
 
-    val pipeline = ch.pipeline();
+    val pipeline = ch.pipeline()
 
-    if (sslCtx != null) {
-      pipeline.addLast(sslCtx.newHandler(ch.alloc()));
+    if (sslCtx.nonEmpty) {
+      pipeline.addLast(sslCtx.get.newHandler(ch.alloc()))
     }
 
     pipeline.addLast(new HttpServerCodec());
@@ -25,6 +25,6 @@ class WebSocketServerInitializer(val factory: ViewServerHandlerFactory, val sslC
     //pipeline.addLast(new WebSocketServerCompressionHandler());
     //each tpc session will have a local view server handler,
     //this allows us to call (handler.close() when disconnected
-    pipeline.addLast(new WebSocketServerHandler(factory.create()));
+    pipeline.addLast(new WebSocketServerHandler(factory.create(), sslCtx.nonEmpty))
   }
 }

--- a/vuu/src/test/scala/org/finos/vuu/net/rest/RestServiceTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/net/rest/RestServiceTest.scala
@@ -56,9 +56,9 @@ class RestServiceTest extends AnyFeatureSpec with Matchers with StrictLogging {
 
       lifecycle.start()
 
-      val vxoptions = new VertxOptions();
+      val vxoptions = new VertxOptions()
 
-      val vertx = Vertx.vertx(vxoptions);
+      val vertx = Vertx.vertx(vxoptions)
 
       import io.vertx.ext.web.client.WebClient
 


### PR DESCRIPTION
Summary of the changes:
  - now we can enable/disable `ssl` in the demo app by setting the property `vuu.ssl` to `true/false`.
  - and to build UI demo so that it uses the insecure websocket connection, need to run `build:app:insecure` or `build:app -- --insecure`. Or if the `vuuConfig` is to be directly used then either specify the `websocketUrl` directly or set the `ssl` property so the fallback/default websocket url reflects the required protocol (`ws` vs `wss`).