### PR TITLE
503 Typeahead service should be case insensitive

### DIFF
--- a/vuu/src/main/scala/org/finos/vuu/core/table/ColumnValueProvider.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/ColumnValueProvider.scala
@@ -33,7 +33,7 @@ class InMemColumnValueProvider(dataTable: InMemDataTable) extends ColumnValuePro
 
   override def getUniqueValuesStartingWith(columnName: String, starts: String): Array[String] =
     dataTable.columnForName(columnName) match {
-      case c: Column => get10DistinctValues(c, _.startsWith(starts))
+      case c: Column => get10DistinctValues(c, _.toLowerCase.startsWith(starts.toLowerCase))
       case null      => logger.error(s"Column $columnName not found in table ${dataTable.name}"); Array.empty;
     }
 

--- a/vuu/src/test/scala/org/finos/vuu/core/table/InMemColumnValueProviderTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/InMemColumnValueProviderTest.scala
@@ -80,6 +80,21 @@ class InMemColumnValueProviderTest extends AnyFeatureSpec with Matchers with Moc
       uniqueValues should contain theSameElementsAs Vector("VOA.L", "VOV.L")
     }
 
+    Scenario("Get all unique value of a given column that starts with specified string case insensitive") {
+      val table = givenTable(pricesDef)
+      val provider = new MockProvider(table)
+      val columnValueProvider = new InMemColumnValueProvider(table)
+
+      provider.tick("1", Map("id" -> "1", "ric" -> "VOA.L", "bid" -> 220, "ask" -> 223))
+      provider.tick("2", Map("id" -> "2", "ric" -> "BT.L", "bid" -> 500, "ask" -> 550))
+      provider.tick("3", Map("id" -> "3", "ric" -> "VOV.L", "bid" -> 240, "ask" -> 244))
+      provider.tick("4", Map("id" -> "4", "ric" -> null, "bid" -> 240, "ask" -> 244))
+
+      val uniqueValues = columnValueProvider.getUniqueValuesStartingWith("ric", "vo")
+
+      uniqueValues should contain theSameElementsAs Vector("VOA.L", "VOV.L")
+    }
+
   }
 
   private def givenTable(tableDef: TableDef): InMemDataTable = new InMemDataTable(tableDef, JoinTableProviderImpl())


### PR DESCRIPTION
Choose toLowerCase as solution considering Iterator is lazy and filter will be applied to the first 10 elments, which means no big impact to performance.
