### PR TITLE
fix: scroll bug with tanstack table

### DIFF
--- a/vuu-ui/packages/vuu-tanstack-table/src/useTanstackTableWithVuuDatasource.ts
+++ b/vuu-ui/packages/vuu-tanstack-table/src/useTanstackTableWithVuuDatasource.ts
@@ -76,10 +76,11 @@ export const useTanstackTableWithVuuDatasource = <T extends VuuDataSourceRow>({
       for (const row of updates) {
         dataWindow.add(row);
       }
+
       // We do the slice because an in-place update like a select operation replaces
       // only a single row within the collection. Tanstack table does an identity check
       // on the collection itself.
-      data.current = dataWindow.data.slice();
+      data.current = dataWindow.slice();
       // if (isMounted.current) {
       // TODO do we ever need to worry about missing updates here ?
       if (dataWindow.hasAllRowsWithinRange) {
@@ -102,7 +103,9 @@ export const useTanstackTableWithVuuDatasource = <T extends VuuDataSourceRow>({
     const dataSourceMessageHandler: SubscribeCallback = (message) => {
       switch (message.type) {
         case "subscribed":
-          console.log("[useVuuData] dataSourceMessageHandler subscribed");
+          console.log(
+            "[useTanstackTableWithVuuDataSource] dataSourceMessageHandler subscribed",
+          );
           break;
         case "viewport-update":
           {
@@ -198,7 +201,6 @@ export const useTanstackTableWithVuuDatasource = <T extends VuuDataSourceRow>({
     columns: columnsWithVuuAccessors,
     enableMultiRowSelection: false,
     enableRowSelection: true,
-    // getRowId: (row) => `${row[0]}`, // is this right ?
     getRowId: (row) => {
       return `${row[0]}`;
     }, // is this right ?

--- a/vuu-ui/packages/vuu-utils/src/moving-window.ts
+++ b/vuu-ui/packages/vuu-utils/src/moving-window.ts
@@ -83,6 +83,19 @@ export class MovingWindow {
     return this.#range;
   }
 
+  slice(): DataSourceRow[] {
+    const data: DataSourceRow[] = [];
+    const { from } = this.range;
+    for (let i = 0; i < this.data.length; i++) {
+      if (this.data[i]) {
+        data.push(this.data[i]);
+      } else {
+        data.push([from + i, from + i, true, false, 1, 0, "", 0]);
+      }
+    }
+    return data;
+  }
+
   // TODO make this more performant, see implementation in
   // array-backed-moving-window - use same implementation
   get hasAllRowsWithinRange(): boolean {


### PR DESCRIPTION
vertical scrolling can cause tanstack virtual to
trigger render even on a horizontally virtualised
set (eg table columns). This can trigger a render
when data rows are not available (because
waiting for response from server).
Provide dummy data rows in this scenario.