### PR TITLE
fix drag drop with dndKit

### DIFF
--- a/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
+++ b/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
@@ -372,7 +372,10 @@ export class ArrayDataSource
     }
 
     this.setRange(this.#range, true);
-    this.emit("row-selection", this.selectedRows.size);
+    this.emit(
+      "row-selection",
+      selectRequest.type === "SELECT_ALL" ? this.size : this.selectedRows.size,
+    );
   }
 
   private getRowKey(keyOrIndex: string | number) {

--- a/vuu-ui/packages/vuu-table-extras/src/column-picker/ColumnPicker.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/column-picker/ColumnPicker.tsx
@@ -19,7 +19,6 @@ import {
   useSortable,
 } from "@vuu-ui/vuu-utils";
 
-import columnPickerCss from "./ColumnPicker.css";
 import { Input, ListBox, Option, OptionProps } from "@salt-ds/core";
 import {
   ColumPickerHookProps,
@@ -28,6 +27,8 @@ import {
 } from "./useColumnPicker";
 import { IconButton } from "@vuu-ui/vuu-ui-controls";
 import { useHighlighting } from "@vuu-ui/vuu-table";
+
+import columnPickerCss from "./ColumnPicker.css";
 
 const classBase = "vuuColumnPicker";
 export const classBaseListItem = "vuuColumnPickerListItem";

--- a/vuu-ui/packages/vuu-utils/src/column-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/column-utils.ts
@@ -1323,10 +1323,16 @@ export const reorderColumnItems = <
   orderedNames: string[],
 ): T[] => {
   const columns: T[] = [];
+  let previousName = "";
   for (const name of orderedNames) {
-    const columnItem = columnItems.find((c) => c.name === name);
-    if (columnItem) {
-      columns.push(columnItem);
+    // Because of the way ordered names are captured, it can happen that a duplicate entry
+    // is captured for the dropped item. Ignore it. Only observed on slow clients.
+    if (previousName !== name) {
+      const columnItem = columnItems.find((c) => c.name === name);
+      if (columnItem) {
+        columns.push(columnItem);
+      }
+      previousName = name;
     }
   }
   return columns;

--- a/vuu-ui/packages/vuu-utils/test/column-utils.test.ts
+++ b/vuu-ui/packages/vuu-utils/test/column-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   addColumnToSubscribedColumns,
   applyWidthToColumns,
+  reorderColumnItems,
 } from "../src/column-utils";
 import type { RuntimeColumnDescriptor } from "@vuu-ui/vuu-table-types";
 import { getColumnsInViewport } from "../src/column-utils";
@@ -507,5 +508,24 @@ describe("addColumnToSubscribedColumns", () => {
       { name: "price", serverDataType: "double" },
       { name: "vuuCreatedTimestamp", serverDataType: "long" },
     ]);
+  });
+});
+
+describe("reorderColumnItems", () => {
+  it("reorders columns to match sortedNames", () => {
+    expect(
+      reorderColumnItems(
+        [{ name: "test1" }, { name: "test2" }, { name: "test3" }],
+        ["test3", "test1", "test2"],
+      ),
+    ).toEqual([{ name: "test3" }, { name: "test1" }, { name: "test2" }]);
+  });
+  it("ignores duplicates in sortedNames", () => {
+    expect(
+      reorderColumnItems(
+        [{ name: "test1" }, { name: "test2" }, { name: "test3" }],
+        ["test3", "test3", "test1", "test2"],
+      ),
+    ).toEqual([{ name: "test3" }, { name: "test1" }, { name: "test2" }]);
   });
 });

--- a/vuu-ui/showcase/src/examples/Table/TableSelection.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/TableSelection.examples.tsx
@@ -1,6 +1,7 @@
 import { getSchema } from "@vuu-ui/vuu-data-test";
 import { TableSchema } from "@vuu-ui/vuu-data-types";
 import { Table, TableProps } from "@vuu-ui/vuu-table";
+import { DataSourceStats } from "@vuu-ui/vuu-table-extras";
 import {
   ColumnLayout,
   SelectionChangeHandler,
@@ -54,22 +55,27 @@ const DataTableTemplate = ({
   }, [VuuDataSource, dataSourceProp, schema]);
 
   return (
-    <Table
-      {...props}
-      allowCellBlockSelection={allowCellBlockSelection}
-      allowSelectAll={allowSelectAll}
-      config={tableConfig}
-      data-testid="table"
-      dataSource={dataSource}
-      height={height}
-      maxViewportRowLimit={maxViewportRowLimit}
-      navigationStyle={navigationStyle}
-      renderBufferSize={20}
-      rowHeight={rowHeight}
-      selectionModel={selectionModel}
-      viewportRowLimit={viewportRowLimit}
-      width={width}
-    />
+    <>
+      <Table
+        {...props}
+        allowCellBlockSelection={allowCellBlockSelection}
+        allowSelectAll={allowSelectAll}
+        config={tableConfig}
+        data-testid="table"
+        dataSource={dataSource}
+        height={height}
+        maxViewportRowLimit={maxViewportRowLimit}
+        navigationStyle={navigationStyle}
+        renderBufferSize={20}
+        rowHeight={rowHeight}
+        selectionModel={selectionModel}
+        viewportRowLimit={viewportRowLimit}
+        width={width}
+      />
+      <div style={{ height: 40 }}>
+        <DataSourceStats dataSource={dataSource} itemLabel="instrument" />
+      </div>
+    </>
   );
 };
 

--- a/vuu-ui/tools/vuu-showcase/src/ShowcaseStandalone.tsx
+++ b/vuu-ui/tools/vuu-showcase/src/ShowcaseStandalone.tsx
@@ -163,11 +163,11 @@ export const ShowcaseStandalone = ({
           </LocalDataSourceProvider>
         ) : (
           <VuuDataSourceProvider
-            authenticate={false}
+            authenticate={true}
             autoConnect
             autoLogin
-            websocketUrl="ws://localhost:8091/websocket"
-            // websocketUrl="wss://localhost:8090/websocket"
+            // websocketUrl="ws://localhost:8091/websocket"
+            websocketUrl="wss://localhost:8090/websocket"
           >
             <div
               className={cx("vuuShowcase-StandaloneRoot", {


### PR DESCRIPTION
in ArrayDataSource, incorrect selectedRowsCount returned in ACK for SELECT_ALL
in drag drop (using dndKit, so ColumnPicker and Table Headers) we may get a duplicate entry in ordreredItems after drop.
Make sure this duplicate is not transmitted to updated items. Only seems to occur on slow  clients. Likely because we are grabbing item names from ui whilst dropped item is still settling.