### PR TITLE
fix: re-enable Playwright component tests with vite-tsconfig-paths

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -71,58 +71,58 @@ jobs:
           working-directory: ./vuu-ui
           browser: edge
 
-  # playwright-component:
-  #   runs-on: ubuntu-latest
-  #   name: playwright-component (${{ matrix.browser }})
-  #   strategy:
-  #     matrix:
-  #       browser: [chromium, firefox, webkit]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #     - name: Install Node & dependencies
-  #       uses: ./.github/actions/setup-vuu-ui
-  #     - name: Build Worker
-  #       run: cd ./vuu-ui && npm run build:worker
-  #     - name: Install Playwright Browser
-  #       run: cd ./vuu-ui && npx playwright install --with-deps ${{ matrix.browser }}
-  #     - name: Run Playwright component tests
-  #       run: cd ./vuu-ui && npx playwright test --config=playwright-ct.config.ts --project=${{ matrix.browser }}
-  #     - name: Upload blob report to GitHub Actions Artifacts
-  #       uses: actions/upload-artifact@v4
-  #       if: always()
-  #       with:
-  #         name: blob-report-${{ matrix.browser }}
-  #         path: vuu-ui/blob-report/
-  #         retention-days: 10
+  playwright-component:
+    runs-on: ubuntu-latest
+    name: playwright-component (${{ matrix.browser }})
+    strategy:
+      matrix:
+        browser: [chromium, firefox, webkit]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Node & dependencies
+        uses: ./.github/actions/setup-vuu-ui
+      - name: Build Worker
+        run: cd ./vuu-ui && npm run build:worker
+      - name: Install Playwright Browser
+        run: cd ./vuu-ui && npx playwright install --with-deps ${{ matrix.browser }}
+      - name: Run Playwright component tests
+        run: cd ./vuu-ui && npx playwright test --config=playwright-ct.config.ts --project=${{ matrix.browser }}
+      - name: Upload blob report to GitHub Actions Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: blob-report-${{ matrix.browser }}
+          path: vuu-ui/blob-report/
+          retention-days: 10
 
-  # playwright-merge-reports:
-  #   runs-on: ubuntu-latest
-  #   needs: playwright-component
-  #   if: always()
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #     - name: Download blob reports from GitHub Actions Artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         path: all-blob-reports
-  #         pattern: blob-report-*
-  #         merge-multiple: true
-  #     - name: Install Node & dependencies
-  #       uses: ./.github/actions/setup-vuu-ui
-  #     - name: Merge into HTML and JSON Reports
-  #       run: PLAYWRIGHT_JSON_OUTPUT_FILE=playwright-report/test-results.json npx playwright merge-reports --reporter html,json ./all-blob-reports
-  #     - name: Upload Merged Playwright Report
-  #       uses: actions/upload-artifact@v4
-  #       if: always()
-  #       with:
-  #         name: playwright-report
-  #         path: playwright-report/
-  #         retention-days: 10
-  #     - name: Add Playwright Results to Summary
-  #       if: always()
-  #       run: ./.github/scripts/generate-playwright-summary.sh playwright-report/test-results.json >> $GITHUB_STEP_SUMMARY
+  playwright-merge-reports:
+    runs-on: ubuntu-latest
+    needs: playwright-component
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+      - name: Install Node & dependencies
+        uses: ./.github/actions/setup-vuu-ui
+      - name: Merge into HTML and JSON Reports
+        run: PLAYWRIGHT_JSON_OUTPUT_FILE=playwright-report/test-results.json npx playwright merge-reports --reporter html,json ./all-blob-reports
+      - name: Upload Merged Playwright Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 10
+      - name: Add Playwright Results to Summary
+        if: always()
+        run: ./.github/scripts/generate-playwright-summary.sh playwright-report/test-results.json >> $GITHUB_STEP_SUMMARY
 
   # ensure the vuu example still builds
   vuu-app-build:

--- a/vuu-ui/playwright-ct.config.ts
+++ b/vuu-ui/playwright-ct.config.ts
@@ -1,6 +1,25 @@
 import { defineConfig, devices } from '@playwright/experimental-ct-react';
 import { createFilter } from "vite";
 import MagicString from "magic-string";
+import tsconfigPaths from "vite-tsconfig-paths";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Path Resolution Strategy for Playwright Component Tests
+ * 
+ * We use vite-tsconfig-paths (same as Cypress) to resolve @vuu-ui/* imports.
+ * It resolves through npm workspaces to each package's "main" field, which
+ * points to source files (src/index.ts) rather than built files.
+ * 
+ * This approach:
+ * - Matches the Cypress setup exactly
+ * - Keeps path configuration isolated from the main tsconfig.json
+ * - Prevents affecting published package type definitions
+ * - Is cleaner than maintaining manual Vite aliases for all packages
+ */
 
 // Custom CSS inline plugin that targets all packages
 function cssInline() {
@@ -47,6 +66,7 @@ export default defineConfig({
         conditions: ['import', 'module', 'browser', 'default'],
       },
       plugins: [
+        tsconfigPaths({ projects: [path.join(__dirname, 'playwright/tsconfig.json')] }),
         cssInline(), // Use the custom CSS inline plugin
       ],
       build: {

--- a/vuu-ui/playwright/tsconfig.json
+++ b/vuu-ui/playwright/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["@playwright/experimental-ct-react"]
+  },
+  "include": ["**/*.ts", "**/*.tsx", "../packages/**/src/**/__component__/*.playwright.test.tsx"]
+}
+


### PR DESCRIPTION
## Summary

Fixes Playwright component tests by using `vite-tsconfig-paths` with a dedicated `playwright/tsconfig.json`, exactly mirroring the Cypress setup.

## Background

PR #1769 added TypeScript paths to the main `tsconfig.json` to support Playwright component tests, but this broke published package type definitions because `tsconfig-emit-types.json` extends the main config. This was reverted in #1789.

## Solution

Instead of adding paths to the main `tsconfig.json`, we:
1. Created `playwright/tsconfig.json` (similar to `cypress/tsconfig.json`)
2. Use `vite-tsconfig-paths` plugin in `playwright-ct.config.ts`
3. Re-enabled Playwright component tests in CI workflow

The `vite-tsconfig-paths` plugin resolves `@vuu-ui/*` imports through npm workspaces to each package's `"main": "src/index.ts"` field, pointing to source files rather than built artifacts.

## Why This Works

- **Cypress** already uses this pattern: `cypress/tsconfig.json` + `vite-tsconfig-paths`
- Package resolution is isolated to test builds, not affecting type emission
- Cleaner than maintaining 23 manual Vite aliases
- Published packages remain unaffected