### PR TITLE
#1702 add invisible flag to table definition

### DIFF
--- a/vuu/src/main/scala/org/finos/vuu/api/TableDef.scala
+++ b/vuu/src/main/scala/org/finos/vuu/api/TableDef.scala
@@ -122,7 +122,8 @@ class TableDef(val name: String,
                val joinFields: Seq[String],
                val autosubscribe: Boolean = false,
                val links: VisualLinks = VisualLinks(),
-               val indices: Indices) extends VuuInMemPluginLocator {
+               val indices: Indices,
+               val invisible: Boolean = false) extends VuuInMemPluginLocator {
 
   private val createdTimeColumn: SimpleColumn = SimpleColumn(CreatedTimeColumnName, customColumns.length, DataType.fromString("long"))
   private val updatedTimeColumn: SimpleColumn = SimpleColumn(LastUpdatedTimeColumnName, customColumns.length + 1, DataType.fromString("long"))

--- a/vuu/src/main/scala/org/finos/vuu/api/TableDef.scala
+++ b/vuu/src/main/scala/org/finos/vuu/api/TableDef.scala
@@ -53,6 +53,10 @@ object TableDef {
   def apply(name: String, keyField: String, columns: Array[Column], joinFields: String*): TableDef = {
     new TableDef(name, keyField, columns, joinFields, indices = Indices())
   }
+
+  def apply(name: String, keyField: String, columns: Array[Column], invisible: Boolean, joinFields: String*): TableDef = {
+    new TableDef(name, keyField, columns, joinFields, indices = Indices(), invisible = invisible)
+  }
 }
 
 object AutoSubscribeTableDef {

--- a/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
@@ -315,9 +315,10 @@ class CoreServerApiHandler(val viewPortContainer: ViewPortContainer,
 
     val table = tableContainer.getTable(msg.table.table)
 
-    if (table == null || table.getTableDef.invisible)
+    if (table == null || table.getTableDef.invisible) {
       errorMsg(s"no table found for ${msg.table}")(ctx)
-    else {
+      vsMsg(CreateViewPortReject(msg.table, s"no table found for ${msg.table}"))(ctx)
+    } else {
 
       val columns = if (msg.columns.length == 1 && msg.columns(0) == "*") {
         logger.trace("[CreateViewPortRequest] Wildcard specified for columns, going to return all")

--- a/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
@@ -315,7 +315,7 @@ class CoreServerApiHandler(val viewPortContainer: ViewPortContainer,
 
     val table = tableContainer.getTable(msg.table.table)
 
-    if (table == null)
+    if (table == null || table.getTableDef.invisible)
       errorMsg(s"no table found for ${msg.table}")(ctx)
     else {
 

--- a/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
@@ -316,7 +316,6 @@ class CoreServerApiHandler(val viewPortContainer: ViewPortContainer,
     val table = tableContainer.getTable(msg.table.table)
 
     if (table == null || table.getTableDef.invisible) {
-      errorMsg(s"no table found for ${msg.table}")(ctx)
       vsMsg(CreateViewPortReject(msg.table, s"no table found for ${msg.table}"))(ctx)
     } else {
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/validation/CreateValidViewportTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/validation/CreateValidViewportTest.scala
@@ -1,10 +1,9 @@
 package org.finos.vuu.viewport.validation
 
 import org.finos.toolbox.jmx.{MetricsProvider, MetricsProviderImpl}
-import org.finos.toolbox.lifecycle.LifecycleContainer
 import org.finos.toolbox.time.{Clock, TestFriendlyClock}
 import org.finos.vuu.core.CoreServerApiHandler
-import org.finos.vuu.net.{ClientSessionId, CreateViewPortRequest, RequestContext}
+import org.finos.vuu.net.{ClientSessionId, CreateViewPortReject, CreateViewPortRequest, CreateViewPortSuccess, RequestContext, ViewServerMessage}
 import org.finos.vuu.viewport.{AbstractViewPortTestCase, ViewPortRange, ViewPortTable}
 import org.scalatest.GivenWhenThen
 import org.scalatest.matchers.should.Matchers
@@ -17,10 +16,9 @@ class CreateValidViewportTest extends AbstractViewPortTestCase with Matchers wit
 
       implicit val clock: Clock = new TestFriendlyClock(1311544800)
       implicit val metrics: MetricsProvider = new MetricsProviderImpl
-      implicit val lifecycle: LifecycleContainer = new LifecycleContainer
 
       Given("we've created a viewport with orders in")
-      val (viewPortContainer, _, _, prices, _, _, outQueue) = createDefaultOrderPricesViewPortInfra()
+      val (viewPortContainer, _, _, _, _, _, outQueue) = createDefaultOrderPricesViewPortInfra()
 
       val api = new CoreServerApiHandler(viewPortContainer, tableContainer = viewPortContainer.tableContainer, providers = viewPortContainer.providerContainer)
 
@@ -28,10 +26,58 @@ class CreateValidViewportTest extends AbstractViewPortTestCase with Matchers wit
 
       val ctx = RequestContext("req-101", ClientSessionId("A", "A"), outQueue, "token-0001")
 
-      val exception = intercept[Exception]{
+      val exception = intercept[Exception] {
         api.process(CreateViewPortRequest(ViewPortTable("orders", "TEST"), ViewPortRange(0, 100), vpcolumnsOrders.toArray))(ctx)
       }
       exception.getMessage should startWith("Invalid columns specified in viewport request")
+    }
+
+    Scenario("create viewport for visible table, return success message") {
+      implicit val clock: Clock = new TestFriendlyClock(1311544800)
+      implicit val metrics: MetricsProvider = new MetricsProviderImpl
+
+      Given("we've created a viewport with orders in")
+      val (viewPortContainer, _, _, _, outQueue) = createDefaultViewPortInfra()
+
+      val api = new CoreServerApiHandler(viewPortContainer, tableContainer = viewPortContainer.tableContainer, providers = viewPortContainer.providerContainer)
+      val ctx = RequestContext("req-101", ClientSessionId("A", "A"), outQueue, "token-0001")
+
+      val result: Option[ViewServerMessage] = api.process(CreateViewPortRequest(ViewPortTable("orders", "TEST"), ViewPortRange(0, 100), Array("orderId")))(ctx)
+      result.isDefined shouldBe true
+      result.get.body.isInstanceOf[CreateViewPortSuccess] shouldBe true
+      result.get.body.asInstanceOf[CreateViewPortSuccess].table shouldBe "orders"
+    }
+
+    Scenario("create viewport for invisible table, return reject message") {
+      implicit val clock: Clock = new TestFriendlyClock(1311544800)
+      implicit val metrics: MetricsProvider = new MetricsProviderImpl
+
+      Given("we've created a viewport with orders in")
+      val (viewPortContainer, _, _, _, outQueue) = createDefaultViewPortInfraWithInvisibleTable()
+      val api = new CoreServerApiHandler(viewPortContainer, tableContainer = viewPortContainer.tableContainer, providers = viewPortContainer.providerContainer)
+
+      val ctx = RequestContext("req-101", ClientSessionId("A", "A"), outQueue, "token-0001")
+
+      val result: Option[ViewServerMessage] = api.process(CreateViewPortRequest(ViewPortTable("orders", "TEST"), ViewPortRange(0, 100), Array("orderId")))(ctx)
+      result.isDefined shouldBe true
+      result.get.body.isInstanceOf[CreateViewPortReject] shouldBe true
+      result.get.body.asInstanceOf[CreateViewPortReject].msg shouldBe "no table found for TEST:orders"
+    }
+
+    Scenario("create viewport for a table that doesn't exist, return reject message") {
+      implicit val clock: Clock = new TestFriendlyClock(1311544800)
+      implicit val metrics: MetricsProvider = new MetricsProviderImpl
+
+      Given("we've created a viewport with orders in")
+      val (viewPortContainer, _, _, _, outQueue) = createDefaultViewPortInfraWithInvisibleTable()
+
+      val api = new CoreServerApiHandler(viewPortContainer, tableContainer = viewPortContainer.tableContainer, providers = viewPortContainer.providerContainer)
+      val ctx = RequestContext("req-101", ClientSessionId("A", "A"), outQueue, "token-0001")
+
+      val result: Option[ViewServerMessage] = api.process(CreateViewPortRequest(ViewPortTable("random_table", "TEST"), ViewPortRange(0, 100), Array("orderId")))(ctx)
+      result.isDefined shouldBe true
+      result.get.body.isInstanceOf[CreateViewPortReject] shouldBe true
+      result.get.body.asInstanceOf[CreateViewPortReject].msg shouldBe "no table found for TEST:random_table"
     }
   }
 }


### PR DESCRIPTION
Add invisible flag to table definition
Reject creating VP if table is invisible
Start using dedicated reject message

Note only supporting invisible flag for standard non-join table for now. I had a battle with JoinTableDef but because joins: JoinTo* is varargs I coulnd't find an easy way to add invisible flag to join table def without changing all lines calling it.

closes #1702 