### PR TITLE
Remove user from ClientSessionId

### DIFF
--- a/benchmark/src/main/java/org/finos/vuu/benchmark/BenchmarkHelper.java
+++ b/benchmark/src/main/java/org/finos/vuu/benchmark/BenchmarkHelper.java
@@ -69,7 +69,7 @@ public class BenchmarkHelper {
     }
 
     public TreeBuilder createTreeBuilder(InMemDataTable table) {
-        var client = new ClientSessionId("A", "B", "C");
+        var client = new ClientSessionId("A", "C");
 
         var groupByTable = TreeSessionTable.apply(table, client, joinProvider, metricsProvider, clock);
         var exchange = table.getTableDef().columnForName("exchange");

--- a/example/basket/src/main/scala/org/finos/vuu/core/module/basket/service/BasketService.scala
+++ b/example/basket/src/main/scala/org/finos/vuu/core/module/basket/service/BasketService.scala
@@ -66,7 +66,7 @@ class BasketService(val table: DataTable, val omsApi: OmsApi)(implicit clock: Cl
   override def createBasket(params: RpcParams): RpcFunctionResult = {
     val sourceBasketId: String = params.namedParams("sourceBasketId").asInstanceOf[String]
     val basketTradeName: String = params.namedParams("basketTradeName").asInstanceOf[String]
-    val basketTradeId = BasketTradeId.oneNew(params.ctx.session.user)
+    val basketTradeId = BasketTradeId.oneNew(params.ctx.user.name)
     val constituents = getConstituentsForSourceBasket(sourceBasketId)
 
     tableContainer.getTable(BasketModule.BasketTradingTable) match {

--- a/example/permission/src/main/scala/org/finos/vuu/core/module/auths/OrderPermissionChecker.scala
+++ b/example/permission/src/main/scala/org/finos/vuu/core/module/auths/OrderPermissionChecker.scala
@@ -20,7 +20,7 @@ class OrderPermissionChecker(val vp: ViewPort, tableContainer: TableContainer)(i
   @volatile private var permissionUserMask = PermissionSet.NoPermissions
 
   def runOnce(): Unit = {
-    val user = vp.session.user
+    val user = vp.user.name
     permissionUserMask = permissionTable.asTable.pullRow(user) match {
       case row: RowWithData =>
         row.get(Bitmask).asInstanceOf[Int]

--- a/example/permission/src/main/scala/org/finos/vuu/core/module/auths/PermissionModule.scala
+++ b/example/permission/src/main/scala/org/finos/vuu/core/module/auths/PermissionModule.scala
@@ -12,12 +12,12 @@ object PermissionModule extends DefaultModule{
 
   private final val NAME = "AUTHS"
 
-  def apply()(implicit clock: Clock, lifecycle: LifecycleContainer, tableDefContainer: TableDefContainer): ViewServerModule = {
+  def apply(users: () => Iterable[String])(implicit clock: Clock, lifecycle: LifecycleContainer, tableDefContainer: TableDefContainer): ViewServerModule = {
 
     import ColumnNames._
 
-  ModuleFactory.withNamespace(NAME)
-    .addTable(
+    ModuleFactory.withNamespace(NAME)
+      .addTable(
       TableDef(
         name = "permission",
         keyField = User,
@@ -25,7 +25,7 @@ object PermissionModule extends DefaultModule{
         VisualLinks(),
         joinFields = User
       ),
-      (table, vs) => new PermissionsProvider(table, vs.sessionContainer),
+      (table, vs) => new PermissionsProvider(table, users),
       (table, _, _, tableContainer) => ViewPortDef(
         columns = table.getTableDef.columns,
         service = new PermissionsRpcService(table)(tableContainer)

--- a/plugin/virtualized-table-plugin/src/test/scala/org/finos/vuu/plugin/virtualized/table/VirtualizedDataTableTest.scala
+++ b/plugin/virtualized-table-plugin/src/test/scala/org/finos/vuu/plugin/virtualized/table/VirtualizedDataTableTest.scala
@@ -16,7 +16,7 @@ class VirtualizedDataTableTest extends AnyFeatureSpec with Matchers with GivenWh
   private implicit val metrics: MetricsProvider = new MetricsProviderImpl
   private implicit val clock: Clock = new TestFriendlyClock(DefaultTestStartTime.TestStartTime)
 
-  private val sessionId = ClientSessionId("AAAA", "user", "channel")
+  private val sessionId = ClientSessionId("AAAA", "channel")
   private val joinProvider = new TestFriendlyJoinTableProvider
 
   private val ordersTableDef = VirtualizedSessionTableDef("bigOrders", "orderId", Columns.fromNames("orderId:String", "ric:String", "quantity:Int", "trader: String"))

--- a/vuu-java/src/test/java/test/helper/ViewPortTestUtils.java
+++ b/vuu-java/src/test/java/test/helper/ViewPortTestUtils.java
@@ -23,6 +23,7 @@ public class ViewPortTestUtils {
     }
 
     public static RequestContext requestContext() {
-        return new RequestContext("", VuuUser.apply(""), new ClientSessionId("", "", ""), null, "");
+        return new RequestContext("", VuuUser.apply(""),
+                new ClientSessionId("", ""), null, "");
     }
 }

--- a/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
@@ -181,7 +181,7 @@ class CoreServerApiHandler(val viewPortContainer: ViewPortContainer,
   }
 
   def vsMsg(body: MessageBody)(ctx: RequestContext): Option[JsonViewServerMessage] = {
-    Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.session.user, body))
+    Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.user.name, body))
   }
 
   override def process(msg: GetTableList)(ctx: RequestContext): Option[ViewServerMessage] = {
@@ -292,11 +292,11 @@ class CoreServerApiHandler(val viewPortContainer: ViewPortContainer,
 
         //logger.info(s"Setting columns to ${columns.map(_.name).mkString(",")} ")
 
-        Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.session.user,
+        Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.user.name,
           ChangeViewPortSuccess(newViewPort.id, viewport.getColumns.getColumns.map(_.name).toArray, sort, msg.groupBy, msg.filterSpec, msg.aggregations)))
 
       case None =>
-        Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.session.user, ChangeViewPortReject(msg.viewPortId, s"Could not find vp ${msg.viewPortId} in session ${ctx.session}")))
+        Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.user.name, ChangeViewPortReject(msg.viewPortId, s"Could not find vp ${msg.viewPortId} in session ${ctx.session}")))
     }
 
   }
@@ -354,7 +354,7 @@ class CoreServerApiHandler(val viewPortContainer: ViewPortContainer,
   }
 
   protected def errorMsg(s: String)(ctx: RequestContext): Option[ViewServerMessage] = {
-    Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.session.user, ErrorResponse(s)))
+    Some(VsMsg(ctx.requestId, ctx.session.sessionId, ctx.token, ctx.user.name, ErrorResponse(s)))
   }
 
 

--- a/vuu/src/main/scala/org/finos/vuu/net/ClientConnectionCreator.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/ClientConnectionCreator.scala
@@ -54,7 +54,7 @@ class DefaultMessageHandler(val channel: Channel,
 
       val formatted = formatDataOutbound(updates)
 
-      val json = serializer.serialize(JsonViewServerMessage("", session.sessionId, "", session.user, formatted))
+      val json = serializer.serialize(JsonViewServerMessage("", session.sessionId, "", user.name, formatted))
 
       logger.debug("ASYNC-SVR-OUT:" + json)
 
@@ -67,7 +67,7 @@ class DefaultMessageHandler(val channel: Channel,
     flowController.shouldSend() match {
       case op: SendHeartbeat =>
         logger.debug("Sending heartbeat")
-        val json = serializer.serialize(JsonViewServerMessage("NA", session.sessionId, "", session.user, HeartBeat(timeProvider.now())))
+        val json = serializer.serialize(JsonViewServerMessage("NA", session.sessionId, "", user.name, HeartBeat(timeProvider.now())))
         channel.writeAndFlush(new TextWebSocketFrame(json))
       case op: Disconnect =>
 
@@ -169,16 +169,11 @@ class DefaultMessageHandler(val channel: Channel,
   }
 }
 
-case class ClientSessionId(sessionId: String, user: String, channelId: String) extends Ordered[ClientSessionId] {
+case class ClientSessionId(sessionId: String, channelId: String) extends Ordered[ClientSessionId] {
 
   override def compare(that: ClientSessionId): Int =  {
     val comp = sessionId.compareTo(that.sessionId)
-    if (comp == 0) {
-      val comp2 = channelId.compareTo(that.channelId)
-      if (comp2 != 0) comp2 else user.compareTo(that.user)
-    } else {
-      comp
-    }
+    if (comp != 0) comp else channelId.compareTo(that.channelId)
   }
 
 }

--- a/vuu/src/main/scala/org/finos/vuu/net/RequestProcessor.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/RequestProcessor.scala
@@ -49,7 +49,7 @@ class RequestProcessor(loginTokenService: LoginTokenService,
                             vuuServerId: String): Option[ViewServerMessage] = {
 
     val session = SessionId.oneNew()
-    val id = ClientSessionId(session, user.name, channel.id().asLongText())
+    val id = ClientSessionId(session, channel.id().asLongText())
 
     logger.debug(s"Creating Session for user ${user.name} with $id ")
     val handler = createMessageHandler(channel, id, user)
@@ -79,7 +79,7 @@ class RequestProcessor(loginTokenService: LoginTokenService,
   }
 
   private def msgToSessionId(msg: ViewServerMessage, channel: Channel): ClientSessionId = {
-    ClientSessionId(msg.sessionId, msg.user, channel.id.asLongText())
+    ClientSessionId(msg.sessionId, channel.id.asLongText())
   }
 
   private def handleMessageWithNoSession(msg: ViewServerMessage, channel: Channel): Unit = {

--- a/vuu/src/main/scala/org/finos/vuu/viewport/ViewPort.scala
+++ b/vuu/src/main/scala/org/finos/vuu/viewport/ViewPort.scala
@@ -155,7 +155,7 @@ trait ViewPort {
   def ForTest_getRowKeyToRowIndex: ConcurrentHashMap[String, Int]
 
   override def toString: String = {
-    "VP(user:" + session.user + ",table:" + table.name + ",size: " + size + ",id:" + id + ") @" + session.sessionId
+    "VP(user:" + user.name + ",table:" + table.name + ",size: " + size + ",id:" + id + ") @" + session.sessionId
   }
 
   def delete(): Unit

--- a/vuu/src/test/scala/org/finos/vuu/api/CoreServerApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/api/CoreServerApiTest.scala
@@ -36,7 +36,7 @@ class CoreServerApiTest extends AnyFeatureSpec with BeforeAndAfterEach with Give
       Given("a heart beat response")
       val heartBeatResponse = HeartBeatResponse(100000)
       val requestContext = RequestContext("reqId", VuuUser("user"),
-        ClientSessionId("sessionId", "user", "channel"), new OutboundRowPublishQueue(), "token")
+        ClientSessionId("sessionId", "channel"), new OutboundRowPublishQueue(), "token")
       val maybeMessage = coreServerApi.process(heartBeatResponse)(requestContext)
 
       Then("core server api should process successfully")

--- a/vuu/src/test/scala/org/finos/vuu/core/groupBy/BuildBigGroupByTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/groupBy/BuildBigGroupByTest.scala
@@ -67,7 +67,7 @@ class BuildBigGroupByTestScenario() extends StrictLogging {
 
     logger.trace("[PERF] Complete Table Build")
 
-    val client = ClientSessionId("A", "B", "C")
+    val client = ClientSessionId("A", "C")
 
     val groupByTable = TreeSessionTable(table, client, joinProvider)(metrics, clock)
 

--- a/vuu/src/test/scala/org/finos/vuu/core/groupBy/PerfTestBigRoupByMain.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/groupBy/PerfTestBigRoupByMain.scala
@@ -45,7 +45,7 @@ object PerfTestBigRoupByMain extends App with StrictLogging {
     table.processUpdate(ric, row)
   })
 
-  val client = ClientSessionId("A", "B", "C")
+  val client = ClientSessionId("A", "C")
 
   val groupByTable = TreeSessionTable(table, client, joinProvider)(metrics, clock)
 

--- a/vuu/src/test/scala/org/finos/vuu/core/groupBy/TreeNodeHashingTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/groupBy/TreeNodeHashingTest.scala
@@ -53,7 +53,7 @@ class TreeNodeHashingTest extends AnyFeatureSpec with Matchers with StrictLoggin
 
       joinProvider.runOnce()
 
-      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "B", "C"), joinProvider)
+      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "C"), joinProvider)
 
       val vpColumns = ViewPortColumnCreator.create(sessionTable, sessionTable.columns().map(_.name).toList)
 
@@ -127,7 +127,7 @@ class TreeNodeHashingTest extends AnyFeatureSpec with Matchers with StrictLoggin
 
       joinProvider.runOnce()
 
-      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "B", "C"), joinProvider)
+      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "C"), joinProvider)
 
       val vpColumns = ViewPortColumnCreator.create(sessionTable, sessionTable.columns().map(_.name).toList)
 

--- a/vuu/src/test/scala/org/finos/vuu/core/table/DataTableTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/DataTableTest.scala
@@ -43,7 +43,7 @@ class DataTableTest extends AnyFeatureSpec with Matchers {
 
       val user: VuuUser = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val vpcolumns = List("ric", "bid", "ask")
 

--- a/vuu/src/test/scala/org/finos/vuu/core/table/InMemSessionDataTableTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/InMemSessionDataTableTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 class InMemSessionDataTableTest extends AnyFeatureSpec with Matchers {
   private implicit val metricsProvider: MetricsProvider = new MetricsProviderImpl()
   private implicit val clock: Clock = new DefaultClock()
-  private val clientSessionId = ClientSessionId(sessionId = "sessionId", user = "user", channelId = "channel")
+  private val clientSessionId = ClientSessionId(sessionId = "sessionId", channelId = "channel")
   private val joinProvider = new TestFriendlyJoinTableProvider()
 
   private val sessionTableDef: SessionTableDef = new SessionTableDef(

--- a/vuu/src/test/scala/org/finos/vuu/core/table/RowDeleteTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/RowDeleteTest.scala
@@ -50,7 +50,7 @@ class RowDeleteTest extends AnyFeatureSpec with Matchers with OneInstancePerTest
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val vpcolumns = ViewPortColumnCreator.create(table, List("ric", "bid", "ask"))
 
@@ -118,7 +118,7 @@ class RowDeleteTest extends AnyFeatureSpec with Matchers with OneInstancePerTest
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val vpcolumns = ViewPortColumnCreator.create(table, List("ric", "bid", "ask"))
 
@@ -172,7 +172,7 @@ class RowDeleteTest extends AnyFeatureSpec with Matchers with OneInstancePerTest
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val vpcolumns = ViewPortColumnCreator.create(orderPrices, orderPrices.getTableDef.columns.map(_.name).toList)
 
@@ -252,7 +252,7 @@ class RowDeleteTest extends AnyFeatureSpec with Matchers with OneInstancePerTest
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val vpcolumns = ViewPortColumnCreator.create(orderPrices, orderPrices.getTableDef.columns.map(_.name).toList)
 

--- a/vuu/src/test/scala/org/finos/vuu/core/table/RpcTableTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/RpcTableTest.scala
@@ -55,7 +55,7 @@ class RpcTableTest extends AnyFeatureSpec with Matchers with OneInstancePerTest 
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val vpcolumns = ViewPortColumnCreator.create(orderEntry, List("clOrderId", "ric", "quantity", "orderType", "price", "priceLevel"))
 

--- a/vuu/src/test/scala/org/finos/vuu/core/table/join/JoinTableTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/join/JoinTableTest.scala
@@ -104,7 +104,7 @@ class JoinTableTest extends AnyFeatureSpec with Matchers with ViewPortSetup {
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val outQueue = new OutboundRowPublishQueue()
 
@@ -192,7 +192,7 @@ class JoinTableTest extends AnyFeatureSpec with Matchers with ViewPortSetup {
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val outQueue = new OutboundRowPublishQueue()
 
@@ -274,7 +274,7 @@ class JoinTableTest extends AnyFeatureSpec with Matchers with ViewPortSetup {
 
       tickInData(ordersProvider, pricesProvider)
 
-      val orderPricesViewport = vpContainer.create(RequestId.oneNew(), VuuUser("B"), ClientSessionId("A", "B", "C"), 
+      val orderPricesViewport = vpContainer.create(RequestId.oneNew(), VuuUser("B"), ClientSessionId("A", "C"),
         queue, orderPrices, ViewPortRange(0, 20), 
         ViewPortColumnCreator.create(orderPrices, orderPrices.getTableDef.columns.map(_.name).toList))
 

--- a/vuu/src/test/scala/org/finos/vuu/core/table/join/JoinsOfJoinsTableTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/join/JoinsOfJoinsTableTest.scala
@@ -119,7 +119,7 @@ class JoinsOfJoinsTableTest extends AnyFeatureSpec with Matchers with ViewPortSe
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 
@@ -216,7 +216,7 @@ class JoinsOfJoinsTableTest extends AnyFeatureSpec with Matchers with ViewPortSe
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 
@@ -310,7 +310,7 @@ class JoinsOfJoinsTableTest extends AnyFeatureSpec with Matchers with ViewPortSe
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 

--- a/vuu/src/test/scala/org/finos/vuu/net/rpc/DefaultRpcHandlerTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/net/rpc/DefaultRpcHandlerTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.matchers.should.Matchers
 
 class DefaultRpcHandlerTest extends AnyFeatureSpec with Matchers with BeforeAndAfterEach {
   private var handler: DefaultRpcHandler = _
-  private val ctx = RequestContext("requestId", VuuUser("user"), ClientSessionId("sessionId", "user", "channel"), null, "token")
+  private val ctx = RequestContext("requestId", VuuUser("user"), ClientSessionId("sessionId", "channel"), null, "token")
 
   override def beforeEach(): Unit = {
     implicit val clock: Clock = new DefaultClock

--- a/vuu/src/test/scala/org/finos/vuu/net/rpc/RpcTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/net/rpc/RpcTest.scala
@@ -60,7 +60,7 @@ class RpcTest extends AnyFeatureSpec with Matchers {
       val myRpcHandler = new MyCustomRpcHandler()(null)
       val customObject = new CustomObject("test")
 
-      val ctx = RequestContext("", VuuUser(""), ClientSessionId("", "", ""), null, "")
+      val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null, "")
 
       val ret = myRpcHandler.processRpcRequest("doSomething", new RpcParams(Map("param1" -> "test", "param2" -> 1234.34), null, ctx))
       ret.isInstanceOf[RpcFunctionSuccess] shouldBe true

--- a/vuu/src/test/scala/org/finos/vuu/test/impl/TestVuuServerImpl.scala
+++ b/vuu/src/test/scala/org/finos/vuu/test/impl/TestVuuServerImpl.scala
@@ -194,7 +194,7 @@ class TestVuuServerImpl(val modules: List[ViewServerModule])(implicit clock: Clo
     channel.popMsg match {
       case Some(msgPacket) =>
         val msg = serializer.deserialize(msgPacket)
-        clientSessionId = ClientSessionId(msg.sessionId, user.name, channel.id().asLongText())
+        clientSessionId = ClientSessionId(msg.sessionId, channel.id().asLongText())
     }
   }
 
@@ -204,7 +204,7 @@ class TestVuuServerImpl(val modules: List[ViewServerModule])(implicit clock: Clo
 
   override def getViewPortRpcServiceProxy[TYPE : _root_.scala.reflect.ClassTag](viewport: ViewPort):TYPE = {
 
-    val interceptor = RpcDynamicProxy(viewport, handler, serializer, session, channel)
+    val interceptor = RpcDynamicProxy(viewport, handler, serializer, user, session, channel)
 
     val clazz: Class[_] = classTag[TYPE].runtimeClass
 

--- a/vuu/src/test/scala/org/finos/vuu/test/rpc/RpcDynamicProxy.scala
+++ b/vuu/src/test/scala/org/finos/vuu/test/rpc/RpcDynamicProxy.scala
@@ -2,6 +2,7 @@ package org.finos.vuu.test.rpc
 
 import com.typesafe.scalalogging.StrictLogging
 import org.finos.vuu.client.messages.RequestId
+import org.finos.vuu.core.auths.VuuUser
 import org.finos.vuu.net.json.JsonVsSerializer
 import org.finos.vuu.net.{ClientSessionId, JsonViewServerMessage, ViewPortAddRowRpcCall, ViewPortDeleteCellRpcCall, ViewPortDeleteRowRpcCall, ViewPortEditCellRpcCall, ViewPortEditRowRpcCall, ViewPortEditSubmitFormRpcCall, ViewServerHandler}
 import org.finos.vuu.test.impl.TestChannel
@@ -10,7 +11,9 @@ import org.finos.vuu.viewport.{ViewPort, ViewPortAddRowAction, ViewPortDeleteCel
 import java.lang.reflect.{InvocationHandler, Method}
 
 class RpcDynamicProxy(viewport: ViewPort,
-                      handler: ViewServerHandler, serializer: JsonVsSerializer,
+                      handler: ViewServerHandler, 
+                      serializer: JsonVsSerializer,
+                      user: VuuUser,
                       session: ClientSessionId,
                       channel: TestChannel) extends InvocationHandler with StrictLogging {
 
@@ -19,7 +22,7 @@ class RpcDynamicProxy(viewport: ViewPort,
 
       val requestId = RequestId.oneNew()
       val rpcMessage = ViewPortEditCellRpcCall(viewport.id, key, col, theValue)
-      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", session.user, rpcMessage)
+      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", user.name, rpcMessage)
 
       val packet = serializer.serialize(vpMsg)
 
@@ -44,7 +47,7 @@ class RpcDynamicProxy(viewport: ViewPort,
 
       val requestId = RequestId.oneNew()
       val rpcMessage = ViewPortEditRowRpcCall(viewport.id, key, map.asInstanceOf[Map[String, Object]])
-      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", session.user, rpcMessage)
+      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", user.name, rpcMessage)
 
       val packet = serializer.serialize(vpMsg)
 
@@ -69,7 +72,7 @@ class RpcDynamicProxy(viewport: ViewPort,
 
       val requestId = RequestId.oneNew()
       val rpcMessage = ViewPortAddRowRpcCall(viewport.id, key, map.asInstanceOf[Map[String, Object]])
-      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", session.user, rpcMessage)
+      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", user.name, rpcMessage)
 
       val packet = serializer.serialize(vpMsg)
 
@@ -95,7 +98,7 @@ class RpcDynamicProxy(viewport: ViewPort,
 
       val requestId = RequestId.oneNew()
       val rpcMessage = ViewPortDeleteRowRpcCall(viewport.id, key)
-      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", session.user, rpcMessage)
+      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", user.name, rpcMessage)
 
       val packet = serializer.serialize(vpMsg)
 
@@ -120,7 +123,7 @@ class RpcDynamicProxy(viewport: ViewPort,
 
       val requestId = RequestId.oneNew()
       val rpcMessage = ViewPortEditSubmitFormRpcCall(viewport.id)
-      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", session.user, rpcMessage)
+      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", user.name, rpcMessage)
 
       val packet = serializer.serialize(vpMsg)
 
@@ -145,7 +148,7 @@ class RpcDynamicProxy(viewport: ViewPort,
 
       val requestId = RequestId.oneNew()
       val rpcMessage = ViewPortDeleteCellRpcCall(viewport.id, key, column)
-      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", session.user, rpcMessage)
+      val vpMsg = JsonViewServerMessage(requestId, session.sessionId, "", user.name, rpcMessage)
 
       val packet = serializer.serialize(vpMsg)
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/AbstractViewPortTestCase.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/AbstractViewPortTestCase.scala
@@ -79,7 +79,7 @@ class AbstractViewPortTestCase extends AnyFeatureSpec {
 
     val user = VuuUser("chris")
 
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 
@@ -139,7 +139,7 @@ class AbstractViewPortTestCase extends AnyFeatureSpec {
 
     val user = VuuUser("chris")
 
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 
@@ -198,7 +198,7 @@ class AbstractViewPortTestCase extends AnyFeatureSpec {
 
     val user = VuuUser("chris")
 
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/AmendViewPortToTreeTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/AmendViewPortToTreeTest.scala
@@ -74,7 +74,7 @@ class AmendViewPortToTreeTest extends AnyFeatureSpec with ViewPortSetup {
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 
@@ -195,7 +195,7 @@ class AmendViewPortToTreeTest extends AnyFeatureSpec with ViewPortSetup {
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/CalculatedColumnsViewPortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/CalculatedColumnsViewPortTest.scala
@@ -263,7 +263,7 @@ class CalculatedColumnsViewPortTest extends AbstractViewPortTestCase with Matche
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val outQueue = new OutboundRowPublishQueue()
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/ChangeViewPortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/ChangeViewPortTest.scala
@@ -88,7 +88,7 @@ class ChangeViewPortTest extends AnyFeatureSpec{
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val outQueue = new OutboundRowPublishQueue()
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/FilterAndSortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/FilterAndSortTest.scala
@@ -54,7 +54,7 @@ class FilterAndSortTest extends AnyFeatureSpec with Matchers with ViewPortSetup 
 
       val columns = ViewPortColumnCreator.create(orders, orders.getTableDef.columns.map(_.name).toList)
 
-      val viewport = viewPortContainer.create(RequestId.oneNew(), VuuUser("B"), ClientSessionId("A", "B", "C"), queue, orders, ViewPortRange(0, 5), columns)
+      val viewport = viewPortContainer.create(RequestId.oneNew(), VuuUser("B"), ClientSessionId("A", "C"), queue, orders, ViewPortRange(0, 5), columns)
 
       viewPortContainer.runOnce()
 
@@ -182,7 +182,7 @@ class FilterAndSortTest extends AnyFeatureSpec with Matchers with ViewPortSetup 
 
       //val columns = orderPrices.getTableDef.columns
 
-      val viewport = viewPortContainer.create(RequestId.oneNew(), VuuUser("B"), ClientSessionId("A", "B", "C"), queue, orderPrices, ViewPortRange(0, 20), columns)
+      val viewport = viewPortContainer.create(RequestId.oneNew(), VuuUser("B"), ClientSessionId("A", "C"), queue, orderPrices, ViewPortRange(0, 20), columns)
 
       viewPortContainer.runOnce()
 
@@ -344,7 +344,7 @@ class FilterAndSortTest extends AnyFeatureSpec with Matchers with ViewPortSetup 
 
       //val columns = orderPrices.getTableDef.columns
 
-      val viewport = viewPortContainer.create(RequestId.oneNew(), VuuUser("B"), ClientSessionId("A", "B", "C"), queue, orderPrices, ViewPortRange(0, 20), columns)
+      val viewport = viewPortContainer.create(RequestId.oneNew(), VuuUser("B"), ClientSessionId("A", "C"), queue, orderPrices, ViewPortRange(0, 20), columns)
 
       viewPortContainer.runOnce()
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/TreeAndAggregate2Test.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/TreeAndAggregate2Test.scala
@@ -43,7 +43,7 @@ class TreeAndAggregate2Test extends AnyFeatureSpec with Matchers with GivenWhenT
 
       val viewport = viewPortContainer.create(RequestId.oneNew(),
         VuuUser("B"),
-        ClientSessionId("A", "B", "C"),
+        ClientSessionId("A", "C"),
         queue, orderPrices, ViewPortRange(0, 20), columns,
         SortSpec(List()),
         FilterSpec(""),
@@ -181,7 +181,7 @@ class TreeAndAggregate2Test extends AnyFeatureSpec with Matchers with GivenWhenT
 
       val viewport = viewPortContainer.create(RequestId.oneNew(),
         VuuUser("B"),
-        ClientSessionId("A", "B", "C"),
+        ClientSessionId("A", "C"),
         queue, orderPrices, ViewPortRange(0, 20), columns,
         SortSpec(List()),
         FilterSpec(""),
@@ -248,7 +248,7 @@ class TreeAndAggregate2Test extends AnyFeatureSpec with Matchers with GivenWhenT
 
       val viewport = viewPortContainer.create(RequestId.oneNew(),
         VuuUser("B"),
-        ClientSessionId("A", "B", "C"),
+        ClientSessionId("A", "C"),
         queue, orderPrices, ViewPortRange(0, 20), columns,
         SortSpec(List()),
         FilterSpec(""),
@@ -311,7 +311,7 @@ class TreeAndAggregate2Test extends AnyFeatureSpec with Matchers with GivenWhenT
 
       val viewport = viewPortContainer.create(RequestId.oneNew(),
         VuuUser("B"),
-        ClientSessionId("A", "B", "C"),
+        ClientSessionId("A", "C"),
         queue, orderPrices, ViewPortRange(0, 20), columns,
         SortSpec(List()),
         FilterSpec(""),
@@ -371,7 +371,7 @@ class TreeAndAggregate2Test extends AnyFeatureSpec with Matchers with GivenWhenT
 
       val viewport = viewPortContainer.create(RequestId.oneNew(),
         VuuUser("B"),
-        ClientSessionId("A", "B", "C"),
+        ClientSessionId("A", "C"),
         queue, orderPrices, ViewPortRange(0, 20), columns,
         SortSpec(List()),
         FilterSpec(""),
@@ -430,7 +430,7 @@ class TreeAndAggregate2Test extends AnyFeatureSpec with Matchers with GivenWhenT
 
       val viewport = viewPortContainer.create(RequestId.oneNew(),
         VuuUser("B"),
-        ClientSessionId("A", "B", "C"),
+        ClientSessionId("A", "C"),
         queue, orderPrices, ViewPortRange(0, 20), columns,
         SortSpec(List()),
         FilterSpec(""),

--- a/vuu/src/test/scala/org/finos/vuu/viewport/TreeAndAggregateTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/TreeAndAggregateTest.scala
@@ -40,7 +40,7 @@ class TreeAndAggregateTest extends AnyFeatureSpec with Matchers with GivenWhenTh
 
       val viewport = viewPortContainer.create(RequestId.oneNew(),
         VuuUser("B"),
-        ClientSessionId("A", "B", "C"),
+        ClientSessionId("A", "C"),
         queue, orderPrices, ViewPortRange(0, 20), columns,
         SortSpec(List()),
         FilterSpec(""),
@@ -184,7 +184,7 @@ class TreeAndAggregateTest extends AnyFeatureSpec with Matchers with GivenWhenTh
 
     val viewport = viewPortContainer.create(RequestId.oneNew(),
       VuuUser("B"),
-      ClientSessionId("A", "B", "C"),
+      ClientSessionId("A", "C"),
       queue, orderPrices, ViewPortRange(0, 20), columns,
       SortSpec(List()),
       FilterSpec(""),

--- a/vuu/src/test/scala/org/finos/vuu/viewport/TreeBuilderAndAggregatesTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/TreeBuilderAndAggregatesTest.scala
@@ -49,7 +49,7 @@ class TreeBuilderAndAggregatesTest extends AnyFeatureSpec with Matchers with Vie
 
       joinProvider.runOnce()
 
-      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "B", "C"), joinProvider)
+      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "C"), joinProvider)
 
       val columns = ViewPortColumnCreator.create(sessionTable, sessionTable.getTableDef.columns.map(_.name).toList)
 
@@ -86,7 +86,7 @@ class TreeBuilderAndAggregatesTest extends AnyFeatureSpec with Matchers with Vie
 
       joinProvider.runOnce()
 
-      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "B", "C"), joinProvider)
+      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "C"), joinProvider)
 
       val columns = ViewPortColumnCreator.create(sessionTable, sessionTable.getTableDef.columns.map(_.name).toList)
 
@@ -123,7 +123,7 @@ class TreeBuilderAndAggregatesTest extends AnyFeatureSpec with Matchers with Vie
 
       joinProvider.runOnce()
 
-      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "B", "C"), joinProvider)
+      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "C"), joinProvider)
 
       val columns = ViewPortColumnCreator.create(sessionTable, sessionTable.getTableDef.columns.map(_.name).toList)
 
@@ -161,7 +161,7 @@ class TreeBuilderAndAggregatesTest extends AnyFeatureSpec with Matchers with Vie
 
       joinProvider.runOnce()
 
-      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "B", "C"), joinProvider)
+      val sessionTable = new TreeSessionTableImpl(orderPrices, ClientSessionId("A", "C"), joinProvider)
 
       val columns = ViewPortColumnCreator.create(sessionTable, sessionTable.getTableDef.columns.map(_.name).toList)
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/TreeOnOffTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/TreeOnOffTest.scala
@@ -46,7 +46,7 @@ class TreeOnOffTest extends AnyFeatureSpec with Matchers with ViewPortSetup {
 
       val queue = new OutboundRowPublishQueue()
       val user = VuuUser("B")
-      val session = ClientSessionId("A", "B", "C")
+      val session = ClientSessionId("A", "C")
       val columns = ViewPortColumnCreator.create(orderPrices, orderPrices.getTableDef.columns.map(_.name).toList)
       val range = ViewPortRange(0, 20)
       val viewPort = viewPortContainer.create(RequestId.oneNew(), user, session, queue, orderPrices, range, columns)

--- a/vuu/src/test/scala/org/finos/vuu/viewport/TreeSortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/TreeSortTest.scala
@@ -42,7 +42,7 @@ class TreeSortTest extends AnyFeatureSpec with Matchers with GivenWhenThen with 
 
     val viewport = viewPortContainer.create(RequestId.oneNew(),
       VuuUser("B"),
-      ClientSessionId("A", "B", "C"),
+      ClientSessionId("A", "C"),
       queue, orderPrices, ViewPortRange(0, 20), vpColumns,
       SortSpec(List(
         SortDef("trader", 'D'),

--- a/vuu/src/test/scala/org/finos/vuu/viewport/TreeUpdateChildCountsTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/TreeUpdateChildCountsTest.scala
@@ -43,7 +43,7 @@ class TreeUpdateChildCountsTest extends AnyFeatureSpec with Matchers with GivenW
 
     val viewport = viewPortContainer.create(RequestId.oneNew(),
       VuuUser("B"),
-      ClientSessionId("A", "B", "C"),
+      ClientSessionId("A", "C"),
       queue, orderPrices, ViewPortRange(0, 20), vpColumns,
       SortSpec(List()),
       FilterSpec(""),
@@ -100,7 +100,7 @@ class TreeUpdateChildCountsTest extends AnyFeatureSpec with Matchers with GivenW
 
     val viewport = viewPortContainer.create(RequestId.oneNew(),
       VuuUser("B"),
-      ClientSessionId("A", "B", "C"),
+      ClientSessionId("A", "C"),
       queue, orderPrices, ViewPortRange(0, 20), vpColumns,
       SortSpec(List()),
       FilterSpec(""),

--- a/vuu/src/test/scala/org/finos/vuu/viewport/VisualLinkedViewPortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/VisualLinkedViewPortTest.scala
@@ -237,7 +237,7 @@ class VisualLinkedViewPortTest extends AbstractViewPortTestCase with Matchers wi
 
       val user = VuuUser("chris")
       
-      val session = ClientSessionId("sess-01", "chris", "channel")
+      val session = ClientSessionId("sess-01", "channel")
 
       val outQueue = new OutboundRowPublishQueue()
       val vpcolumnsOrders1 = ViewPortColumnCreator.create(orders1, List("orderId", "trader", "tradeTime", "quantity", "ric"))

--- a/vuu/src/test/scala/org/finos/vuu/viewport/editable/EditableViewPortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/editable/EditableViewPortTest.scala
@@ -152,7 +152,7 @@ abstract class EditableViewPortTest extends AbstractViewPortTestCase with Matche
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/menurpc/CallMenuRpcFromViewPortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/menurpc/CallMenuRpcFromViewPortTest.scala
@@ -94,7 +94,7 @@ class CallMenuRpcFromViewPortTest extends AnyFeatureSpec with Matchers with View
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
     val highPriorityQueue = new OutboundRowPublishQueue()

--- a/vuu/src/test/scala/org/finos/vuu/viewport/performance/CalculateTreeOptimizationTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/performance/CalculateTreeOptimizationTest.scala
@@ -74,7 +74,7 @@ class CalculateTreeOptimizationTest extends AnyFeatureSpec with ViewPortSetup {
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/sessiontable/AbstractSessionTestCase.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/sessiontable/AbstractSessionTestCase.scala
@@ -82,7 +82,7 @@ trait AbstractSessionTestCase {
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/sessiontable/SessionTableViewportTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/sessiontable/SessionTableViewportTest.scala
@@ -172,7 +172,7 @@ class SessionTableViewportTest extends AbstractViewPortTestCase with Matchers wi
 
     val user = VuuUser("chris")
     
-    val session = ClientSessionId("sess-01", "chris", "channel")
+    val session = ClientSessionId("sess-01", "channel")
 
     val outQueue = new OutboundRowPublishQueue()
 


### PR DESCRIPTION
Part 2 (of 3)

User has been removed from the client session id trait.

Had to update the permission module to break the link between the sessionContainer and the list of known users.
