### PR TITLE
Upgrade to Jackson 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <!-- Dependencies -->
         <antlr.version>4.13.2</antlr.version>
         <assertj.version>3.27.7</assertj.version>
-        <jackson.version>3.1.0</jackson.version>
+        <jackson.version>3.1.1</jackson.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <logback.version>1.5.32</logback.version>
         <metrics.version>4.2.38</metrics.version>


### PR DESCRIPTION
Contains a fix for https://github.com/FasterXML/jackson-core/security/advisories/GHSA-2m67-wjpj-xhg9