### PR TITLE
Change blocking queue behaviour to respect insertion order regardless of priority

### DIFF
--- a/toolbox/src/main/scala/org/finos/toolbox/collection/queue/BinaryPriorityBlockingQueue.scala
+++ b/toolbox/src/main/scala/org/finos/toolbox/collection/queue/BinaryPriorityBlockingQueue.scala
@@ -26,7 +26,7 @@ object BinaryPriorityBlockingQueue {
 
 private class BinaryPriorityBlockingQueueImpl[T](capacity: Int) extends BinaryPriorityBlockingQueue[T] with StrictLogging {
 
-  private final val overflowQueue = new util.ArrayDeque[T]()
+  private final val overflowQueue = new util.LinkedList[T]()
   private final val mainQueue = new util.ArrayDeque[T](capacity)
   private final val running = AtomicBoolean(true)
   private final val lock = ReentrantLock()

--- a/toolbox/src/test/scala/org/finos/toolbox/collection/queue/BinaryPriorityBlockingQueueTest.scala
+++ b/toolbox/src/test/scala/org/finos/toolbox/collection/queue/BinaryPriorityBlockingQueueTest.scala
@@ -137,16 +137,22 @@ class BinaryPriorityBlockingQueueTest extends AnyFunSuite with Matchers {
     val bq = BinaryPriorityBlockingQueue[String](1)
     bq.put("1")
 
-    bq.putHighPriority("98")
-    val future = CompletableFuture.supplyAsync(() => bq.put("99"))
-    future.isDone shouldBe false
-    bq.putHighPriority("100")
+    val future = CompletableFuture.supplyAsync(() => bq.putHighPriority("98"))
+    eventually {
+      future.isDone shouldBe true
+    }
+    val future2 = CompletableFuture.supplyAsync(() => bq.put("99"))
+    val future3 = CompletableFuture.supplyAsync(() => bq.putHighPriority("100"))
+    eventually {
+      future3.isDone shouldBe true
+    }
+    future2.isDone shouldBe false
 
     val result = new util.ArrayList[String]()
     bq.drainTo(result)
     result shouldBe java.util.List.of("1", "98", "100")
     eventually {
-      future.isDone shouldBe true
+      future2.isDone shouldBe true
     }
 
     result.clear()


### PR DESCRIPTION
The current priority implementation led to hard to detect race conditions on join of join data tables.

Shame on me.