### PR TITLE
fix useVuuTables, same table name different modules

### DIFF
--- a/vuu-ui/packages/vuu-shell/src/feature-and-layout-provider/FeatureAndLayoutProvider.tsx
+++ b/vuu-ui/packages/vuu-shell/src/feature-and-layout-provider/FeatureAndLayoutProvider.tsx
@@ -58,16 +58,16 @@ export const FeatureAndLayoutProvider = ({
   staticFeatures,
   systemLayouts,
 }: FeatureAndLayoutProviderProps): ReactElement => {
-  const vuuTables = useVuuTables();
+  const tableSchemas = useVuuTables();
   const { dynamicFeatures, tableFeatures } = useMemo<{
     dynamicFeatures: DynamicFeatureProps[];
     tableFeatures: DynamicFeatureProps<FilterTableFeatureProps>[];
   }>(
     () =>
-      vuuTables
-        ? getCustomAndTableFeatures(dynamicFeaturesProp, vuuTables)
+      tableSchemas
+        ? getCustomAndTableFeatures(dynamicFeaturesProp, tableSchemas)
         : NO_FEATURES_VUU,
-    [dynamicFeaturesProp, vuuTables],
+    [dynamicFeaturesProp, tableSchemas],
   );
 
   return (

--- a/vuu-ui/sample-apps/app-vuu-example/src/useRpcResponseHandler.tsx
+++ b/vuu-ui/sample-apps/app-vuu-example/src/useRpcResponseHandler.tsx
@@ -3,7 +3,7 @@ import { RpcResponseHandler } from "@finos/vuu-data-types";
 import { useDialog } from "@finos/vuu-popups";
 import { VuuTable } from "@finos/vuu-protocol-types";
 import { Feature } from "@finos/vuu-shell";
-import { isActionMessage } from "@finos/vuu-utils";
+import { isActionMessage, isSameTable } from "@finos/vuu-utils";
 import { useCallback } from "react";
 
 const withTable = (action: unknown): action is { table: VuuTable } =>
@@ -12,7 +12,7 @@ const withTable = (action: unknown): action is { table: VuuTable } =>
 const vuuFilterTableFeatureUrl = "../feature-filter-table/index.js";
 
 export const useRpcResponseHandler = () => {
-  const tables = useVuuTables();
+  const tableSchemas = useVuuTables();
   const { setDialogState } = useDialog();
 
   const handleRpcResponse = useCallback<RpcResponseHandler>(
@@ -26,10 +26,13 @@ export const useRpcResponseHandler = () => {
       ) {
         if (
           withTable(rpcResponse.action) &&
-          tables &&
+          tableSchemas &&
           rpcResponse.action.table
         ) {
-          const schema = tables.get(rpcResponse.action.table.table);
+          const { table } = rpcResponse.action;
+          const schema = tableSchemas.find((tableSchema) =>
+            isSameTable(tableSchema.table, table),
+          );
           if (schema) {
             // If we already have this table open in this viewport, ignore
             setDialogState({
@@ -49,7 +52,7 @@ export const useRpcResponseHandler = () => {
       }
       return false;
     },
-    [setDialogState, tables],
+    [setDialogState, tableSchemas],
   );
 
   return {

--- a/vuu-ui/showcase/src/examples/VUU/Vuu.examples.tsx
+++ b/vuu-ui/showcase/src/examples/VUU/Vuu.examples.tsx
@@ -1,24 +1,30 @@
 import { List, ListItem } from "@finos/vuu-ui-controls";
-import { useVuuTables } from "@finos/vuu-data-react";
+import { useVuuTables, VuuDataSourceProvider } from "@finos/vuu-data-react";
 import { useAutoLoginToVuuServer } from "../utils";
 
 let displaySequence = 1;
 
-export const VuuTables = () => {
-  const tables = useVuuTables();
+const VuuTablesTemplate = () => {
+  const tableSchemas = useVuuTables();
 
-  useAutoLoginToVuuServer();
+  useAutoLoginToVuuServer({ authenticate: false });
 
   return (
-    <List width={200}>
-      {tables
-        ? Array.from(tables.entries()).map(([tableName, schema]) => (
-            <ListItem
-              key={tableName}
-            >{`[${schema.table.module}] ${schema.table.table}`}</ListItem>
-          ))
-        : null}
-    </List>
+    <VuuDataSourceProvider>
+      <List width={200}>
+        {tableSchemas?.map(({ table: { module, table } }, i) => (
+          <ListItem key={i}>{`[${module}] ${table}`}</ListItem>
+        )) ?? null}
+      </List>
+    </VuuDataSourceProvider>
+  );
+};
+
+export const VuuTables = () => {
+  return (
+    <VuuDataSourceProvider>
+      <VuuTablesTemplate />
+    </VuuDataSourceProvider>
   );
 };
 


### PR DESCRIPTION
if two modules provide a table with same name, one currently overrides the other in vuu table list provided by useVuuTables hook