### PR TITLE
ensure when columnDescriptors have labels, filter

### DIFF
--- a/vuu-ui/packages/vuu-filters/src/filter-clause/ColumnPicker.tsx
+++ b/vuu-ui/packages/vuu-filters/src/filter-clause/ColumnPicker.tsx
@@ -41,7 +41,9 @@ export const ColumnPicker = forwardRef(function ColumnPicker(
           name.toLowerCase().includes(comboProps.value.toLowerCase()),
         )
         .map(({ name, label = name }) => (
-          <Option value={label} key={name} />
+          <Option value={name} key={name}>
+            {label}
+          </Option>
         ))}
     </ExpandoCombobox>
   );

--- a/vuu-ui/packages/vuu-theme/css/components/split-button.css
+++ b/vuu-ui/packages/vuu-theme/css/components/split-button.css
@@ -13,6 +13,9 @@
             border-radius: var(--trigger-border-radius);
         }
         
+        &.vuuFocusVisible {
+            --vuuButton-borderColor: transparent;
+        }
         
     }
 }

--- a/vuu-ui/showcase/src/examples/Filters/FilterBar/FilterBar.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Filters/FilterBar/FilterBar.examples.tsx
@@ -10,9 +10,10 @@ import {
   useRef,
   useState,
 } from "react";
-import type { DataSourceFilter } from "@finos/vuu-data-types";
+import type { DataSourceFilter, SchemaColumn } from "@finos/vuu-data-types";
 import { Input, ToggleButton, ToggleButtonGroup } from "@salt-ds/core";
 import { LocalDataSourceProvider, getSchema } from "@finos/vuu-data-test";
+import { ColumnDescriptor } from "@finos/vuu-table-types";
 
 const lastUpdatedColumn = {
   name: "lastUpdated",
@@ -51,6 +52,7 @@ const FilterContainer = ({
 
 const DefaultFilterBarCore = ({
   QuickFilterProps,
+  columnDescriptors,
   filterState,
   onApplyFilter,
   onFilterDeleted,
@@ -61,8 +63,8 @@ const DefaultFilterBarCore = ({
   const [filterStruct, setFilterStruct] = useState<Filter | null>(null);
   const tableSchema = useMemo(() => getSchema("instruments"), []);
   const columns = useMemo(
-    () => [...tableSchema.columns, lastUpdatedColumn],
-    [tableSchema],
+    () => columnDescriptors ?? [...tableSchema.columns, lastUpdatedColumn],
+    [columnDescriptors, tableSchema.columns],
   );
 
   const handleApplyFilter = useCallback(
@@ -105,7 +107,7 @@ const DefaultFilterBarCore = ({
         onFilterDeleted={handleFilterDeleted}
         onFilterRenamed={handleFilterRenamed}
         onFilterStateChanged={handleFilterStateChange}
-        tableSchema={{ ...tableSchema, columns }}
+        tableSchema={{ ...tableSchema, columns: columns as SchemaColumn[] }}
         variant={variant}
       />
     </FilterContainer>
@@ -159,6 +161,30 @@ export const DefaultFilterBar = (props: Partial<FilterBarProps>) => (
     <FilterBarTemplate {...props} />
   </LocalDataSourceProvider>
 );
+
+export const DefaultFilterBarColumnLabels = (
+  props: Partial<FilterBarProps>,
+) => {
+  const columnDescriptors: ColumnDescriptor[] = [
+    { label: "BBG", name: "bbg", serverDataType: "string" },
+    { label: "Currency", name: "currency", serverDataType: "string" },
+    { label: "Description", name: "description", serverDataType: "string" },
+    { label: "Exchange", name: "exchange", serverDataType: "string" },
+    { label: "ISIN", name: "isin", serverDataType: "string" },
+    { label: "Lot size", name: "lotSize", serverDataType: "int" },
+    { label: "RIC", name: "ric", serverDataType: "string" },
+    { label: "Supported", name: "supported", serverDataType: "boolean" },
+    { label: "Wish list", name: "wishlist", serverDataType: "boolean" },
+    { label: "Last Updated", name: "lastUpdated", serverDataType: "long" },
+    { label: "Price", name: "price", serverDataType: "double" },
+    { label: "Date", name: "date", serverDataType: "long" },
+  ];
+  return (
+    <LocalDataSourceProvider modules={["SIMUL"]}>
+      <FilterBarTemplate {...props} columnDescriptors={columnDescriptors} />
+    </LocalDataSourceProvider>
+  );
+};
 
 export const FilterBarOneSimpleFilter = () => {
   return (


### PR DESCRIPTION
When columnDescriptors have labels (that differ from column.name) label is shown in columnpicker. 
Bug: when label is selected in FilterClause, change is not applied correctly.