### PR TITLE
feat: add vuu_msg default column to session tables (#2166)

### DIFF
--- a/vuu/src/main/scala/org/finos/vuu/api/TableDef.scala
+++ b/vuu/src/main/scala/org/finos/vuu/api/TableDef.scala
@@ -216,7 +216,7 @@ class TableDef(val name: String,
                val permissionFunction: (ViewPort, TableContainer) => PermissionFilter = (_, _) => AllowAllPermissionFilter,
                val defaultSort: SortSpec = SortSpec(List.empty)) extends VuuInMemPluginLocator {
 
-  private val defaultColumns: Array[Column] = if (includeDefaultColumns) DefaultColumn.getDefaultColumns(customColumns) else Array.empty
+  private val defaultColumns: Array[Column] = if (includeDefaultColumns) DefaultColumn.getDefaultColumns(customColumns, this.isInstanceOf[SessionTableDef] || this.isInstanceOf[JoinSessionTableDef]) else Array.empty
   private val columns: Array[Column] = if (includeDefaultColumns) customColumns ++ defaultColumns else customColumns
   private val columnsByName: Map[String, Column] = getColumns.map(c => c.name -> c).toMap
   private val deletedColumnName: String = s"$name._isDeleted"

--- a/vuu/src/main/scala/org/finos/vuu/core/table/DefaultColumn.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/DefaultColumn.scala
@@ -3,6 +3,7 @@ package org.finos.vuu.core.table
 enum DefaultColumn(val name: String, val dataType: Class[_]) {
   case CreatedTime extends DefaultColumn("vuuCreatedTimestamp", DataType.EpochTimestampType)
   case LastUpdatedTime extends DefaultColumn("vuuUpdatedTimestamp", DataType.EpochTimestampType)
+  case VuuMsg extends DefaultColumn("vuu_msg", DataType.StringDataType)
 }
 
 object DefaultColumn {
@@ -10,11 +11,16 @@ object DefaultColumn {
   val COUNT: Int = DefaultColumn.values.length
   val CREATED_TIME: DefaultColumn = DefaultColumn.CreatedTime
   val LAST_UPDATED_TIME: DefaultColumn = DefaultColumn.LastUpdatedTime
+  val VUU_MSG: DefaultColumn = DefaultColumn.VuuMsg
 
   private val allDefaults = DefaultColumn.values
 
-  def getDefaultColumns(customColumns: Array[Column]): Array[Column] =
-    allDefaults.map(f => SimpleColumn(f.name, customColumns.length + f.ordinal, f.dataType))
+  def getDefaultColumns(customColumns: Array[Column], isSessionTable: Boolean = false): Array[Column] = {
+    val defaults = if (isSessionTable) allDefaults else allDefaults.filterNot(_ == DefaultColumn.VuuMsg)
+    defaults.zipWithIndex.map({ case (f, index) =>
+      SimpleColumn(f.name, customColumns.length + index, f.dataType)
+    })
+  }
 
   def isDefaultColumn(column: Column): Boolean =
     allDefaults.exists(f => f.name == column.name && f.dataType == column.dataType)
@@ -23,3 +29,4 @@ object DefaultColumn {
     allDefaults.map(f => f.name)
 
 }
+

--- a/vuu/src/test/scala/org/finos/vuu/core/module/ModuleSyntaxTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/module/ModuleSyntaxTest.scala
@@ -40,7 +40,7 @@ class ModuleSyntaxTest extends AnyFeatureSpec with Matchers with GivenWhenThen {
 
       val instrumentPrices = module.tableDefs.tail.tail.head
       instrumentPrices.name should equal("instrumentPrices")
-      instrumentPrices.getColumns.length should equal(prices.customColumns.length + instruments.customColumns.length + DefaultColumn.values.length - 1)
+      instrumentPrices.getColumns.length should equal(prices.customColumns.length + instruments.customColumns.length + DefaultColumn.getDefaultColumns(Array.empty, isSessionTable = false).length - 1)
       // exclude default columns in left and right table and exclude join column, and add default columns to the join table itself
 
       instrumentPrices.joinFields should equal(Seq())

--- a/vuu/src/test/scala/org/finos/vuu/core/table/DefaultColumnTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/DefaultColumnTest.scala
@@ -1,6 +1,6 @@
 package org.finos.vuu.core.table
 
-import org.finos.vuu.api.{Indices, TableDef}
+import org.finos.vuu.api.{Indices, SessionTableDef, TableDef}
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -10,7 +10,7 @@ class DefaultColumnTest extends AnyFeatureSpec with Matchers {
 
     Scenario("Check default column count") {
 
-      DefaultColumn.values.length shouldEqual 2
+      DefaultColumn.values.length shouldEqual 3
 
     }
 
@@ -30,11 +30,19 @@ class DefaultColumnTest extends AnyFeatureSpec with Matchers {
       lastUpdatedTime.dataType.isInstanceOf[DataType.EpochTimestampType.type] shouldBe true
     }
 
+    Scenario("Check vuu_msg column") {
+
+      val vuuMsg = DefaultColumn.VuuMsg
+
+      vuuMsg.name shouldEqual "vuu_msg"
+      vuuMsg.dataType.isInstanceOf[DataType.StringDataType.type] shouldBe true
+    }
+
     Scenario("Default columns are created as expected") {
 
       val customColumn: Column = SimpleColumn("name", 0, DataType.StringDataType)
 
-      val result = DefaultColumn.getDefaultColumns(Array(customColumn))
+      val result = DefaultColumn.getDefaultColumns(Array(customColumn), isSessionTable = false)
 
       result.length shouldEqual 2
       //result.head shouldEqual customColumn
@@ -83,7 +91,30 @@ class DefaultColumnTest extends AnyFeatureSpec with Matchers {
       DefaultColumn.isDefaultColumn(result.head) shouldBe false
     }
 
+    Scenario("Default column vuu_msg is added to SessionTableDef as expected") {
+      val customColumn: Column = SimpleColumn("keyCol", 0, DataType.StringDataType)
+      val sessionTableDef: SessionTableDef = new SessionTableDef(
+        name = "mySessionTable",
+        keyField = "keyCol",
+        customColumns = Array(customColumn),
+        joinFields = Seq.empty,
+        indices = Indices()
+      )
+      val result = sessionTableDef.getColumns
+
+      // custom + CreatedTime + LastUpdatedTime + VuuMsg = 4 columns
+      result.length shouldEqual 4
+      result.head shouldEqual customColumn
+      DefaultColumn.isDefaultColumn(result.head) shouldBe false
+      result(1).name shouldEqual DefaultColumn.CreatedTime.name
+      DefaultColumn.isDefaultColumn(result(1)) shouldBe true
+      result(2).name shouldEqual DefaultColumn.LastUpdatedTime.name
+      DefaultColumn.isDefaultColumn(result(2)) shouldBe true
+      result(3).name shouldEqual DefaultColumn.VuuMsg.name
+      DefaultColumn.isDefaultColumn(result(3)) shouldBe true
+    }
+
   }
 
-
 }
+

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -43,7 +43,7 @@ object TableAsserts {
      val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
        .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
        .filter(_.isInstanceOf[RowWithData])
-       .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+       .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
        .toArray
 
      val heading = expectation.heading
@@ -61,7 +61,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
       .filter(_.isInstanceOf[RowWithData])
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading
@@ -79,7 +79,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
       .filter(_.isInstanceOf[RowWithData])
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading
@@ -97,7 +97,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
       .filter(_.isInstanceOf[RowWithData])
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading
@@ -115,7 +115,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
       .filter(_.isInstanceOf[RowWithData])
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading
@@ -133,7 +133,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .filter(vpu => vpu.table.pullRow(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading
@@ -150,7 +150,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .filter(vpu => vpu.table.pullRow(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading
@@ -167,7 +167,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .filter(vpu => vpu.table.pullRow(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading
@@ -215,7 +215,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
       .filter(_.isInstanceOf[RowWithData])
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading
@@ -232,7 +232,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRow(vpu.key.key, getColumns(vpu.vp.getColumns)))
       .filter(_.isInstanceOf[RowWithData])
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading
@@ -249,7 +249,7 @@ object TableAsserts {
     val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRow(vpu.key.key, getColumns(vpu.vp.getColumns)))
       .filter(_.isInstanceOf[RowWithData])
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => !DefaultColumn.getDefaultColumnNames.contains(k)))
       .toArray
 
     val heading = expectation.heading

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/TableWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/TableWSApiTest.scala
@@ -39,7 +39,7 @@ class TableWSApiTest extends WebSocketApiTestBase {
 
       val responseBody = assertBodyIsInstanceOf[GetTableMetaResponse](response)
       responseBody.columns.length shouldEqual 3
-      responseBody.columns should contain theSameElementsAs (Array("id") ++ DefaultColumn.values.map(_.name))
+      responseBody.columns should contain theSameElementsAs (Array("id") ++ DefaultColumn.getDefaultColumns(Array.empty, isSessionTable = false).map(_.name))
     }
 
     Scenario("For a non existent table") {


### PR DESCRIPTION
Add a default column vuu_msg to SessionTableDef so that error messages can be stored per-row in the session table and displayed on the UI. This supports the table edit mode feature.

Changes:
- DefaultColumn.scala: Added VuuMsg case to enum and updated getDefaultColumns() to only include it for session tables
- TableDef.scala: Passes isSessionTable flag when initialising default columns so vuu_msg is only injected in SessionTableDef
- TableAsserts.scala: Updated to dynamically filter all registered default column names instead of hardcoding specific ones, ensuring tests remain forward-compatible with future default column additions
- DefaultColumnTest.scala: Added test scenarios to verify vuu_msg is present in SessionTableDef and absent in regular TableDef
- ModuleSyntaxTest.scala: Updated column-count assertion to use the non-session default column list
- TableWSApiTest.scala: Updated column-list assertion to use the non-session default column list