### PR TITLE
add devcontainer support to VUU

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM   mcr.microsoft.com/devcontainers/java:17
+
+COPY ./install-sdk-packages.sh ./install-sdk-packages.sh
+
+RUN chmod u+x ./install-sdk-packages.sh && ./install-sdk-packages.sh && rm ./install-sdk-packages.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "VUU",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "v18.17.0" }
+  },
+
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {},
+      "extensions": [
+        "Orta.vscode-jest",
+        "dbaeumer.vscode-eslint",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "forwardPorts": [5173, 8443, 8090]
+}

--- a/.devcontainer/install-sdk-packages.sh
+++ b/.devcontainer/install-sdk-packages.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# install required sdk packages
+source "/usr/local/sdkman/bin/sdkman-init.sh"
+
+sdk install maven 3.9.6
+
+sdk install scala 2.13.10
+sudo chmod a+x /usr/local/sdkman/candidates/scala/current/bin/scala


### PR DESCRIPTION
Please note that you need docker running on your machine for both VSCode and IntelliJ setup.

## Set-up for VSCode
1. Install `Dev Containers` extension
2. Press `F1` ->  Select `Dev Containers: Clone Repository in Container Volume...`
3. Use this as the repository url: `https://github.com/junaidzm13/vuu.git`

## Set-up for IntelliJ (only works with Ultimate Edition, tested on v2024.1)

1. Need to have `Dev Containers` plugin enabled: https://plugins.jetbrains.com/plugin/21962-dev-containers
2. `Open IntelliJ UE` -> `Remote Development` -> `Dev Containers` -> `New Dev Container` <img width="807" alt="Screenshot 2024-04-14 at 9 02 07 PM" src="https://github.com/finos/vuu/assets/62522218/e030687a-d67b-4815-becc-6b6ce0f8a161">
3. Paste this for `Git Repository`: https://github.com/junaidzm13/vuu.git and select `100-devcontainer` as the branch
4. Click on `Build Container and Continue` button. Now it will clone the source code, build the image and and create/configure your dev container.
5. Follow the on screen instructions to start-up the IntelliJ client
6. Once started download the Scala plugin and restart your IntelliJ to apply the newly installed plugin. The IDE client might not start automatically in that case just open already created devcontainer. You can see the list of created dev containers from the screen in step 1.
7. Set your Scala SDK (you should already have Scala installed in your env):  `Project Structure` -> `Global Libraries` -> `Add using + icon` -> `Scala SDK` -> `Select the one already installed` -> `OK`
8. Refresh your maven project: https://stackoverflow.com/a/63022272 under **Another Option**

### Incase clone fails to pull the whole project (have happened a few times):
1. Open terminal on IntelliJ IDE client
2. Run the following command:
```
  (might have to remove the existing files/folders inside vuu/)
  git clone https://github.com/junaidzm13/vuu.git .
```
3. Refresh your maven project