### PR TITLE
1258 make opting out of ssl explicit for http/websocket options

### DIFF
--- a/example/apache-ignite/pom.xml
+++ b/example/apache-ignite/pom.xml
@@ -368,6 +368,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals><goal>jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/example/apache-ignite/src/main/java/Dummy4JavaDoc.java
+++ b/example/apache-ignite/src/main/java/Dummy4JavaDoc.java
@@ -1,0 +1,2 @@
+public class Dummy4JavaDoc {
+}

--- a/example/main/src/main/scala/org/finos/vuu/SimulMain.scala
+++ b/example/main/src/main/scala/org/finos/vuu/SimulMain.scala
@@ -106,7 +106,8 @@ object httpServerOptions {
       .withPort(8443)
 
     val sslEnabled = c.getBoolean(ConfigKeys.sslEnabled)
-    if (sslEnabled) options.withSsl(c.getString(ConfigKeys.certPath), c.getString(ConfigKeys.keyPath)) else options
+    if (sslEnabled) options.withSsl(c.getString(ConfigKeys.certPath), c.getString(ConfigKeys.keyPath))
+    else options.withSslDisabled()
   }
 }
 
@@ -118,6 +119,7 @@ object webSocketOptions {
       .withBindAddress("0.0.0.0")
 
     val sslEnabled = c.getBoolean(ConfigKeys.sslEnabled)
-    if (sslEnabled) options.withWss(c.getString(ConfigKeys.certPath), c.getString(ConfigKeys.keyPath)) else options
+    if (sslEnabled) options.withWss(c.getString(ConfigKeys.certPath), c.getString(ConfigKeys.keyPath))
+    else options.withWssDisabled()
   }
 }

--- a/example/rest-api/pom.xml
+++ b/example/rest-api/pom.xml
@@ -91,9 +91,7 @@
                 <executions>
                     <execution>
                         <phase>compile</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
+                        <goals><goal>jar</goal></goals>
                     </execution>
                 </executions>
             </plugin>

--- a/example/virtualized-table/pom.xml
+++ b/example/virtualized-table/pom.xml
@@ -287,6 +287,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals><goal>jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals><goal>jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
     </build>

--- a/example/virtualized-table/src/main/java/Dummy4JavaDoc.java
+++ b/example/virtualized-table/src/main/java/Dummy4JavaDoc.java
@@ -1,0 +1,2 @@
+public class Dummy4JavaDoc {
+}

--- a/plugin/ignite-plugin/pom.xml
+++ b/plugin/ignite-plugin/pom.xml
@@ -279,6 +279,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals><goal>jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals><goal>jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
     </build>

--- a/plugin/ignite-plugin/src/main/java/Dummy4JavaDoc.java
+++ b/plugin/ignite-plugin/src/main/java/Dummy4JavaDoc.java
@@ -1,0 +1,2 @@
+public class Dummy4JavaDoc {
+}

--- a/plugin/virtualized-table-plugin/pom.xml
+++ b/plugin/virtualized-table-plugin/pom.xml
@@ -256,6 +256,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals><goal>jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals><goal>jar</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
     </build>

--- a/plugin/virtualized-table-plugin/src/main/java/Dummy4JavaDoc.java
+++ b/plugin/virtualized-table-plugin/src/main/java/Dummy4JavaDoc.java
@@ -1,0 +1,2 @@
+public class Dummy4JavaDoc {
+}

--- a/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
@@ -38,6 +38,7 @@ trait VuuWebSocketOptions {
   def withUri(uri: String): VuuWebSocketOptions
   def withBindAddress(address: String): VuuWebSocketOptions
   def withWss(certPath: String, keyPath: String, passphrase: Option[String] = None): VuuWebSocketOptions
+  def withWssDisabled(): VuuWebSocketOptions
 }
 
 trait VuuThreadingOptions{
@@ -52,11 +53,17 @@ case class VuuSecurityOptionsImpl(authenticator: Authenticator, loginTokenValida
   override def withLoginValidator(tokenValidator: LoginTokenValidator): VuuSecurityOptions = this.copy(authenticator = authenticator)
 }
 
-case class VuuWebSocketOptionsImpl(wsPort: Int, uri: String, bindAddress: String, wssEnabled: Boolean = false, certPath: String = "", keyPath: String = "", passPhrase: Option[String] = None) extends VuuWebSocketOptions {
+private case class VuuWebSocketOptionsImpl(wsPort: Int,
+                                   uri: String,
+                                   bindAddress: String,
+                                   wssEnabled: Boolean = true,
+                                   certPath: String = "",
+                                   keyPath: String = "",
+                                   passPhrase: Option[String] = None) extends VuuWebSocketOptions {
   override def withWsPort(port: Int): VuuWebSocketOptions = this.copy(wsPort = port)
   override def withUri(uri: String): VuuWebSocketOptions = this.copy(uri = uri)
   override def withBindAddress(address: String): VuuWebSocketOptions = this.copy(bindAddress = bindAddress)
-
+  override def withWssDisabled(): VuuWebSocketOptions = this.copy(wssEnabled = false)
   override def withWss(certPath: String, keyPath: String, passphrase: Option[String] = None): VuuWebSocketOptions =
     this.copy(wssEnabled = true, certPath = certPath, keyPath = keyPath, passPhrase = passphrase)
 }

--- a/vuu/src/main/scala/org/finos/vuu/net/http/VuuHttp2ServerOptions.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/http/VuuHttp2ServerOptions.scala
@@ -18,6 +18,7 @@ trait VuuHttp2ServerOptions {
   def port: Int
   def bindAddress: String
   def withSsl(certPath: String, keyPath: String): VuuHttp2ServerOptions
+  def withSslDisabled(): VuuHttp2ServerOptions
   def withWebRoot(webRoot: String): VuuHttp2ServerOptions
   def withDirectoryListings(allow: Boolean): VuuHttp2ServerOptions
   def withPort(port: Int): VuuHttp2ServerOptions
@@ -26,19 +27,21 @@ trait VuuHttp2ServerOptions {
 
 object VuuHttp2ServerOptions {
   def apply(): VuuHttp2ServerOptions = {
-    VuuHttp2ServerOptionsImpl(false, "", "", "", 8080, false)
+    VuuHttp2ServerOptionsImpl(port = 8080, allowDirectoryListings = false)
   }
 }
 
-case class VuuHttp2ServerOptionsImpl(sslEnabled: Boolean = false,
-                                     certPath: String = "",
-                                     keyPath: String = "", webRoot: String = "",
-                                     port: Int,
-                                     allowDirectoryListings: Boolean, bindAddress: String = "") extends VuuHttp2ServerOptions {
+private case class VuuHttp2ServerOptionsImpl(sslEnabled: Boolean = true,
+                                             certPath: String = "", keyPath: String = "",
+                                             webRoot: String = "", port: Int,
+                                             allowDirectoryListings: Boolean,
+                                             bindAddress: String = "") extends VuuHttp2ServerOptions {
 
   def withPort(port: Int): VuuHttp2ServerOptions = {
     this.copy(port = port)
   }
+
+  override def withSslDisabled(): VuuHttp2ServerOptions = this.copy(sslEnabled = false)
 
   def withSsl(certPath: String, keyPath: String): VuuHttp2ServerOptions = {
     this.copy(certPath = certPath, keyPath = keyPath, sslEnabled = true)

--- a/vuu/src/test/scala/org/finos/vuu/net/ws/WebSocketServerClientTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/net/ws/WebSocketServerClientTest.scala
@@ -1,7 +1,7 @@
 package org.finos.vuu.net.ws
 
 import org.finos.vuu.client.ClientHelperFns.awaitMsgBody
-import org.finos.vuu.core.{CoreServerApiHandler, VuuWebSocketOptions, VuuWebSocketOptionsImpl}
+import org.finos.vuu.core.{CoreServerApiHandler, VuuWebSocketOptions}
 import org.finos.vuu.core.module.ModuleContainer
 import org.finos.vuu.core.table.TableContainer
 import org.finos.vuu.net._


### PR DESCRIPTION
make opting out of ssl explicit for http/websocket options

- for now as a quick fix I've set ssl being enabled by default. So that user
  will always have to either call `withSslDisabled` to disable ssl or
  call `withSsl` to provide cert/key paths.