### PR TITLE
fix rowcount glitch on table startup

### DIFF
--- a/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
+++ b/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
@@ -149,7 +149,6 @@ export class ArrayDataSource
     viewport,
   }: ArrayDataSourceConstructorProps) {
     super();
-    console.log(`ArrayDataSource #${viewport}`);
     if (!data || !columnDescriptors) {
       throw Error(
         "ArrayDataSource constructor called without data or without columnDescriptors",
@@ -490,7 +489,6 @@ export class ArrayDataSource
   };
 
   private validateDataValue(columnName: string, value: VuuRowDataItemType) {
-    console.log(`validate data value ${columnName} ${value}`);
     const columnDescriptor = this.columnDescriptors.find(
       (col) => col.name === columnName,
     );

--- a/vuu-ui/packages/vuu-shell/src/feature-and-layout-provider/FeatureAndLayoutProvider.tsx
+++ b/vuu-ui/packages/vuu-shell/src/feature-and-layout-provider/FeatureAndLayoutProvider.tsx
@@ -21,8 +21,8 @@ export interface FeatureContextProps {
   staticFeatures?: StaticFeatureDescriptor[];
 }
 
-export interface LayoutContextProps{
-  systemLayouts?: SystemLayoutMetadata[]
+export interface LayoutContextProps {
+  systemLayouts?: SystemLayoutMetadata[];
 }
 
 const NO_FEATURES: DynamicFeatureDescriptor[] = [];
@@ -41,10 +41,11 @@ const FeatureContext = createContext<FeatureContextProps>({
 });
 
 const LayoutContext = createContext<LayoutContextProps>({
-  systemLayouts: NO_SYSTEMLAYOUTS
-})
+  systemLayouts: NO_SYSTEMLAYOUTS,
+});
 
-export interface FeatureAndLayoutProviderProps extends Partial<FeatureContextProps> {
+export interface FeatureAndLayoutProviderProps
+  extends Partial<FeatureContextProps> {
   children: ReactNode;
   dynamicFeatures?: DynamicFeatureDescriptor[];
   staticFeatures?: StaticFeatureDescriptor[];
@@ -55,7 +56,7 @@ export const FeatureAndLayoutProvider = ({
   children,
   dynamicFeatures: dynamicFeaturesProp = [],
   staticFeatures,
-  systemLayouts
+  systemLayouts,
 }: FeatureAndLayoutProviderProps): ReactElement => {
   const vuuTables = useVuuTables();
   const { dynamicFeatures, tableFeatures } = useMemo<{
@@ -69,9 +70,6 @@ export const FeatureAndLayoutProvider = ({
     [dynamicFeaturesProp, vuuTables],
   );
 
-  console.log({ tableFeatures });
-  console.log(systemLayouts)
-
   return (
     <FeatureContext.Provider
       value={{
@@ -82,11 +80,11 @@ export const FeatureAndLayoutProvider = ({
     >
       <LayoutContext.Provider
         value={{
-          systemLayouts
+          systemLayouts,
         }}
-      > 
+      >
         {children}
-      </LayoutContext.Provider> 
+      </LayoutContext.Provider>
     </FeatureContext.Provider>
   );
 };

--- a/vuu-ui/packages/vuu-table/src/useTable.ts
+++ b/vuu-ui/packages/vuu-table/src/useTable.ts
@@ -145,14 +145,20 @@ export const useTable = ({
   useMemo(() => {
     tableConfigRef.current = config;
   }, [config]);
-  const [headerHeight, setHeaderHeight] = useState(0);
+
+  const [headerHeight, setHeaderHeight] = useState(-1);
   const [rowCount, setRowCount] = useState<number>(dataSource.size);
   if (dataSource === undefined) {
     throw Error("no data source provided to Vuu Table");
   }
 
+  const onDataRowcountChange = useCallback((size: number) => {
+    setRowCount(size);
+  }, []);
+
   const virtualContentHeight = rowHeight * rowCount;
-  const viewportBodyHeight = size.height - headerHeight;
+  const viewportBodyHeight =
+    size.height - (headerHeight === -1 ? 0 : headerHeight);
   const verticalScrollbarWidth =
     virtualContentHeight > viewportBodyHeight ? 10 : 0;
   const availableWidth = size.width - (verticalScrollbarWidth + 8);
@@ -165,10 +171,6 @@ export const useTable = ({
     () => buildContextMenuDescriptors(dataSource),
     [dataSource],
   );
-
-  const onDataRowcountChange = useCallback((size: number) => {
-    setRowCount(size);
-  }, []);
 
   const {
     columns,

--- a/vuu-ui/packages/vuu-table/src/useTableScroll.ts
+++ b/vuu-ui/packages/vuu-table/src/useTableScroll.ts
@@ -71,7 +71,7 @@ const getMaxScroll = (container: HTMLElement) => {
 
 const getScrollDirection = (
   prevScrollPositions: ScrollPos | undefined,
-  scrollPos: number
+  scrollPos: number,
 ) => {
   if (prevScrollPositions === undefined) {
     return undefined;
@@ -141,7 +141,7 @@ const useCallbackRef = <T = HTMLElement>({
         onDetach?.(originalRef);
       }
     },
-    [onAttach, onDetach]
+    [onAttach, onDetach],
   );
   return callbackRef;
 };
@@ -200,6 +200,7 @@ export const useTableScroll = ({
     isVirtualScroll,
     rowCount: viewportRowCount,
     totalHeaderHeight,
+    usesMeasuredHeaderHeight,
     viewportWidth,
   } = viewportMeasurements;
 
@@ -214,7 +215,7 @@ export const useTableScroll = ({
       contentContainerPosRef.current.scrollLeft,
       contentContainerPosRef.current.scrollLeft +
         viewportWidth +
-        HORIZONTAL_SCROLL_BUFFER
+        HORIZONTAL_SCROLL_BUFFER,
     );
     preSpanRef.current = offset;
     columnsWithinViewportRef.current = visibleColumns;
@@ -234,7 +235,7 @@ export const useTableScroll = ({
         const [visibleColumns, pre] = getColumnsInViewport(
           columns,
           scrollLeft,
-          scrollLeft + viewportWidth + HORIZONTAL_SCROLL_BUFFER
+          scrollLeft + viewportWidth + HORIZONTAL_SCROLL_BUFFER,
         );
 
         if (itemsChanged(columnsWithinViewportRef.current, visibleColumns)) {
@@ -244,7 +245,7 @@ export const useTableScroll = ({
         }
       }
     },
-    [columns, onHorizontalScroll, viewportWidth]
+    [columns, onHorizontalScroll, viewportWidth],
   );
   const handleVerticalScroll = useCallback(
     (scrollTop: number, pctScrollTop: number) => {
@@ -264,7 +265,7 @@ export const useTableScroll = ({
       onVerticalScrollInSitu,
       setRange,
       viewportRowCount,
-    ]
+    ],
   );
 
   const handleScrollbarContainerScroll = useCallback(() => {
@@ -319,7 +320,7 @@ export const useTableScroll = ({
         scrollbarContainerScrolledRef.current = false;
       } else {
         scrollbarContainer.scrollLeft = Math.round(
-          pctScrollLeft * maxScrollLeft
+          pctScrollLeft * maxScrollLeft,
         );
         scrollbarContainer.scrollTop = pctScrollTop * maxScrollTop;
       }
@@ -340,7 +341,7 @@ export const useTableScroll = ({
         passive: true,
       });
     },
-    [handleScrollbarContainerScroll]
+    [handleScrollbarContainerScroll],
   );
 
   const handleDetachScrollbarContainer = useCallback(
@@ -348,7 +349,7 @@ export const useTableScroll = ({
       scrollbarContainerRef.current = null;
       el.removeEventListener("scroll", handleScrollbarContainerScroll);
     },
-    [handleScrollbarContainerScroll]
+    [handleScrollbarContainerScroll],
   );
 
   const handleAttachContentContainer = useCallback(
@@ -358,7 +359,7 @@ export const useTableScroll = ({
         passive: true,
       });
     },
-    [handleContentContainerScroll]
+    [handleContentContainerScroll],
   );
 
   const handleDetachContentContainer = useCallback(
@@ -366,7 +367,7 @@ export const useTableScroll = ({
       contentContainerRef.current = null;
       el.removeEventListener("scroll", handleContentContainerScroll);
     },
-    [handleContentContainerScroll]
+    [handleContentContainerScroll],
   );
 
   const contentContainerCallbackRef = useCallbackRef({
@@ -389,13 +390,13 @@ export const useTableScroll = ({
         if (scrollRequest.type === "scroll-row") {
           const activeRow = getRowElementAtIndex(
             contentContainer,
-            scrollRequest.rowIndex
+            scrollRequest.rowIndex,
           );
 
           if (activeRow !== null) {
             const [direction, distance] = howFarIsRowOutsideViewport(
               activeRow,
-              totalHeaderHeight
+              totalHeaderHeight,
             );
             if (direction && distance) {
               if (isVirtualScroll) {
@@ -413,12 +414,12 @@ export const useTableScroll = ({
                 if (direction === "up" || direction === "down") {
                   newScrollTop = Math.min(
                     Math.max(0, scrollTop + distance),
-                    maxScrollTop
+                    maxScrollTop,
                   );
                 } else {
                   newScrollLeft = Math.min(
                     Math.max(0, scrollLeft + distance),
-                    maxScrollLeft
+                    maxScrollLeft,
                   );
                 }
                 contentContainer.scrollTo({
@@ -443,7 +444,7 @@ export const useTableScroll = ({
               direction === "down" ? appliedPageSize : -appliedPageSize;
             const newScrollTop = Math.min(
               Math.max(0, scrollTop + scrollBy),
-              maxScrollTop
+              maxScrollTop,
             );
             contentContainer.scrollTo({
               top: newScrollTop,
@@ -469,7 +470,7 @@ export const useTableScroll = ({
       setRange,
       totalHeaderHeight,
       viewportRowCount,
-    ]
+    ],
   );
 
   const scrollHandles: ScrollingAPI = useMemo(
@@ -486,20 +487,16 @@ export const useTableScroll = ({
         console.log(`scrollToKey ${rowKey}`);
       },
     }),
-    []
+    [],
   );
 
-  useImperativeHandle(
-    scrollingApiRef,
-    () => {
-      if (scrollbarContainerRef.current) {
-        return scrollHandles;
-      } else {
-        return noScrolling;
-      }
-    },
-    [scrollHandles]
-  );
+  useImperativeHandle(scrollingApiRef, () => {
+    if (scrollbarContainerRef.current) {
+      return scrollHandles;
+    } else {
+      return noScrolling;
+    }
+  }, [scrollHandles]);
 
   useEffect(() => {
     if (rowHeight !== rowHeightRef.current) {
@@ -509,12 +506,12 @@ export const useTableScroll = ({
           contentContainerRef.current.scrollTop = 0;
         }
       }
-    } else {
+    } else if (usesMeasuredHeaderHeight) {
       const { current: from } = firstRowRef;
       const rowRange = { from, to: from + viewportRowCount };
       setRange(rowRange);
     }
-  }, [rowHeight, setRange, viewportRowCount]);
+  }, [rowHeight, setRange, usesMeasuredHeaderHeight, viewportRowCount]);
 
   return {
     columnsWithinViewport: columnsWithinViewportRef.current,

--- a/vuu-ui/packages/vuu-table/src/useTableViewport.ts
+++ b/vuu-ui/packages/vuu-table/src/useTableViewport.ts
@@ -37,6 +37,7 @@ export interface ViewportMeasurements {
   rowCount: number;
   contentWidth: number;
   totalHeaderHeight: number;
+  usesMeasuredHeaderHeight: boolean;
   verticalScrollbarWidth: number;
   viewportBodyHeight: number;
   viewportWidth: number;
@@ -66,6 +67,7 @@ const UNMEASURED_VIEWPORT: TableViewportHookResult = {
   setInSituRowOffset: () => undefined,
   setScrollTop: () => undefined,
   totalHeaderHeight: 0,
+  usesMeasuredHeaderHeight: false,
   verticalScrollbarWidth: 0,
   viewportBodyHeight: 0,
   viewportWidth: 0,
@@ -88,7 +90,7 @@ export const useTableViewport = ({
 
   const { pinnedWidthLeft, pinnedWidthRight, unpinnedWidth } = useMemo(
     () => measurePinnedColumns(columns, selectionEndSize),
-    [columns, selectionEndSize]
+    [columns, selectionEndSize],
   );
 
   const [getRowOffset, getRowAtPosition, isVirtualScroll] =
@@ -121,7 +123,7 @@ export const useTableViewport = ({
     } else {
       inSituRowOffsetRef.current = Math.max(
         0,
-        inSituRowOffsetRef.current + rowIndexOffset
+        inSituRowOffsetRef.current + rowIndexOffset,
       );
     }
   }, []);
@@ -133,11 +135,12 @@ export const useTableViewport = ({
       const contentWidth = pinnedWidthLeft + unpinnedWidth + pinnedWidthRight;
       const horizontalScrollbarHeight =
         contentWidth > size.width ? scrollbarSize : 0;
-      const visibleRows = (size.height - headerHeight) / rowHeight;
+      const measuredHeaderHeight = headerHeight === -1 ? 0 : headerHeight;
+      const visibleRows = (size.height - measuredHeaderHeight) / rowHeight;
       const count = Number.isInteger(visibleRows)
         ? visibleRows
         : Math.ceil(visibleRows);
-      const viewportBodyHeight = size.height - headerHeight;
+      const viewportBodyHeight = size.height - measuredHeaderHeight;
       const verticalScrollbarWidth =
         pixelContentHeight > viewportBodyHeight ? scrollbarSize : 0;
 
@@ -147,6 +150,7 @@ export const useTableViewport = ({
       const viewportWidth = size.width;
 
       return {
+        usesMeasuredHeaderHeight: headerHeight !== -1,
         appliedPageSize,
         contentHeight: pixelContentHeight,
         contentWidth,

--- a/vuu-ui/packages/vuu-utils/src/feature-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/feature-utils.ts
@@ -186,9 +186,6 @@ export const getCustomAndTableFeatures = (
   dynamicFeatures: DynamicFeatureProps[];
   tableFeatures: DynamicFeatureProps<FilterTableFeatureProps>[];
 } => {
-  console.log(`getCustomAndTableFeatures`, {
-    vuuTables,
-  });
   const [customFeatureConfig, tableFeaturesConfig] = partition(
     dynamicFeatures,
     isCustomFeature,

--- a/vuu-ui/sample-apps/feature-filter-table/src/useSessionDataSource.ts
+++ b/vuu-ui/sample-apps/feature-filter-table/src/useSessionDataSource.ts
@@ -23,8 +23,6 @@ export const useSessionDataSource = ({
   const { id, load, save, loadSession, saveSession, title } = useViewContext();
   const { VuuDataSource } = useDataSource();
 
-  console.log(`useSessionDataSource #${id}`);
-
   const { "datasource-config": dataSourceConfigFromState } =
     useMemo<SessionDataSourceConfig>(() => load?.() ?? NO_CONFIG, [load]);
 

--- a/vuu-ui/tools/vuu-showcase/src/showcase-utils.ts
+++ b/vuu-ui/tools/vuu-showcase/src/showcase-utils.ts
@@ -12,7 +12,7 @@ export type ExamplesModule = Module<VuuExample>;
 export type VuuTuple = [string, VuuExample | ExamplesModule];
 
 export const isVuuExample = (
-  item: VuuExample | ExamplesModule
+  item: VuuExample | ExamplesModule,
 ): item is VuuExample => typeof item === "function";
 
 export const byDisplaySequence = ([, f1]: VuuTuple, [, f2]: VuuTuple) => {
@@ -58,7 +58,7 @@ export const pathToExample = (path: string): [string[], string] => {
 
 export const getComponent = <T = ReactComponent>(
   module: Module,
-  paths: string[]
+  paths: string[],
 ): T | undefined => {
   let importedEntity = module;
   while (paths.length > 0) {
@@ -79,7 +79,6 @@ export const getComponent = <T = ReactComponent>(
 
 export const loadTheme = (themeName: string): Promise<void> =>
   new Promise((resolve) => {
-    console.log(`load theme ${themeName} ${env}`);
     if (env === "development") {
       import(`./themes/${themeName}.ts`).then(() => {
         resolve();


### PR DESCRIPTION
table calls setrange on dataSource once rowCount is determined. This is currently happening twice, because headerHeight in only known after initial render, so first calculation of rowCount doesn't take headerHeight into account.

DO not call setRange until headerHeight has been measured.