### PR TITLE
feat: redesign freeze control with new styling and behavior

### DIFF
--- a/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/freeze-control/FreezeControl.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/freeze-control/FreezeControl.playwright.test.tsx
@@ -14,7 +14,7 @@ const createMockDataSource = (isFrozen = false): Partial<DataSource> => ({
 });
 
 test.describe("Given a FreezeControl", () => {
-  test("THEN it loads with Live and Freeze buttons, with Live selected", async ({
+  test("THEN it loads with Freeze and Active buttons, with Active selected", async ({
     mount,
   }) => {
     const dataSource = createMockDataSource(false);
@@ -24,19 +24,19 @@ test.describe("Given a FreezeControl", () => {
       </LocalDataSourceProvider>,
     );
 
-    const liveButton = component.locator('button[value="live"]');
+    const activeButton = component.locator('button[value="live"]');
     const freezeButton = component.locator('button[value="frozen"]');
 
-    await expect(liveButton).toBeVisible();
+    await expect(activeButton).toBeVisible();
     await expect(freezeButton).toBeVisible();
 
     const buttonGroup = component.locator(".saltToggleButtonGroup");
     await expect(buttonGroup).toBeVisible();
 
-    const liveWrapper = component
+    const activeWrapper = component
       .locator(".FreezeControl-buttonWrapper-active")
       .first();
-    await expect(liveWrapper).toBeVisible();
+    await expect(activeWrapper).toBeVisible();
   });
 
   test("WHEN frozen THEN New Orders section appears with counter at 0", async ({

--- a/vuu-ui/packages/vuu-table-extras/src/freeze-control/FreezeControl.css
+++ b/vuu-ui/packages/vuu-table-extras/src/freeze-control/FreezeControl.css
@@ -1,6 +1,8 @@
 .FreezeControl {
   display: inline-flex;
   --freeze-control-flash-duration: 0.25s;
+  --freeze-control-active-button-color: var(--salt-palette-error-background);
+  --freeze-control-badge-color: var(--salt-palette-success-background);
 
   .FreezeControl-buttonRow {
     background-color: var(--salt-container-secondary-background);
@@ -14,19 +16,28 @@
   .FreezeControl-buttonWrapper {
     border-radius: 50px;
     padding: 0 var(--salt-spacing-150);
+    background-color: var(--salt-container-secondary-background);
   }
 
   .FreezeControl-buttonWrapper-active {
-    background-color: var(--salt-actionable-secondary-background-active);
+    background-color: var(--freeze-control-active-button-color);
   }
 
-  .saltToggleButtonGroup.vuuStateButtonGroup
-    .saltToggleButton[aria-pressed="true"] {
+  .FreezeControl-buttonWrapper-active .saltToggleButton {
+    background-color: var(--freeze-control-active-button-color);
+    color: var(--salt-actionable-secondary-foreground-active);
+  }
+
+  .saltToggleButtonGroup.vuuStateButtonGroup {
+    background-color: var(--salt-container-secondary-background);
+  }
+
+  .saltToggleButtonGroup.vuuStateButtonGroup .saltToggleButton {
     background-color: transparent;
   }
 
   .FreezeControl-customBadge {
-    background-color: var(--salt-container-primary-background);
+    background-color: transparent;
     border-radius: 50%;
     color: var(--salt-text-primary-foreground);
     display: flex;
@@ -42,7 +53,7 @@
 
   .FreezeControl-newOrders {
     align-items: center;
-    background-color: transparent;
+    background-color: var(--salt-container-secondary-background);
     display: flex;
     font-size: var(--salt-text-fontSize);
     padding: 0 var(--salt-spacing-200);
@@ -56,12 +67,12 @@
 
 @keyframes flashGreenRed {
   0% {
-    background-color: var(--salt-status-success-background);
+    background-color: var(--freeze-control-badge-color);
   }
   50% {
-    background-color: var(--salt-container-primary-background);
+    background-color: transparent;
   }
   100% {
-    background-color: var(--salt-status-success-background);
+    background-color: var(--freeze-control-badge-color);
   }
 }

--- a/vuu-ui/packages/vuu-table-extras/src/freeze-control/FreezeControl.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/freeze-control/FreezeControl.tsx
@@ -74,19 +74,19 @@ export const FreezeControl = ({
         >
           <div
             className={cx(`FreezeControl-buttonWrapper`, {
-              [`FreezeControl-buttonWrapper-active`]: !isFrozen,
-            })}
-          >
-            <ToggleButton value="live">Live</ToggleButton>
-          </div>
-          <div
-            className={cx(`FreezeControl-buttonWrapper`, {
               [`FreezeControl-buttonWrapper-active`]: isFrozen,
             })}
           >
             <ToggleButton value="frozen">
               {isFrozen ? "Frozen" : "Freeze"}
             </ToggleButton>
+          </div>
+          <div
+            className={cx(`FreezeControl-buttonWrapper`, {
+              [`FreezeControl-buttonWrapper-active`]: !isFrozen,
+            })}
+          >
+            <ToggleButton value="live">Active</ToggleButton>
           </div>
         </ToggleButtonGroup>
         {isFrozen && (

--- a/vuu-ui/packages/vuu-table-extras/src/freeze-control/FrozenBanner.css
+++ b/vuu-ui/packages/vuu-table-extras/src/freeze-control/FrozenBanner.css
@@ -1,6 +1,7 @@
 .FrozenBanner {
+  --freeze-control-active-button-color: var(--salt-palette-error-background);
   align-items: center;
-  background-color: var(--salt-actionable-secondary-background-active);
+  background-color: var(--freeze-control-active-button-color);
   border-radius: 4px;
   color: var(--salt-actionable-secondary-foreground-active);
   display: flex;

--- a/vuu-ui/showcase/src/examples/TableExtras/FreezeTable.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/FreezeTable.examples.tsx
@@ -72,12 +72,17 @@ export const TableFreezing = () => {
           display: "flex",
           height: 50,
           gap: "10px",
+          justifyContent: "space-between",
         }}
       >
-        <Button onClick={() => startOrderCreation()}>
-          Start Order Creation
-        </Button>
-        <Button onClick={() => stopOrderCreation()}>Stop Order Creation</Button>
+        <div style={{ display: "flex", gap: "10px" }}>
+          <Button onClick={() => startOrderCreation()}>
+            Start Order Creation
+          </Button>
+          <Button onClick={() => stopOrderCreation()}>
+            Stop Order Creation
+          </Button>
+        </div>
         <FreezeControl dataSource={dataSource} />
       </div>
       <FrozenBanner dataSource={dataSource} />
@@ -87,7 +92,6 @@ export const TableFreezing = () => {
         height={600}
         navigationStyle="row"
         renderBufferSize={5}
-        width={723}
       />
       <DataSourceStats dataSource={dataSource} />
     </div>

--- a/vuu-ui/tools/vuu-showcase/src/shared-utils.ts
+++ b/vuu-ui/tools/vuu-showcase/src/shared-utils.ts
@@ -63,7 +63,7 @@ export const getTargetTreeNode = <T = unknown>(
   ) {
     return treeNode;
   } else if (throwIfNotFound) {
-    throw Error("dsdsdsdsdsd");
+    throw Error(`Target tree node not found for path: ${pathname}`);
   }
 };
 


### PR DESCRIPTION
PR to make some small updates to the FreezeControl component, changes are:

- Change "Live" to "Active" for clarity
- Swap button order: Freeze/Frozen (left), Active (right)
- Use error red for active button color (more prominent frozen state)
- Use success green for badge flash
- Make badge background transparent when count is 0
- Add themeable CSS variables (--freeze-control-active-button-color, --freeze-control-badge-color)
- Update FrozenBanner to match active button color
- Update showcase example to demonstrate expand-to-left behavior
- Update Playwright tests for new button text

Should be no breaking changes - purely visual/UX improvements, shown below:

![2025-10-30 09 16 42](https://github.com/user-attachments/assets/650372f5-1d21-4188-8114-73e6e01fd1da)
