### PR TITLE
create visualLink options dynamically

### DIFF
--- a/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
+++ b/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
@@ -255,16 +255,17 @@ export class ArrayDataSource
     if (this.#status !== "unsubscribed") {
       info?.(`suspend #${this.viewport}, current status ${this.#status}`);
       this.#status = "suspended";
+      this.emit("suspended", this.viewport);
     }
   }
 
   resume() {
-    // const isDisabled = this.#status.startsWith("disabl");
     const isSuspended = this.#status === "suspended";
     info?.(`resume #${this.viewport}, current status ${this.#status}`);
     if (isSuspended) {
       this.#status = "subscribed";
     }
+    this.emit("resumed", this.viewport);
   }
 
   disable() {

--- a/vuu-ui/packages/vuu-data-remote/src/vuu-data-source.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/vuu-data-source.ts
@@ -267,6 +267,7 @@ export class VuuDataSource
           type: "suspend",
           viewport: this.viewport,
         });
+        this.emit("suspended", this.viewport);
       }
     }
   }
@@ -284,6 +285,7 @@ export class VuuDataSource
           viewport: this.viewport,
         });
         this.#status = "subscribed";
+        this.emit("resumed", this.viewport);
       }
     }
   }

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -63,7 +63,9 @@ export class TickingArrayDataSource extends ArrayDataSource {
   #table?: Table;
   #selectionLinkSubscribers: Map<string, LinkSubscription> | undefined;
   #visualLinkService?: VisualLinkHandler;
-  #getVisualLinks: (tableName: string) => LinkDescriptorWithLabel[] | undefined;
+  #getVisualLinks?: (
+    tableName: string,
+  ) => LinkDescriptorWithLabel[] | undefined;
 
   constructor({
     data,
@@ -128,7 +130,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
   }
 
   get links() {
-    return this.#getVisualLinks(this.table.table);
+    return this.#getVisualLinks?.(this.table.table);
   }
 
   private getSelectedRowIds() {

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -39,12 +39,12 @@ export type VisualLinkHandler = (
 export interface TickingArrayDataSourceConstructorProps
   extends Omit<ArrayDataSourceConstructorProps, "data"> {
   data?: Array<VuuRowDataItemType[]>;
+  getVisualLinks: (tableName: string) => LinkDescriptorWithLabel[] | undefined;
   menu?: VuuMenu;
   menuRpcServices?: RpcService[];
   rpcServices?: RpcService[];
   sessionTables?: SessionTableMap;
   table?: Table;
-  visualLinks?: LinkDescriptorWithLabel[];
   visualLinkService?: VisualLinkHandler;
 }
 
@@ -63,16 +63,17 @@ export class TickingArrayDataSource extends ArrayDataSource {
   #table?: Table;
   #selectionLinkSubscribers: Map<string, LinkSubscription> | undefined;
   #visualLinkService?: VisualLinkHandler;
+  #getVisualLinks: (tableName: string) => LinkDescriptorWithLabel[] | undefined;
 
   constructor({
     data,
+    getVisualLinks,
     menuRpcServices,
     rpcServices,
     sessionTables,
     table,
     menu,
     visualLink,
-    visualLinks,
     visualLinkService,
     ...arrayDataSourceProps
   }: TickingArrayDataSourceConstructorProps) {
@@ -91,8 +92,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
     this.#sessionTables = sessionTables;
     this.#table = table;
     this.#visualLinkService = visualLinkService;
-
-    this.links = visualLinks;
+    this.#getVisualLinks = getVisualLinks;
 
     if (table) {
       this.tableSchema = table.schema;
@@ -125,6 +125,10 @@ export class TickingArrayDataSource extends ArrayDataSource {
   }
   get range() {
     return super.range;
+  }
+
+  get links() {
+    return this.#getVisualLinks(this.table.table);
   }
 
   private getSelectedRowIds() {

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -39,7 +39,7 @@ export type VisualLinkHandler = (
 export interface TickingArrayDataSourceConstructorProps
   extends Omit<ArrayDataSourceConstructorProps, "data"> {
   data?: Array<VuuRowDataItemType[]>;
-  getVisualLinks: (tableName: string) => LinkDescriptorWithLabel[] | undefined;
+  getVisualLinks?: (tableName: string) => LinkDescriptorWithLabel[] | undefined;
   menu?: VuuMenu;
   menuRpcServices?: RpcService[];
   rpcServices?: RpcService[];

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -341,6 +341,8 @@ export type DataSourceEvents = {
   "row-selection": RowSelectionEventHandler;
   subscribed: (subscription: DataSourceSubscribedMessage) => void;
   unsubscribed: DataSourceEventHandler;
+  suspended: DataSourceEventHandler;
+  resumed: DataSourceEventHandler;
   disabled: DataSourceEventHandler;
   enabled: DataSourceEventHandler;
   "title-changed": (id: string, title: string) => void;


### PR DESCRIPTION
with client test data ...
visual links are currently generated when dataSource is created, with adjustments made when new dataSOurces are subscribed

this does not take into account that some target dataSources may not be in same layout as source

build the list of available visual links dynamically when context menu is created. Take ststus of potential targets inot acocunt 