### PR TITLE
FilterClause component changes

### DIFF
--- a/vuu-ui/packages/vuu-filters/src/__tests__/__component__/FilterClause.cy.tsx
+++ b/vuu-ui/packages/vuu-filters/src/__tests__/__component__/FilterClause.cy.tsx
@@ -3,7 +3,9 @@ import {
   NewFilterClause,
   PartialFilterClauseColumnAndOperator,
   PartialFilterClauseColumnAndOperatorWithDataSource,
-  PartialFilterClauseColumnAndOperatorWithoutDefaultDropdown,
+  FilterColumnAndOperatorWithDropdownOpenOnFocusDisabled,
+  FilterColumnWithDropdownOpenOnFocusDisabled,
+  NewFilterClauseWithDropdownOpenOnFocusDisabled,
 } from "../../../../../showcase/src/examples/Filters/FilterClause/FilterClause.examples";
 
 describe("FilterClause", () => {
@@ -35,7 +37,7 @@ describe("FilterClause", () => {
     });
   });
 
-  describe("WHEN partial filter clause with Column and Operator is rendered and dataSOurce is available", () => {
+  describe("WHEN partial filter clause with Column and Operator is rendered and dataSource is available", () => {
     it("THEN component is rendered with controls for column, operator and value, value suggestions are offered", () => {
       cy.mount(
         <LocalDataSourceProvider>
@@ -51,19 +53,51 @@ describe("FilterClause", () => {
     });
   });
 
-  describe("WHEN partial filter clause with Column and Operator is rendered and default dropdown is disabled for value editor", () => {
-    it("THEN component is rendered with controls for column, operator and value, no suggestions provided", () => {
-      cy.mount(
-        <LocalDataSourceProvider>
-          <PartialFilterClauseColumnAndOperatorWithoutDefaultDropdown />
-        </LocalDataSourceProvider>,
-      );
-      const container = cy.findByTestId("filterclause");
-      container.find(".vuuFilterClauseField").should("have.length", 3);
-      cy.findByTestId("filterclause")
-        .find(".vuuFilterClauseValue input")
-        .should("be.focused");
-      cy.findAllByRole("listbox").should("not.exist");
+  describe("WHEN filter clause is rendered with openDropdownOnFocus disabled", () => {
+    describe("WITH new filter clause", () => {
+      it("THEN component is rendered with controls for column, no suggestions provided for column control", () => {
+        cy.mount(
+          <LocalDataSourceProvider>
+            <NewFilterClauseWithDropdownOpenOnFocusDisabled />
+          </LocalDataSourceProvider>,
+        );
+        const container = cy.findByTestId("filterclause");
+        container.find(".vuuFilterClauseField").should("have.length", 1);
+        cy.findByTestId("filterclause")
+          .find(".vuuFilterClauseColumn input")
+          .should("not.be.focused");
+        cy.findAllByRole("listbox").should("not.exist");
+      });
+    });
+    describe("WITH Column control set", () => {
+      it("THEN component is rendered with controls for column, operator, no suggestions provided for operator control", () => {
+        cy.mount(
+          <LocalDataSourceProvider>
+            <FilterColumnWithDropdownOpenOnFocusDisabled />
+          </LocalDataSourceProvider>,
+        );
+        const container = cy.findByTestId("filterclause");
+        container.find(".vuuFilterClauseField").should("have.length", 2);
+        cy.findByTestId("filterclause")
+          .find(".vuuFilterClauseOperator input")
+          .should("not.be.focused");
+        cy.findAllByRole("listbox").should("not.exist");
+      });
+    });
+    describe("WITH Column and Operator controls set", () => {
+      it("THEN component is rendered with controls for column, operator and value, no suggestions provided for value control", () => {
+        cy.mount(
+          <LocalDataSourceProvider>
+            <FilterColumnAndOperatorWithDropdownOpenOnFocusDisabled />
+          </LocalDataSourceProvider>,
+        );
+        const container = cy.findByTestId("filterclause");
+        container.find(".vuuFilterClauseField").should("have.length", 3);
+        cy.findByTestId("filterclause")
+          .find(".vuuFilterClauseValue input")
+          .should("not.be.focused");
+        cy.findAllByRole("listbox").should("not.exist");
+      });
     });
   });
 });

--- a/vuu-ui/packages/vuu-filters/src/filter-clause/ColumnPicker.tsx
+++ b/vuu-ui/packages/vuu-filters/src/filter-clause/ColumnPicker.tsx
@@ -1,5 +1,5 @@
 import type { ColumnDescriptor } from "@vuu-ui/vuu-table-types";
-import { ExpandoCombobox, ExpandoComboboxProps } from "./ExpandoCombobox";
+import { ExpandoCombobox } from "./ExpandoCombobox";
 import { ComboBoxProps, Option } from "@salt-ds/core";
 import { ForwardedRef, SyntheticEvent, forwardRef } from "react";
 import { useExpandoComboBox } from "./useExpandoCombobox";
@@ -10,7 +10,6 @@ export type ColumnPickerProps = Pick<
 > & {
   columns: ColumnDescriptor[];
   onSelect: (evt: SyntheticEvent, columnName: string) => void;
-  defaultDropdown?: ExpandoComboboxProps["defaultDropdown"];
 };
 
 export const ColumnPicker = forwardRef(function ColumnPicker(
@@ -20,7 +19,6 @@ export const ColumnPicker = forwardRef(function ColumnPicker(
     inputProps,
     onSelect,
     value: valueProp,
-    defaultDropdown = true,
   }: ColumnPickerProps,
   forwardedRef: ForwardedRef<HTMLDivElement>,
 ) {
@@ -37,7 +35,6 @@ export const ColumnPicker = forwardRef(function ColumnPicker(
       data-field="column"
       ref={forwardedRef}
       title="column"
-      defaultDropdown={defaultDropdown}
     >
       {columns
         .filter(({ name }) =>

--- a/vuu-ui/packages/vuu-filters/src/filter-clause/ExpandoCombobox.tsx
+++ b/vuu-ui/packages/vuu-filters/src/filter-clause/ExpandoCombobox.tsx
@@ -21,7 +21,6 @@ const classBase = "vuuExpandoCombobox";
 export interface ExpandoComboboxProps<Item = string>
   extends ComboBoxProps<Item> {
   itemToString?: (item: Item) => string;
-  defaultDropdown?: boolean | undefined;
 }
 
 export type ComboBoxOpenChangeHandler = Exclude<
@@ -49,7 +48,6 @@ export const ExpandoCombobox = forwardRef(function ExpandoCombobox<
     onSelectionChange,
     onOpenChange,
     value: valueProp,
-    defaultDropdown = true,
     ...props
   }: ExpandoComboboxProps<Item>,
   forwardedRef: ForwardedRef<HTMLDivElement>,
@@ -65,7 +63,6 @@ export const ExpandoCombobox = forwardRef(function ExpandoCombobox<
   const [value, setValue] = useState(
     valueProp === undefined ? "" : valueProp.toString(),
   );
-  const [touched, setTouched] = useState<boolean>(false);
 
   const handleChange = useCallback(
     (evt: ChangeEvent<HTMLInputElement>) => {
@@ -105,17 +102,13 @@ export const ExpandoCombobox = forwardRef(function ExpandoCombobox<
       ...inputPropsProp,
       onFocus: (evt) => {
         inputPropsProp?.onFocus?.(evt);
-        if (!defaultDropdown && !touched) {
-          setTouched(true);
-          return;
-        }
 
         setTimeout(() => {
           setOpen(true);
         }, 100);
       },
     };
-  }, [inputPropsProp, defaultDropdown, touched]);
+  }, [inputPropsProp]);
 
   return (
     <div

--- a/vuu-ui/packages/vuu-filters/src/filter-clause/FilterClause.tsx
+++ b/vuu-ui/packages/vuu-filters/src/filter-clause/FilterClause.tsx
@@ -15,19 +15,12 @@ import { FilterClauseValueEditor } from "./value-editors/FilterClauseValueEditor
 import { VuuTable } from "@vuu-ui/vuu-protocol-types";
 import filterClauseCss from "./FilterClause.css";
 import { OperatorPicker } from "./OperatorPicker";
-import { ExpandoComboboxProps } from "./ExpandoCombobox";
 
 export type FilterClauseCancelType = "Backspace" | "Escape";
 export type FilterClauseCancelHandler = (
   filterClause: FilterClauseModel,
   reason: FilterClauseCancelType,
 ) => void;
-
-export type ShowDefaultDropdown = {
-  forColumnPicker?: ExpandoComboboxProps["defaultDropdown"];
-  forOperatorPicker?: ExpandoComboboxProps["defaultDropdown"];
-  forValueEditor?: ExpandoComboboxProps["defaultDropdown"];
-};
 
 export interface FilterClauseProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
@@ -36,7 +29,7 @@ export interface FilterClauseProps
   onCancel?: FilterClauseCancelHandler;
   onDropdownOpen?: () => void;
   onFocusSave?: () => void;
-  showDefaultDropdown?: ShowDefaultDropdown;
+  openDropdownOnFocus?: boolean;
   vuuTable: VuuTable;
 }
 
@@ -50,9 +43,10 @@ export const FilterClause = ({
   onFocusSave,
   filterClauseModel,
   vuuTable,
-  showDefaultDropdown,
+  openDropdownOnFocus = true,
   ...htmlAttributes
 }: FilterClauseProps) => {
+
   const {
     inputProps,
     columnRef,
@@ -70,6 +64,7 @@ export const FilterClause = ({
     onCancel,
     onFocusSave,
     columnsByName,
+    openDropdownOnFocus,
   });
 
   const targetWindow = useWindow();
@@ -91,7 +86,6 @@ export const FilterClause = ({
         onSelect={onSelectColumn}
         ref={columnRef}
         value={filterClauseModel.column ?? ""}
-        defaultDropdown={showDefaultDropdown?.forColumnPicker ?? true}
       />
       {selectedColumn?.name ? (
         <OperatorPicker
@@ -104,7 +98,6 @@ export const FilterClause = ({
           onSelect={onSelectOperator}
           ref={operatorRef}
           value={filterClauseModel.op ?? ""}
-          defaultDropdown={showDefaultDropdown?.forOperatorPicker ?? true}
         />
       ) : null}
       {filterClauseModel.op ? (
@@ -122,7 +115,6 @@ export const FilterClause = ({
             (filterClause as MultiValueFilterClause)?.values ??
             (filterClause as SingleValueFilterClause)?.value
           }
-          defaultDropdown={showDefaultDropdown?.forValueEditor ?? true}
         />
       ) : null}
     </div>

--- a/vuu-ui/packages/vuu-filters/src/filter-clause/OperatorPicker.tsx
+++ b/vuu-ui/packages/vuu-filters/src/filter-clause/OperatorPicker.tsx
@@ -3,7 +3,7 @@ import type { ColumnDescriptor } from "@vuu-ui/vuu-table-types";
 import { isValidFilterClauseOp } from "@vuu-ui/vuu-utils";
 import { ComboBoxProps, Option } from "@salt-ds/core";
 import { ForwardedRef, SyntheticEvent, forwardRef } from "react";
-import { ExpandoCombobox, ExpandoComboboxProps } from "./ExpandoCombobox";
+import { ExpandoCombobox } from "./ExpandoCombobox";
 import { getOperators } from "./operator-utils";
 
 export type OperatorPickerProps = Pick<
@@ -12,7 +12,6 @@ export type OperatorPickerProps = Pick<
 > & {
   column: ColumnDescriptor;
   onSelect: (evt: SyntheticEvent, operator: FilterClauseOp) => void;
-  defaultDropdown?: ExpandoComboboxProps["defaultDropdown"];
 };
 
 export const OperatorPicker = forwardRef(function ColumnPicker(
@@ -22,7 +21,6 @@ export const OperatorPicker = forwardRef(function ColumnPicker(
     inputProps,
     onSelect,
     value,
-    defaultDropdown = true,
   }: OperatorPickerProps,
   forwardedRef: ForwardedRef<HTMLDivElement>,
 ) {
@@ -45,7 +43,6 @@ export const OperatorPicker = forwardRef(function ColumnPicker(
       ref={forwardedRef}
       title="operator"
       value={value}
-      defaultDropdown={defaultDropdown}
     >
       {getOperators(column).map((op) => (
         <Option value={op} key={op} />

--- a/vuu-ui/packages/vuu-filters/src/filter-clause/value-editors/FilterClauseValueEditor.tsx
+++ b/vuu-ui/packages/vuu-filters/src/filter-clause/value-editors/FilterClauseValueEditor.tsx
@@ -11,7 +11,6 @@ import {
 import { isDateTimeDataValue } from "@vuu-ui/vuu-utils";
 import { ForwardedRef, forwardRef } from "react";
 import { FilterClauseValueEditorDate } from "./FilterClauseValueEditorDate";
-import { ExpandoComboboxProps } from "../ExpandoCombobox";
 
 const classBase = "vuuFilterClause";
 
@@ -27,7 +26,6 @@ type FilterClauseValueEditorProps = Pick<
 } & {
   operator?: SingleValueFilterClauseOp | "in";
   value?: string | string[] | number | number[] | boolean | boolean[];
-  defaultDropdown?: ExpandoComboboxProps["defaultDropdown"];
 };
 
 export const FilterClauseValueEditor = forwardRef(
@@ -41,7 +39,6 @@ export const FilterClauseValueEditor = forwardRef(
       onOpenChange,
       table,
       value,
-      defaultDropdown = true,
     }: FilterClauseValueEditorProps,
     forwardedRef: ForwardedRef<HTMLDivElement>,
   ) {
@@ -83,7 +80,6 @@ export const FilterClauseValueEditor = forwardRef(
                   ? value.map((val) => val.toString())
                   : (value.toString() as string | string[])
             }
-            defaultDropdown={defaultDropdown}
           />
         );
       case "int":

--- a/vuu-ui/packages/vuu-filters/src/filter-clause/value-editors/FilterClauseValueEditorText.tsx
+++ b/vuu-ui/packages/vuu-filters/src/filter-clause/value-editors/FilterClauseValueEditorText.tsx
@@ -15,7 +15,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { ExpandoCombobox, ExpandoComboboxProps } from "../ExpandoCombobox";
+import { ExpandoCombobox } from "../ExpandoCombobox";
 import { FilterClauseValueEditor } from "../filterClauseTypes";
 
 export interface FilterClauseTextValueEditorProps
@@ -25,7 +25,6 @@ export interface FilterClauseTextValueEditorProps
   // ref: RefObject<HTMLDivElement>;
   operator: string;
   value: string | string[];
-  defaultDropdown?: ExpandoComboboxProps["defaultDropdown"];
 }
 
 export const FilterClauseValueEditorText = forwardRef(
@@ -39,7 +38,6 @@ export const FilterClauseValueEditorText = forwardRef(
       operator,
       table,
       value,
-      defaultDropdown = true,
     }: FilterClauseTextValueEditorProps,
     forwardedRef: ForwardedRef<HTMLDivElement>,
   ) {
@@ -177,7 +175,6 @@ export const FilterClauseValueEditorText = forwardRef(
               multiselect
               truncate
               value={value}
-              defaultDropdown={defaultDropdown}
             >
               {typeaheadValues
                 // .filter((typeaheadValue) =>
@@ -200,7 +197,6 @@ export const FilterClauseValueEditorText = forwardRef(
               onSelectionChange={handleSingleValueSelectionChange}
               ref={forwardedRef}
               value={value}
-              defaultDropdown={defaultDropdown}
             >
               {typeaheadValues.map((state) => (
                 <Option value={state} key={state} disabled />
@@ -232,8 +228,7 @@ export const FilterClauseValueEditorText = forwardRef(
               onSelectionChange={handleSingleValueSelectionChange}
               ref={forwardedRef}
               value={value}
-              defaultDropdown={defaultDropdown}
-            >
+             >
               {typeaheadValues.map((state) => (
                 <Option value={state} key={state} />
               ))}
@@ -254,7 +249,6 @@ export const FilterClauseValueEditorText = forwardRef(
       value,
       handleSingleValueSelectionChange,
       onOpenChange,
-      defaultDropdown
     ]);
 
     return getValueInputField();

--- a/vuu-ui/showcase/src/examples/DataTable/Tree.data.ts
+++ b/vuu-ui/showcase/src/examples/DataTable/Tree.data.ts
@@ -595,6 +595,15 @@ export default [
                 },
               },
               {
+                id: "Filters/FilterClause/FilterClause/NewFilterClauseWithDropdownOpenOnFocusDisabled",
+                label: "NewFilterClauseWithDropdownOpenOnFocusDisabled",
+                nodeData: {
+                  componentName:
+                    "NewFilterClauseWithDropdownOpenOnFocusDisabled",
+                  path: "src/examples/Filters/FilterClause/FilterClause.examples.tsx",
+                },
+              },
+              {
                 id: "Filters/FilterClause/FilterClause/PartialFilterClauseColumnOnly",
                 label: "PartialFilterClauseColumnOnly",
                 nodeData: {
@@ -611,12 +620,22 @@ export default [
                 },
               },
               {
-                id: "Filters/FilterClause/FilterClause/PartialFilterClauseColumnAndOperatorWithoutDefaultDropdown",
+                id: "Filters/FilterClause/FilterClause/FilterColumnWithDropdownOpenOnFocusDisabled",
                 label:
-                  "PartialFilterClauseColumnAndOperatorWithoutDefaultDropdown",
+                  "FilterColumnWithDropdownOpenOnFocusDisabled",
                 nodeData: {
                   componentName:
-                    "PartialFilterClauseColumnAndOperatorWithoutDefaultDropdown",
+                    "FilterColumnWithDropdownOpenOnFocusDisabled",
+                  path: "src/examples/Filters/FilterClause/FilterClause.examples.tsx",
+                },
+              },
+              {
+                id: "Filters/FilterClause/FilterClause/FilterColumnAndOperatorWithDropdownOpenOnFocusDisabled",
+                label:
+                  "FilterColumnAndOperatorWithDropdownOpenOnFocusDisabled",
+                nodeData: {
+                  componentName:
+                    "FilterColumnAndOperatorWithDropdownOpenOnFocusDisabled",
                   path: "src/examples/Filters/FilterClause/FilterClause.examples.tsx",
                 },
               },

--- a/vuu-ui/showcase/src/examples/Filters/FilterClause/FilterClause.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Filters/FilterClause/FilterClause.examples.tsx
@@ -2,11 +2,7 @@ import { Input } from "@salt-ds/core";
 import { LocalDataSourceProvider, getSchema } from "@vuu-ui/vuu-data-test";
 import { SchemaColumn, TableSchema } from "@vuu-ui/vuu-data-types";
 import { ColumnDescriptorsByName } from "@vuu-ui/vuu-filter-types";
-import {
-  ShowDefaultDropdown,
-  FilterClause,
-  FilterClauseModel,
-} from "@vuu-ui/vuu-filters";
+import { FilterClause, FilterClauseModel } from "@vuu-ui/vuu-filters";
 import { ColumnPicker } from "@vuu-ui/vuu-filters/src/filter-clause/ColumnPicker";
 import { DataSourceProvider, toColumnName, useData } from "@vuu-ui/vuu-utils";
 import { ReactNode, useMemo } from "react";
@@ -17,12 +13,12 @@ const FilterClauseTemplate = ({
   filterClauseModel = new FilterClauseModel({}),
   tableSchema = getSchema("instruments"),
   columnsByName = columnDescriptorsByName(tableSchema.columns),
-  showDefaultDropdown,
+  openDropdownOnFocus,
 }: {
   columnsByName?: ColumnDescriptorsByName;
   filterClauseModel?: FilterClauseModel;
   tableSchema?: TableSchema;
-  showDefaultDropdown?: ShowDefaultDropdown;
+  openDropdownOnFocus?: boolean;
 }) => {
   const { VuuDataSource } = useData();
   const dataSource = useMemo(() => {
@@ -40,7 +36,7 @@ const FilterClauseTemplate = ({
           data-testid="filterclause"
           filterClauseModel={filterClauseModel}
           vuuTable={tableSchema.table}
-          showDefaultDropdown={showDefaultDropdown}
+          openDropdownOnFocus={openDropdownOnFocus}
         />
       </div>
     </DataSourceProvider>
@@ -90,6 +86,17 @@ export const NewFilterClauseNoCompletions = () => {
   return <FilterClauseTemplate />;
 };
 
+/** tags=data-consumer */
+export const NewFilterClauseWithDropdownOpenOnFocusDisabled = () => {
+  const filterClauseModel = useMemo(() => new FilterClauseModel({}), []);
+  return (
+    <FilterClauseTemplate
+      filterClauseModel={filterClauseModel}
+      openDropdownOnFocus={false}
+    />
+  );
+};
+
 export const PartialFilterClauseColumnOnly = () => {
   const filterClauseModel = useMemo(
     () =>
@@ -119,11 +126,27 @@ export const PartialFilterClauseColumnAndOperator = () => {
 };
 
 /** tags=data-consumer */
-export const PartialFilterClauseColumnAndOperatorWithoutDefaultDropdown = () => {
+export const FilterColumnWithDropdownOpenOnFocusDisabled = () => {
   const filterClauseModel = useMemo(
     () =>
       new FilterClauseModel({
         column: "currency",
+      }),
+    [],
+  );
+  return (
+    <FilterClauseTemplate
+      filterClauseModel={filterClauseModel}
+      openDropdownOnFocus={false}
+    />
+  );
+};
+
+export const FilterColumnAndOperatorWithDropdownOpenOnFocusDisabled = () => {
+  const filterClauseModel = useMemo(
+    () =>
+      new FilterClauseModel({
+        column: "exchange",
         op: "=",
       }),
     [],
@@ -131,7 +154,7 @@ export const PartialFilterClauseColumnAndOperatorWithoutDefaultDropdown = () => 
   return (
     <FilterClauseTemplate
       filterClauseModel={filterClauseModel}
-      showDefaultDropdown={{ forValueEditor: false }}
+      openDropdownOnFocus={false}
     />
   );
 };


### PR DESCRIPTION
The filterclause component opens up the suggestions dropdown by default. 
In the scenario where we place multiple FilterClauses (without a filtereditor) on the page, they render with open dropdowns. This dropdown behaviour can now be controlled via a prop.

Also, for multiselect setup, if the values are cleared, the model will trigger a commit on close of the dropdown. (useFilterClause.ts -> handleOpenChange). This will enable the consumer to attach a handler based on the value of the filter.

<img width="1740" height="88" alt="image" src="https://github.com/user-attachments/assets/36050672-7a38-49e0-b5a6-b019ca358df5" />
