### PR TITLE
Join table performance improvements

### DIFF
--- a/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
@@ -293,7 +293,7 @@ class CoreServerApiHandler(val viewPortContainer: ViewPortContainer,
         //logger.info(s"Setting columns to ${columns.map(_.name).mkString(",")} ")
 
         Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.session.user,
-          ChangeViewPortSuccess(newViewPort.id, viewport.getColumns.getColumns().map(_.name).toArray, sort, msg.groupBy, msg.filterSpec, msg.aggregations)))
+          ChangeViewPortSuccess(newViewPort.id, viewport.getColumns.getColumns.map(_.name).toArray, sort, msg.groupBy, msg.filterSpec, msg.aggregations)))
 
       case None =>
         Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.session.user, ChangeViewPortReject(msg.viewPortId, s"Could not find vp ${msg.viewPortId} in session ${ctx.session}")))

--- a/vuu/src/main/scala/org/finos/vuu/core/table/InMemDataTable.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/InMemDataTable.scala
@@ -324,7 +324,7 @@ class InMemDataTable(val tableDef: TableDef, val joinProvider: JoinTableProvider
       case null =>
         Array[Any]()
       case row: RowWithData =>
-        row.toArray(columns.getColumns())
+        row.toArray(columns.getColumns)
     }
   }
 

--- a/vuu/src/main/scala/org/finos/vuu/core/table/JoinTable.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/JoinTable.scala
@@ -466,16 +466,12 @@ class JoinTable(val tableDef: JoinTableDef, val sourceTables: Map[String, DataTa
           previous
         } else {
           val sourceColumns = viewPortColumns.getJoinViewPortColumns(sourceTableName)
-          if (sourceColumns.nonEmpty) {
-            table.pullRow(fk, sourceColumns.get) match {
+          table.pullRow(fk, sourceColumns) match {
               case EmptyRowData =>
                 previous
               case data: RowWithData =>
                 previous ++ columnList.map(column => column.name -> column.sourceColumn.getData(data)).toMap
             }
-          } else {
-            previous
-          }
         }
       })
 

--- a/vuu/src/main/scala/org/finos/vuu/core/table/ViewPortColumnCreator.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/ViewPortColumnCreator.scala
@@ -3,6 +3,8 @@ package org.finos.vuu.core.table
 import org.finos.vuu.core.table.column.CalculatedColumnFactory
 import org.finos.vuu.viewport.ViewPortColumns
 
+import scala.collection.mutable.ListBuffer
+
 object ViewPortColumnCreator {
 
   def isCalculatedColumn(column: String): Boolean = {
@@ -17,18 +19,18 @@ object ViewPortColumnCreator {
 
   def create(table: DataTable, columns: List[String]): ViewPortColumns = {
 
-    var vpColumns: ViewPortColumns = ViewPortColumns()
+    val vpColumns: ListBuffer[Column] = ListBuffer()
 
     columns.foreach( column => {
       if (isCalculatedColumn(column)) {
         val (name, dataType, definition) = parseCalcColumn(column)
-        vpColumns = ViewPortColumns(CalculatedColumnFactory.parse(vpColumns, name, dataType, definition), vpColumns)
+        vpColumns.addOne(CalculatedColumnFactory.parse(vpColumns, name, dataType, definition))
       } else {
-        vpColumns = ViewPortColumns(table.getTableDef.columnForName(column), vpColumns)
+        vpColumns.addOne(table.getTableDef.columnForName(column))
       }
     })
 
-    vpColumns
+    ViewPortColumns(vpColumns.toList)
   }
 
 }

--- a/vuu/src/main/scala/org/finos/vuu/core/table/ViewPortColumnCreator.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/ViewPortColumnCreator.scala
@@ -1,5 +1,6 @@
 package org.finos.vuu.core.table
 
+import org.finos.vuu.api.TableDef
 import org.finos.vuu.core.table.column.CalculatedColumnFactory
 import org.finos.vuu.viewport.ViewPortColumns
 
@@ -18,6 +19,10 @@ object ViewPortColumnCreator {
   }
 
   def create(table: DataTable, columns: List[String]): ViewPortColumns = {
+    create(table.getTableDef, columns)
+  }
+
+  def create(tableDef: TableDef, columns: List[String]): ViewPortColumns = {
 
     val vpColumns: ListBuffer[Column] = ListBuffer()
 
@@ -26,7 +31,7 @@ object ViewPortColumnCreator {
         val (name, dataType, definition) = parseCalcColumn(column)
         vpColumns.addOne(CalculatedColumnFactory.parse(vpColumns, name, dataType, definition))
       } else {
-        vpColumns.addOne(table.getTableDef.columnForName(column))
+        vpColumns.addOne(tableDef.columnForName(column))
       }
     })
 

--- a/vuu/src/main/scala/org/finos/vuu/core/table/column/CalculatedColumnFactory.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/column/CalculatedColumnFactory.scala
@@ -3,12 +3,10 @@ package org.finos.vuu.core.table.column
 import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
 import org.finos.vuu.core.table.{CalculatedColumn, Column, DataType}
 import org.finos.vuu.grammar.{CalculatedColumnLexer, CalculatedColumnParser}
-import org.finos.vuu.viewport.ViewPortColumns
 
 object CalculatedColumnFactory {
 
-  def parse(columns: ViewPortColumns, name: String, dataType: String, definition: String): Column = {
-
+  def parse(columns: Iterable[Column], name: String, dataType: String, definition: String): Column = {
       val dt = DataType.fromString(dataType)
       val input = CharStreams.fromString(definition)
       val lexer = new CalculatedColumnLexer(input)
@@ -17,7 +15,7 @@ object CalculatedColumnFactory {
       val tree = parser.expression()
       val eval = new CalculatedColumnVisitor(columns)
       val clause = eval.visit(tree)
-      CalculatedColumn(name, clause, columns.count(), dt)
+      CalculatedColumn(name, clause, columns.size, dt)
   }
 
 }

--- a/vuu/src/main/scala/org/finos/vuu/core/table/column/CalculatedColumnVisitor.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/column/CalculatedColumnVisitor.scala
@@ -5,11 +5,10 @@ import org.antlr.v4.runtime.tree.{ErrorNode, ParseTree, TerminalNode}
 import org.finos.vuu.core.table.{Column, DataType}
 import org.finos.vuu.grammar.CalculatedColumnParser.{FunctionContext, OperatorContext}
 import org.finos.vuu.grammar.{CalculatedColumnBaseVisitor, CalculatedColumnLexer, CalculatedColumnParser}
-import org.finos.vuu.viewport.ViewPortColumns
 
 import scala.jdk.CollectionConverters._
 
-class CalculatedColumnVisitor(val columns: ViewPortColumns) extends CalculatedColumnBaseVisitor[CalculatedColumnClause] with StrictLogging {
+class CalculatedColumnVisitor(val columns: Iterable[Column]) extends CalculatedColumnBaseVisitor[CalculatedColumnClause] with StrictLogging {
 
   override def visitExpression(ctx: CalculatedColumnParser.ExpressionContext): CalculatedColumnClause = {
     logger.trace("VISIT: Expression:" + ctx)
@@ -245,7 +244,7 @@ class CalculatedColumnVisitor(val columns: ViewPortColumns) extends CalculatedCo
   }
 
   private def getColumn(name: String): Option[Column] = {
-    columns.getColumnForName(name)
+    columns.find(p => p.name == name)
   }
 
   //  override def aggregateResult(aggregate: CalculatedColumnClause, nextResult: CalculatedColumnClause): CalculatedColumnClause = {

--- a/vuu/src/main/scala/org/finos/vuu/core/tree/TreeSessionTableImpl.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/tree/TreeSessionTableImpl.scala
@@ -193,7 +193,7 @@ class TreeSessionTableImpl(val source: RowSource, val session: ClientSessionId, 
 
   private def getOnlyTreeColumnsAsMap(key: String, columns: ViewPortColumns, node: TreeNode): Map[String, Any] = {
 
-    columns.getColumns().map(c => {
+    columns.getColumns.map(c => {
       val aggregation = node.getAggregationFor(c)
 
       val r = if (aggregation == null)
@@ -209,7 +209,7 @@ class TreeSessionTableImpl(val source: RowSource, val session: ClientSessionId, 
 
   private def getOnlyTreeColumns(key: String, columns: ViewPortColumns, node: TreeNode): Array[Any] = {
     val keysByColumn = node.keysByColumn
-    columns.getColumns().map(c => {
+    columns.getColumns.map(c => {
 
       val aggregation = node.getAggregationFor(c)
 

--- a/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
+++ b/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
@@ -8,7 +8,7 @@ trait ViewPortColumns {
   def getColumnForName(name: String): Option[Column]
   def hasJoinColumns: Boolean
   def getJoinColumnsByTable: Map[String, List[JoinColumn]]
-  def getJoinViewPortColumns(sourceTable: String): Option[ViewPortColumns]
+  def getJoinViewPortColumns(sourceTable: String): ViewPortColumns
   def hasCalculatedColumns: Boolean
   def getCalculatedColumns: List[CalculatedColumn]
   def pullRow(key: String, row: RowData): RowData
@@ -17,7 +17,9 @@ trait ViewPortColumns {
 
 object ViewPortColumns {
 
-  def apply(): ViewPortColumns = ViewPortColumnsImpl(List())
+  private final val emptyViewPortColumns = ViewPortColumnsImpl(List())
+
+  def apply(): ViewPortColumns = emptyViewPortColumns
 
   def apply(columns: List[Column]): ViewPortColumns = {
     ViewPortColumnsImpl(columns)
@@ -71,7 +73,7 @@ private case class ViewPortColumnsImpl(sourceColumns: List[Column]) extends View
     }
   }
 
-  override def getJoinViewPortColumns(sourceTable: String): Option[ViewPortColumns] = joinViewPortColumns.get(sourceTable)
+  override def getJoinViewPortColumns(sourceTable: String): ViewPortColumns = joinViewPortColumns.getOrElse(sourceTable, ViewPortColumns())
 
   private lazy val hasCalculatedColumn: Boolean = sourceColumns.exists(_.isInstanceOf[CalculatedColumn])
 

--- a/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
+++ b/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
@@ -17,7 +17,7 @@ trait ViewPortColumns {
 
 object ViewPortColumns {
 
-  private final val emptyViewPortColumns = ViewPortColumnsImpl(List())
+  private final val emptyViewPortColumns = ViewPortColumnsImpl(List.empty)
 
   def apply(): ViewPortColumns = emptyViewPortColumns
 

--- a/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
+++ b/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
@@ -28,14 +28,14 @@ object ViewPortColumns {
 private case class ViewPortColumnsImpl(sourceColumns: List[Column]) extends ViewPortColumns {
 
   override def columnExists(name: String): Boolean = {
-    sourceColumns.exists(c => c.name == name)
+    sourceColumns.exists(_.name == name)
   }
 
   override def getColumns: List[Column] = sourceColumns
 
   override def getColumnForName(name: String): Option[Column] = {
     val evaluatedName = getEvaluatedName(name)
-    sourceColumns.find(c => c.name == evaluatedName)
+    sourceColumns.find(_.name == evaluatedName)
   }
 
   private def getEvaluatedName(name: String): String = {
@@ -53,7 +53,9 @@ private case class ViewPortColumnsImpl(sourceColumns: List[Column]) extends View
 
   private lazy val joinColumnsByTable: Map[String, List[JoinColumn]] = {
     if (hasJoinColumn) {
-      sourceColumns.filter(_.isInstanceOf[JoinColumn]).map(_.asInstanceOf[JoinColumn]).groupBy(_.sourceTable.name)
+      sourceColumns.filter(_.isInstanceOf[JoinColumn])
+        .map(_.asInstanceOf[JoinColumn])
+        .groupBy(_.sourceTable.name)
     } else {
       Map.empty
     }
@@ -63,7 +65,7 @@ private case class ViewPortColumnsImpl(sourceColumns: List[Column]) extends View
 
   private lazy val joinViewPortColumns: Map[String, ViewPortColumns] = {
     if (hasJoinColumn) {
-      joinColumnsByTable.view.mapValues(f => ViewPortColumnCreator.create(f.head.sourceTable, f.map(f => f.name))).toMap
+      joinColumnsByTable.view.mapValues(f => ViewPortColumnCreator.create(f.head.sourceTable, f.map(_.name))).toMap
     } else {
       Map.empty
     }

--- a/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
+++ b/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
@@ -19,10 +19,6 @@ object ViewPortColumns {
     ViewPortColumnsImpl(columns)
   }
 
-  def apply(column: Column, viewPortColumns: ViewPortColumns): ViewPortColumns = {
-    ViewPortColumnsImpl(viewPortColumns.getColumns() :+ column)
-  }
-
 }
 
 private case class ViewPortColumnsImpl(sourceColumns: List[Column]) extends ViewPortColumns {

--- a/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
+++ b/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortColumns.scala
@@ -7,6 +7,7 @@ trait ViewPortColumns {
   def getColumns(): List[Column]
   def getColumnForName(name: String): Option[Column]
   def count(): Int
+  def hasCalculatedColumn(): Boolean
   def pullRow(key: String, row: RowData): RowData
   def pullRowAlwaysFilter(key: String, row: RowData): RowData
 }
@@ -45,10 +46,12 @@ private case class ViewPortColumnsImpl(sourceColumns: List[Column]) extends View
 
   override def count(): Int = getColumns().size
 
-  private lazy val hasCalculatedColumn = sourceColumns.exists(c => c.isInstanceOf[CalculatedColumn])
+  private lazy val hasCalcColumn = sourceColumns.exists(c => c.isInstanceOf[CalculatedColumn])
+
+  override def hasCalculatedColumn(): Boolean = hasCalcColumn
 
   override def pullRow(key: String, row: RowData): RowData = {
-    if (!hasCalculatedColumn) {
+    if (!hasCalculatedColumn()) {
       row
     } else {
       this.pullRowAlwaysFilter(key, row)

--- a/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortContainer.scala
+++ b/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortContainer.scala
@@ -410,9 +410,9 @@ class ViewPortContainer(val tableContainer: TableContainer, val providerContaine
         val rows = keys.map(key => vp.table.pullRowAsArray(key, columns)).toArray
 
         val headers = if (vp.hasGroupBy)
-          Array[String]("depth", "isOpen", "key", "isLeaf") ++ columns.getColumns().map(_.name).toArray[String]
+          Array[String]("depth", "isOpen", "key", "isLeaf") ++ columns.getColumns.map(_.name).toArray[String]
         else
-          columns.getColumns().map(_.name).toArray
+          columns.getColumns.map(_.name).toArray
 
         AsciiUtil.asAsciiTable(headers, rows)
     }

--- a/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnFixture.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnFixture.scala
@@ -142,7 +142,7 @@ object CalculatedColumnFixture extends StrictLogging {
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
-  private def rowToMap(row: RowData, columns: ViewPortColumns) = columns.getColumns().map(c => c.name -> c.getData(row)).toMap
+  private def rowToMap(row: RowData, columns: ViewPortColumns) = columns.getColumns.map(c => c.name -> c.getData(row)).toMap
 
   def withCalculatedColumns(rows: List[RowWithData], columns: List[Column], calcs: String*)(expectedFn: => Any): Unit = {
 

--- a/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnFixture.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnFixture.scala
@@ -9,6 +9,8 @@ import org.finos.vuu.util.table.TableAsserts.genericLogic
 import org.finos.vuu.viewport.ViewPortColumns
 import org.scalatest.prop.{TableFor11, TableFor12, TableFor13}
 
+import scala.collection.mutable.ListBuffer
+
 object CalculatedColumnFixture extends StrictLogging {
 
   def CalcColumn(name: String, dataType: String, calcDef: String): String = {
@@ -28,7 +30,7 @@ object CalculatedColumnFixture extends StrictLogging {
     logger.debug("OUT" + tree.toStringTree(parser)) // print LISP-style tree
   }
 
-  def parseAndUpdateColumns(columns: ViewPortColumns, calcDef: String): ViewPortColumns = {
+  def parseColumn(columns: Iterable[Column], calcDef: String): Column = {
     val name :: dataType :: calcdsl :: _ = calcDef.split(":").toList
     val dt = DataType.fromString(dataType)
     val input = CharStreams.fromString(calcdsl)
@@ -40,8 +42,7 @@ object CalculatedColumnFixture extends StrictLogging {
     logger.debug("Parse OUT" + tree.toStringTree(parser))
     val eval = new CalculatedColumnVisitor(columns)
     val clause = eval.visit(tree)
-    val column = CalculatedColumn(name, clause, columns.count(), dt)
-    ViewPortColumns(column, columns)
+    CalculatedColumn(name, clause, columns.size, dt)
   }
 
   val tableColumns: List[Column] = Columns.fromNames(
@@ -145,11 +146,13 @@ object CalculatedColumnFixture extends StrictLogging {
 
   def withCalculatedColumns(rows: List[RowWithData], columns: List[Column], calcs: String*)(expectedFn: => Any): Unit = {
 
-    var vpColumns = ViewPortColumns(columns)
+    val columnBuffer: ListBuffer[Column] = ListBuffer()
 
     for (calc <- calcs) {
-      vpColumns = parseAndUpdateColumns(vpColumns, calc)
+      columnBuffer.addOne(parseColumn(columnBuffer, calc))
     }
+
+    val vpColumns = ViewPortColumns(columnBuffer.toList)
 
     expectedFn match {
       case table: TableFor11[_, _, _, _, _, _, _, _, _, _, _] => generic11Assert(rows, vpColumns, table)

--- a/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnFixture.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnFixture.scala
@@ -146,7 +146,7 @@ object CalculatedColumnFixture extends StrictLogging {
 
   def withCalculatedColumns(rows: List[RowWithData], columns: List[Column], calcs: String*)(expectedFn: => Any): Unit = {
 
-    val columnBuffer: ListBuffer[Column] = ListBuffer()
+    val columnBuffer: ListBuffer[Column] = ListBuffer().addAll(columns)
 
     for (calc <- calcs) {
       columnBuffer.addOne(parseColumn(columnBuffer, calc))

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -1,10 +1,10 @@
 package org.finos.vuu.util.table
 
-import org.finos.vuu.core.table.{EmptyRowData, RowWithData}
-import org.finos.vuu.viewport.{RowUpdateType, ViewPortColumns, ViewPortUpdate}
 import org.finos.toolbox.collection.MapDiffUtils
 import org.finos.toolbox.text.AsciiUtil
-import org.finos.vuu.core.table.DefaultColumnNames.{CreatedTimeColumnName, LastUpdatedTimeColumnName}
+import org.finos.vuu.core.table.DefaultColumnNames.allDefaultColumns
+import org.finos.vuu.core.table.{EmptyRowData, RowWithData}
+import org.finos.vuu.viewport.{RowUpdateType, ViewPortColumns, ViewPortUpdate}
 import org.scalatest.prop._
 
 object TableAsserts {
@@ -447,9 +447,9 @@ object TableAsserts {
 
   }
 
-  private def getColumns(columns: ViewPortColumns, rempveDefaultColumns: Boolean = true): ViewPortColumns = {
-    if (rempveDefaultColumns) {
-      ViewPortColumns(columns.getColumns().filter(c => !c.name.equals(CreatedTimeColumnName) && !c.name.equals(LastUpdatedTimeColumnName)))
+  private def getColumns(columns: ViewPortColumns, removeDefaultColumns: Boolean = true): ViewPortColumns = {
+    if (removeDefaultColumns) {
+      ViewPortColumns(columns.getColumns.filter(c => !allDefaultColumns.contains(c.name)))
     } else {
       columns
     }

--- a/vuu/src/test/scala/org/finos/vuu/viewport/ViewPortColumnsTests.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/ViewPortColumnsTests.scala
@@ -5,6 +5,22 @@ import org.scalatest.featurespec.AnyFeatureSpec
 
 class ViewPortColumnsTests extends AnyFeatureSpec {
 
+  Feature("Construction") {
+    Scenario("Check basic behaviour") {
+      val columns = Columns.fromNames("firstColumn:String", "secondColumn:String").toList
+      val vpColumns = ViewPortColumns(columns)
+
+      assert(vpColumns.getColumns == columns)
+      assert(vpColumns.columnExists("firstColumn"))
+      assert(vpColumns.getColumnForName("firstColumn").get == columns.head)
+      assert(!vpColumns.columnExists("thirdColumn"))
+      assert(!vpColumns.hasJoinColumns)
+      assert(vpColumns.getJoinColumnsByTable.isEmpty)
+      assert(!vpColumns.hasCalculatedColumns)
+      assert(vpColumns.getCalculatedColumns.isEmpty)
+    }
+  }
+
   Feature("compare two view port columns") {
 
     Scenario("when all the columns names are same equality check should return true and hashcode should be equal") {

--- a/vuu/src/test/scala/org/finos/vuu/viewport/ViewPortColumnsTests.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/ViewPortColumnsTests.scala
@@ -1,12 +1,14 @@
 package org.finos.vuu.viewport
 
-import org.finos.vuu.core.table.Columns
+import org.finos.vuu.api.{JoinSpec, JoinTableDef, JoinTo, LeftOuterJoin, TableDef, VisualLinks}
+import org.finos.vuu.core.table.{Columns, DataType, ViewPortColumnCreator}
 import org.scalatest.featurespec.AnyFeatureSpec
 
 class ViewPortColumnsTests extends AnyFeatureSpec {
 
-  Feature("Construction") {
-    Scenario("Check basic behaviour") {
+  Feature("Basic operations") {
+
+    Scenario("Simple viewport with no joins or calculated columns") {
       val columns = Columns.fromNames("firstColumn:String", "secondColumn:String").toList
       val vpColumns = ViewPortColumns(columns)
 
@@ -19,6 +21,64 @@ class ViewPortColumnsTests extends AnyFeatureSpec {
       assert(!vpColumns.hasCalculatedColumns)
       assert(vpColumns.getCalculatedColumns.isEmpty)
     }
+
+    Scenario("Viewport with joins") {
+      val ordersDef = TableDef(
+        name = "orders",
+        keyField = "orderId",
+        columns = Columns.fromNames("orderId:String", "trader:String", "ric:String"),
+        joinFields =  "ric", "orderId")
+
+      val pricesDef = TableDef("prices", "ric", Columns.fromNames("ric:String", "bid:Double"), "ric")
+
+      val joinDef = JoinTableDef(
+        name          = "orderPrices",
+        baseTable     = ordersDef,
+        joinColumns   = Columns.allFrom(ordersDef) ++ Columns.allFromExcept(pricesDef, "ric"),
+        joins  =
+          JoinTo(
+            table = pricesDef,
+            joinSpec = JoinSpec( left = "ric", right = "ric", LeftOuterJoin)
+          ),
+        links = VisualLinks(),
+        joinFields = Seq()
+      )
+
+      val vpColumns = ViewPortColumnCreator.create(joinDef, List("orderId", "trader", "ric", "bid"))
+
+      assert(vpColumns.hasJoinColumns)
+      val vpColumnsByTable = vpColumns.getJoinColumnsByTable
+      assert(vpColumnsByTable.size == 2)
+      assert(vpColumnsByTable.contains("orders"))
+      assert(vpColumnsByTable("orders").size == 3)
+      assert(vpColumnsByTable.contains("prices"))
+      assert(vpColumnsByTable("prices").size == 1)
+      val orderJoinVpColumns = vpColumns.getJoinViewPortColumns("orders")
+      assert(orderJoinVpColumns.isDefined)
+      assert(orderJoinVpColumns.get.getColumns.size == 3)
+      assert(orderJoinVpColumns.get.getColumns == ordersDef.columns.filter(c => List("orderId", "trader", "ric").contains(c.name)).toList)
+      val priceJoinVpColumns = vpColumns.getJoinViewPortColumns("prices")
+      assert(priceJoinVpColumns.isDefined)
+      assert(priceJoinVpColumns.get.getColumns.size == 1)
+      assert(priceJoinVpColumns.get.getColumns == pricesDef.columns.filter(_.name == "bid").toList)
+    }
+
+    Scenario("Viewport with calculations") {
+      val ordersDef = TableDef(
+        name = "orders",
+        keyField = "orderId",
+        columns = Columns.fromNames("orderId:String", "trader:String", "ric:String"),
+        joinFields =  "ric", "orderId")
+
+      val vpColumns = ViewPortColumnCreator.create(ordersDef,
+        List("orderId", "trader", "ric", "calcField:String:=concatenate(orderId, trader)"))
+
+      assert(vpColumns.hasCalculatedColumns)
+      assert(vpColumns.getCalculatedColumns.size == 1)
+      assert(vpColumns.getCalculatedColumns.head.name == "calcField")
+      assert(vpColumns.getCalculatedColumns.head.dataType == DataType.StringDataType)
+    }
+
   }
 
   Feature("compare two view port columns") {

--- a/vuu/src/test/scala/org/finos/vuu/viewport/ViewPortColumnsTests.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/ViewPortColumnsTests.scala
@@ -18,6 +18,7 @@ class ViewPortColumnsTests extends AnyFeatureSpec {
       assert(!vpColumns.columnExists("thirdColumn"))
       assert(!vpColumns.hasJoinColumns)
       assert(vpColumns.getJoinColumnsByTable.isEmpty)
+      assert(vpColumns.getJoinViewPortColumns("lol") == ViewPortColumns())
       assert(!vpColumns.hasCalculatedColumns)
       assert(vpColumns.getCalculatedColumns.isEmpty)
     }
@@ -54,13 +55,11 @@ class ViewPortColumnsTests extends AnyFeatureSpec {
       assert(vpColumnsByTable.contains("prices"))
       assert(vpColumnsByTable("prices").size == 1)
       val orderJoinVpColumns = vpColumns.getJoinViewPortColumns("orders")
-      assert(orderJoinVpColumns.isDefined)
-      assert(orderJoinVpColumns.get.getColumns.size == 3)
-      assert(orderJoinVpColumns.get.getColumns == ordersDef.columns.filter(c => List("orderId", "trader", "ric").contains(c.name)).toList)
+      assert(orderJoinVpColumns.getColumns.size == 3)
+      assert(orderJoinVpColumns.getColumns == ordersDef.columns.filter(c => List("orderId", "trader", "ric").contains(c.name)).toList)
       val priceJoinVpColumns = vpColumns.getJoinViewPortColumns("prices")
-      assert(priceJoinVpColumns.isDefined)
-      assert(priceJoinVpColumns.get.getColumns.size == 1)
-      assert(priceJoinVpColumns.get.getColumns == pricesDef.columns.filter(_.name == "bid").toList)
+      assert(priceJoinVpColumns.getColumns.size == 1)
+      assert(priceJoinVpColumns.getColumns == pricesDef.columns.filter(_.name == "bid").toList)
     }
 
     Scenario("Viewport with calculations") {


### PR DESCRIPTION
Related to #1753 

* Use a ListBuffer when constructing ViewPortColumns
* Added utility methods backed by lazy vals into ViewPortColumns to avoid repeated calculations and transformations in JoinTable.
