### PR TITLE
fix for useTableContextMenu with wrong columnMap

### DIFF
--- a/vuu-ui/packages/vuu-table/src/useTable.ts
+++ b/vuu-ui/packages/vuu-table/src/useTable.ts
@@ -736,6 +736,7 @@ export const useTable = ({
   );
 
   const onContextMenu = useTableContextMenu({
+    columnMap,
     columns,
     data,
     dataSource,

--- a/vuu-ui/packages/vuu-table/src/useTableContextMenu.ts
+++ b/vuu-ui/packages/vuu-table/src/useTableContextMenu.ts
@@ -2,15 +2,21 @@ import { useContextMenu } from "@vuu-ui/vuu-context-menu";
 import { DataSource, DataSourceRow } from "@vuu-ui/vuu-data-types";
 import {
   ColumnDescriptor,
+  RuntimeColumnDescriptor,
   TableContextMenuOptions,
   TableMenuLocation,
 } from "@vuu-ui/vuu-table-types";
-import { buildColumnMap, isTypeDescriptor } from "@vuu-ui/vuu-utils";
+import {
+  columnByAriaIndex,
+  ColumnMap,
+  useStableReference,
+} from "@vuu-ui/vuu-utils";
 import { MouseEvent, useCallback } from "react";
 import { getAriaColIndex, getAriaRowIndex } from "./table-dom-utils";
 
 export interface TableContextMenuHookProps {
   allowContextMenu?: boolean;
+  columnMap: ColumnMap;
   columns: ColumnDescriptor[];
   data: DataSourceRow[];
   dataSource: DataSource;
@@ -39,6 +45,7 @@ const getDataSourceRow = (rows: DataSourceRow[], rowIndex: number) => {
 
 export const useTableContextMenu = ({
   allowContextMenu = true,
+  columnMap: columnMapProp,
   columns,
   data,
   dataSource,
@@ -46,6 +53,7 @@ export const useTableContextMenu = ({
   headerCount = 1,
 }: TableContextMenuHookProps) => {
   const showContextMenu = useContextMenu();
+  const { current: columnMap } = useStableReference(columnMapProp);
 
   const onContextMenu = useCallback(
     (evt: MouseEvent<HTMLElement>) => {
@@ -53,18 +61,19 @@ export const useTableContextMenu = ({
       const cellEl = target?.closest<HTMLElement>("div[role='cell']");
       const rowEl = target?.closest<HTMLElement>("div[role='row']");
       if (cellEl && rowEl) {
-        const [firstColumn] = columns;
-        const hasCheckBox =
-          firstColumn?.isSystemColumn &&
-          isTypeDescriptor(firstColumn?.type) &&
-          firstColumn.type.name === "checkbox";
+        // const [firstColumn] = columns;
+        // const hasCheckBox =
+        //   firstColumn?.isSystemColumn &&
+        //   isTypeDescriptor(firstColumn?.type) &&
+        //   firstColumn.type.name === "checkbox";
         const { selectedRowsCount } = dataSource;
-        const columnMap = buildColumnMap(columns);
         const rowIndex = getAriaRowIndex(rowEl) - headerCount - 1;
         const ariaColIndex = getAriaColIndex(cellEl);
-        const cellIndex = hasCheckBox ? ariaColIndex : ariaColIndex - 1;
         const row = getDataSourceRow(data, rowIndex);
-        const column = columns[cellIndex];
+        const column = columnByAriaIndex(
+          columns as RuntimeColumnDescriptor[],
+          ariaColIndex,
+        );
 
         // TODO does it really make sense to collect selected rows ?
         // We only have access to rows in local cache
@@ -88,7 +97,15 @@ export const useTableContextMenu = ({
         }
       }
     },
-    [columns, data, dataSource, getSelectedRows, headerCount, showContextMenu],
+    [
+      columnMap,
+      columns,
+      data,
+      dataSource,
+      getSelectedRows,
+      headerCount,
+      showContextMenu,
+    ],
   );
 
   return allowContextMenu ? onContextMenu : undefined;

--- a/vuu-ui/packages/vuu-utils/src/column-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/column-utils.ts
@@ -1357,3 +1357,18 @@ export const reorderColumnItems = <
   }
   return columns;
 };
+
+export const columnByAriaIndex = (
+  columns: RuntimeColumnDescriptor[],
+  ariaColIndex: number,
+) => {
+  const column = columns[ariaColIndex - 1];
+  if (column && column.ariaColIndex === ariaColIndex) {
+    return column;
+  } else if (column && column.ariaColIndex < ariaColIndex) {
+    if (columns[ariaColIndex]?.ariaColIndex === ariaColIndex) {
+      return columns[ariaColIndex];
+    }
+  }
+  throw Error(`no column with aria-colIndex ${ariaColIndex}`);
+};

--- a/vuu-ui/packages/vuu-utils/src/react-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/react-utils.ts
@@ -5,6 +5,7 @@ import {
   ReactNode,
   SetStateAction,
   useEffect,
+  useMemo,
   useRef,
 } from "react";
 
@@ -74,4 +75,16 @@ export const createSyntheticEvent = <T extends Element, E extends Event>(
     timeStamp: event.timeStamp,
     type: event.type,
   };
+};
+
+/**
+ * Store a value in a RefObject and update that ref whenever the value changes.
+ * Use to maintain a stable reference to a changing value that we need to use
+ * within a hook, but when that hook does not need to be triggered just because
+ * this value changes.
+ */
+export const useStableReference = <T>(value: T) => {
+  const referenceToProp = useRef<T>(value);
+  useMemo(() => (referenceToProp.current = value), [value]);
+  return referenceToProp;
 };

--- a/vuu-ui/showcase/src/examples/Filters/TabbedFilterContainer.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Filters/TabbedFilterContainer.examples.tsx
@@ -9,7 +9,7 @@ import {
   useFilterContextMenu,
   useSavedFilters,
 } from "@vuu-ui/vuu-filters";
-import { Table } from "@vuu-ui/vuu-table";
+import { Table, TableProps } from "@vuu-ui/vuu-table";
 import {
   ColumnDescriptor,
   TableContextMenuDef,
@@ -242,10 +242,12 @@ const useLocalContextMenu = (): TableContextMenuDef => {
 const TableWithTabbedFilterContainerTemplate = ({
   SavedFilterPanelProps,
   children,
+  selectionModel,
   table = "instruments",
-}: Pick<TabbedFilterContainerProps, "children" | "SavedFilterPanelProps"> & {
-  table?: VuuTableName;
-}) => {
+}: Pick<TabbedFilterContainerProps, "children" | "SavedFilterPanelProps"> &
+  Pick<TableProps, "selectionModel"> & {
+    table?: VuuTableName;
+  }) => {
   const showContextPanel = useContextPanel();
   const { VuuDataSource } = useData();
 
@@ -305,14 +307,20 @@ const TableWithTabbedFilterContainerTemplate = ({
       </div>
       <ContextMenuProvider {...copyContextMenuProps}>
         <ContextMenuProvider {...filterContextMenuProps}>
-          <Table config={config} dataSource={dataSource} />
+          <Table
+            config={config}
+            dataSource={dataSource}
+            selectionModel={selectionModel}
+          />
         </ContextMenuProvider>
       </ContextMenuProvider>
     </>
   );
 };
 
-export const InstrumentsWithTabbedFilterContainerAndFilterProvider = () => {
+export const InstrumentsWithTabbedFilterContainerAndFilterProvider = ({
+  selectionModel,
+}: Pick<TableProps, "selectionModel">) => {
   const table = useMemo<TableSchemaTable>(
     () => ({ module: "SIMUL", table: "instruments" }),
     [],
@@ -354,6 +362,7 @@ export const InstrumentsWithTabbedFilterContainerAndFilterProvider = () => {
           <ContextPanelProvider>
             <TableWithTabbedFilterContainerTemplate
               SavedFilterPanelProps={SavedFilterPanelProps}
+              selectionModel={selectionModel}
             >
               <FormField>
                 <FormFieldLabel>Vuu Created</FormFieldLabel>
@@ -402,6 +411,10 @@ export const InstrumentsWithTabbedFilterContainerAndFilterProvider = () => {
     </>
   );
 };
+
+export const WithCheckbox = () => (
+  <InstrumentsWithTabbedFilterContainerAndFilterProvider selectionModel="checkbox" />
+);
 
 export const OrdersWithTabbedFilterContainerAndFilterProvider = () => {
   const table = useMemo<TableSchemaTable>(


### PR DESCRIPTION
bug in table context menu when table includes a checkbox selection column. Out by one error in cell identification caused by badly generated columnMap