### PR TITLE
use tableSchema passed to feature rather than from dataSource

### DIFF
--- a/vuu-ui/sample-apps/feature-filter-table/src/useFilterTable.tsx
+++ b/vuu-ui/sample-apps/feature-filter-table/src/useFilterTable.tsx
@@ -259,7 +259,7 @@ export const useFilterTable = ({ tableSchema }: FilterTableFeatureProps) => {
     onFilterDeleted: handleFilterDeleted,
     onFilterRenamed: handleFilterRenamed,
     onFilterStateChanged: handleFilterStateChanged,
-    tableSchema: dataSource.tableSchema,
+    tableSchema,
   };
 
   const tableProps = {


### PR DESCRIPTION
filterbar need tableSchema (to populate column lookup) 
use schema passed to feature rather than reading it from dataSource. Property on dataSOurce is only set asynchronously after subscription is complete, it is not yet set on initial render of a new table