### PR TITLE
#2171 part 2 reject view port change with invalid columns

### DIFF
--- a/vuu/src/test/scala/org/finos/vuu/core/table/RowDeleteTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/RowDeleteTest.scala
@@ -196,11 +196,11 @@ class RowDeleteTest extends AnyFeatureSpec with Matchers with OneInstancePerTest
 
       assertVpEq(updates) {
         Table(
-          ("ric"     ,"bid"     ,"ask"     ,"orderId" ,"trader"  ,"ric"     ,"quantity","last"    ,"open"    ,"close"   ,"tradeTime"),
-          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0001","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0002","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0003","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0004","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L)
+          ("ric"     ,"bid"     ,"ask"     ,"orderId" ,"trader"  ,"quantity","last"    ,"open"    ,"close"   ,"tradeTime"),
+          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0001","chris"   ,100       ,null      ,null      ,null      ,1437732000000L),
+          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0002","chris"   ,100       ,null      ,null      ,null      ,1437732000000L),
+          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0003","chris"   ,100       ,null      ,null      ,null      ,1437732000000L),
+          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0004","chris"   ,100       ,null      ,null      ,null      ,1437732000000L)
         )
       }
 
@@ -215,10 +215,10 @@ class RowDeleteTest extends AnyFeatureSpec with Matchers with OneInstancePerTest
 
       assertVpEq(updates2) {
         Table(
-          ("ric"     ,"bid"     ,"ask"     ,"orderId" ,"trader"  ,"ric"     ,"quantity","last"    ,"open"    ,"close"   ,"tradeTime"),
-          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0002","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0003","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0004","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L)
+          ("ric"     ,"bid"     ,"ask"     ,"orderId" ,"trader"  ,"quantity","last"    ,"open"    ,"close"   ,"tradeTime"),
+          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0002","chris"   ,100       ,null      ,null      ,null      ,1437732000000L),
+          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0003","chris"   ,100       ,null      ,null      ,null      ,1437732000000L),
+          ("VOD.L"   ,220.0     ,222.0     ,"NYC-0004","chris"   ,100       ,null      ,null      ,null      ,1437732000000L)
         )
       }
 
@@ -286,12 +286,12 @@ class RowDeleteTest extends AnyFeatureSpec with Matchers with OneInstancePerTest
 
       assertVpEq(updates) {
         Table(
-          ("_childCount","_depth"  ,"_caption","_isOpen" ,"_treeKey","_isLeaf" ,"ric"     ,"bid"     ,"ask"     ,"orderId" ,"trader"  ,"ric"     ,"quantity","last"    ,"open"    ,"close"   ,"tradeTime"),
-          (4         ,1         ,"chris"   ,true      ,"$root|chris",false     ,""        ,""        ,""        ,""        ,1         ,""        ,400.0     ,""        ,""        ,""        ,""        ),
-          (0         ,2         ,"NYC-0001",false     ,"$root|chris|NYC-0001",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0001","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          (0         ,2         ,"NYC-0002",false     ,"$root|chris|NYC-0002",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0002","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          (0         ,2         ,"NYC-0003",false     ,"$root|chris|NYC-0003",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0003","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          (0         ,2         ,"NYC-0004",false     ,"$root|chris|NYC-0004",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0004","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L)
+          ("_childCount","_depth"  ,"_caption","_isOpen" ,"_treeKey","_isLeaf" ,"ric"     ,"bid"     ,"ask"     ,"orderId" ,"trader"  ,"quantity","last"    ,"open"    ,"close"   ,"tradeTime"),
+          (4         ,1         ,"chris"   ,true      ,"$root|chris",false     ,""        ,""        ,""        ,""        ,1         ,400.0     ,""        ,""        ,""        ,""        ),
+          (0         ,2         ,"NYC-0001",false     ,"$root|chris|NYC-0001",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0001","chris",100       ,null      ,null      ,null      ,1437732000000L),
+          (0         ,2         ,"NYC-0002",false     ,"$root|chris|NYC-0002",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0002","chris",100       ,null      ,null      ,null      ,1437732000000L),
+          (0         ,2         ,"NYC-0003",false     ,"$root|chris|NYC-0003",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0003","chris",100       ,null      ,null      ,null      ,1437732000000L),
+          (0         ,2         ,"NYC-0004",false     ,"$root|chris|NYC-0004",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0004","chris",100       ,null      ,null      ,null      ,1437732000000L)
         )
       }
 
@@ -322,12 +322,12 @@ class RowDeleteTest extends AnyFeatureSpec with Matchers with OneInstancePerTest
 
       assertVpEq(combineQs(viewPort)) {
         Table(
-          ("_childCount","_depth"  ,"_caption","_isOpen" ,"_treeKey","_isLeaf" ,"ric"     ,"bid"     ,"ask"     ,"orderId" ,"trader"  ,"ric"     ,"quantity","last"    ,"open"    ,"close"   ,"tradeTime"),
-          (4         ,1         ,"chris"   ,true      ,"$root|chris",false     ,""        ,""        ,""        ,""        ,1         ,""        ,400.0     ,""        ,""        ,""        ,""        ),
-          (0         ,2         ,"NYC-0005",false     ,"$root|chris|NYC-0005",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0005","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          (0         ,2         ,"NYC-0006",false     ,"$root|chris|NYC-0006",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0006","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          (0         ,2         ,"NYC-0007",false     ,"$root|chris|NYC-0007",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0007","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L),
-          (0         ,2         ,"NYC-0008",false     ,"$root|chris|NYC-0008",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0008","chris"   ,"VOD.L"   ,100       ,null      ,null      ,null      ,1437732000000L)
+          ("_childCount","_depth"  ,"_caption","_isOpen" ,"_treeKey","_isLeaf" ,"ric"     ,"bid"     ,"ask"     ,"orderId" ,"trader"  ,"quantity","last"    ,"open"    ,"close"   ,"tradeTime"),
+          (4         ,1         ,"chris"   ,true      ,"$root|chris",false     ,""        ,""        ,""        ,""        ,1         ,400.0     ,""        ,""        ,""        ,""        ),
+          (0         ,2         ,"NYC-0005",false     ,"$root|chris|NYC-0005",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0005","chris",100       ,null      ,null      ,null      ,1437732000000L),
+          (0         ,2         ,"NYC-0006",false     ,"$root|chris|NYC-0006",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0006","chris",100       ,null      ,null      ,null      ,1437732000000L),
+          (0         ,2         ,"NYC-0007",false     ,"$root|chris|NYC-0007",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0007","chris",100       ,null      ,null      ,null      ,1437732000000L),
+          (0         ,2         ,"NYC-0008",false     ,"$root|chris|NYC-0008",true      ,"VOD.L"   ,220.0     ,222.0     ,"NYC-0008","chris",100       ,null      ,null      ,null      ,1437732000000L)
         )
       }
 
@@ -339,12 +339,12 @@ class RowDeleteTest extends AnyFeatureSpec with Matchers with OneInstancePerTest
 
       assertVpEq(combineQs(viewPort)) {
         Table(
-          ("_childCount", "_depth", "_caption", "_isOpen", "_treeKey", "_isLeaf", "ric", "bid", "ask", "orderId", "trader", "ric", "quantity", "last", "open", "close", "tradeTime"),
-          (4, 1, "chris", true, "$root|chris", false, "", "", "", "", 1, "", 400.0, "", "", "", ""),
-          (0, 2, "NYC-0005", false, "$root|chris|NYC-0005", true, "VOD.L", 219.0, 223.0, "NYC-0005", "chris", "VOD.L", 100, null, null, null, 1437732000000L),
-          (0, 2, "NYC-0006", false, "$root|chris|NYC-0006", true, "VOD.L", 219.0, 223.0, "NYC-0006", "chris", "VOD.L", 100, null, null, null, 1437732000000L),
-          (0, 2, "NYC-0007", false, "$root|chris|NYC-0007", true, "VOD.L", 219.0, 223.0, "NYC-0007", "chris", "VOD.L", 100, null, null, null, 1437732000000L),
-          (0, 2, "NYC-0008", false, "$root|chris|NYC-0008", true, "VOD.L", 219.0, 223.0, "NYC-0008", "chris", "VOD.L", 100, null, null, null, 1437732000000L)
+          ("_childCount", "_depth", "_caption", "_isOpen", "_treeKey", "_isLeaf", "ric", "bid", "ask", "orderId", "trader", "quantity", "last", "open", "close", "tradeTime"),
+          (4, 1, "chris", true, "$root|chris", false, "", "", "", "", 1, 400.0, "", "", "", ""),
+          (0, 2, "NYC-0005", false, "$root|chris|NYC-0005", true, "VOD.L", 219.0, 223.0, "NYC-0005", "chris", 100, null, null, null, 1437732000000L),
+          (0, 2, "NYC-0006", false, "$root|chris|NYC-0006", true, "VOD.L", 219.0, 223.0, "NYC-0006", "chris", 100, null, null, null, 1437732000000L),
+          (0, 2, "NYC-0007", false, "$root|chris|NYC-0007", true, "VOD.L", 219.0, 223.0, "NYC-0007", "chris", 100, null, null, null, 1437732000000L),
+          (0, 2, "NYC-0008", false, "$root|chris|NYC-0008", true, "VOD.L", 219.0, 223.0, "NYC-0008", "chris", 100, null, null, null, 1437732000000L)
         )
       }
 

--- a/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnLogicTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnLogicTest.scala
@@ -124,17 +124,17 @@ class CalculatedColumnLogicTest extends AnyFeatureSpec with Matchers with Strict
         CalcColumn("trueFalse", "Boolean", "=if(trader = \"chris\", true, false)")
       ) {
         Table(
-          ("orderId", "quantity", "ric", "tradeTime", "quantity", "bid", "ask", "onMkt", "trader", "ccyCross", "vwapPerf", "trueFalse"),
-          ("NYC-0004", null, "AAPL.L", 5L, null, 99.0, 101.5, false, "chris", "GBPUSD", -0.1234, true),
-          ("LDN-0001", 100L, "VOD.L", 2L, 100L, 99.0, 101.5, true, "chris", "GBPUSD", 1.1234, true),
-          ("LDN-0002", 100L, "BT.L", 1L, 100L, 99.0, 101.01, true, "steve", "GBPUSD", 1.1234, false),
-          ("LDN-0003", null, "VOD.L", 3L, null, 99.0, 101.3, true, "chris", "GBPUSD", 1.1234, true),
-          ("LDN-0008", 100L, "BT.L", 5L, 100L, 99.0, 106.0, true, "chris", "GBPUSD", 1.1234, true),
-          ("NYC-0002", 100L, "VOD.L", 6L, 100L, 99.0, 102.0, false, "steve", "GBPUSD", 1.1234, false),
-          ("NYC-0010", null, "VOD.L", 6L, null, 99.0, 110.0, true, "steve", "GBPUSD", 1.1234, false),
-          ("NYC-0011", null, "VOD/L", 6L, null, 99.0, 109.0, true, "steve", "GBPUSD", 1.1234, false),
-          ("NYC-0012", null, "VOD\\L", 6L, null, 99.0, 105.11, true, "steve", "GBPUSD", 1.1234, false),
-          ("NYC-0013", null, "VOD\\L", 6L, null, 99.0, 122.0, true, "rahúl", "$GBPUSD", 1.1234, false)
+          ("orderId", "quantity", "ric", "tradeTime", "bid", "ask", "onMkt", "trader", "ccyCross", "vwapPerf", "trueFalse"),
+          ("NYC-0004", null, "AAPL.L", 5L, 99.0, 101.5, false, "chris", "GBPUSD", -0.1234, true),
+          ("LDN-0001", 100L, "VOD.L", 2L, 99.0, 101.5, true, "chris", "GBPUSD", 1.1234, true),
+          ("LDN-0002", 100L, "BT.L", 1L, 99.0, 101.01, true, "steve", "GBPUSD", 1.1234, false),
+          ("LDN-0003", null, "VOD.L", 3L, 99.0, 101.3, true, "chris", "GBPUSD", 1.1234, true),
+          ("LDN-0008", 100L, "BT.L", 5L, 99.0, 106.0, true, "chris", "GBPUSD", 1.1234, true),
+          ("NYC-0002", 100L, "VOD.L", 6L, 99.0, 102.0, false, "steve", "GBPUSD", 1.1234, false),
+          ("NYC-0010", null, "VOD.L", 6L, 99.0, 110.0, true, "steve", "GBPUSD", 1.1234, false),
+          ("NYC-0011", null, "VOD/L", 6L, 99.0, 109.0, true, "steve", "GBPUSD", 1.1234, false),
+          ("NYC-0012", null, "VOD\\L", 6L, 99.0, 105.11, true, "steve", "GBPUSD", 1.1234, false),
+          ("NYC-0013", null, "VOD\\L", 6L, 99.0, 122.0, true, "rahúl", "$GBPUSD", 1.1234, false)
         )
       }
     }

--- a/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnMathTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/column/CalculatedColumnMathTest.scala
@@ -124,17 +124,17 @@ class CalculatedColumnMathTest extends AnyFeatureSpec with Matchers with StrictL
       withCalculatedColumns(sampleRows(), tableColumns,
         CalcColumn("halfTradeTime", "Double", "=tradeTime / 2")) {
         Table(
-          ("orderId", "quantity", "ric", "tradeTime", "quantity", "bid", "ask", "onMkt", "trader", "ccyCross", "vwapPerf", "halfTradeTime"),
-          ("NYC-0004", null, "AAPL.L", 5L, null, 99.0, 101.5, false, "chris", "GBPUSD", -0.1234, 2.5),
-          ("LDN-0001", 100L, "VOD.L", 2L, 100L, 99.0, 101.5, true, "chris", "GBPUSD", 1.1234, 1D),
-          ("LDN-0002", 100L, "BT.L", 1L, 100L, 99.0, 101.01, true, "steve", "GBPUSD", 1.1234, 0.5),
-          ("LDN-0003", null, "VOD.L", 3L, null, 99.0, 101.3, true, "chris", "GBPUSD", 1.1234, 1.5),
-          ("LDN-0008", 100L, "BT.L", 5L, 100L, 99.0, 106.0, true, "chris", "GBPUSD", 1.1234, 2.5),
-          ("NYC-0002", 100L, "VOD.L", 6L, 100L, 99.0, 102.0, false, "steve", "GBPUSD", 1.1234, 3D),
-          ("NYC-0010", null, "VOD.L", 6L, null, 99.0, 110.0, true, "steve", "GBPUSD", 1.1234, 3D),
-          ("NYC-0011", null, "VOD/L", 6L, null, 99.0, 109.0, true, "steve", "GBPUSD", 1.1234, 3D),
-          ("NYC-0012", null, "VOD\\L", 6L, null, 99.0, 105.11, true, "steve", "GBPUSD", 1.1234, 3D),
-          ("NYC-0013", null, "VOD\\L", 6L, null, 99.0, 122.0, true, "rahúl", "$GBPUSD", 1.1234, 3D)
+          ("orderId", "quantity", "ric", "tradeTime", "bid", "ask", "onMkt", "trader", "ccyCross", "vwapPerf", "halfTradeTime"),
+          ("NYC-0004", null, "AAPL.L", 5L, 99.0, 101.5, false, "chris", "GBPUSD", -0.1234, 2.5),
+          ("LDN-0001", 100L, "VOD.L", 2L, 99.0, 101.5, true, "chris", "GBPUSD", 1.1234, 1D),
+          ("LDN-0002", 100L, "BT.L", 1L, 99.0, 101.01, true, "steve", "GBPUSD", 1.1234, 0.5),
+          ("LDN-0003", null, "VOD.L", 3L, 99.0, 101.3, true, "chris", "GBPUSD", 1.1234, 1.5),
+          ("LDN-0008", 100L, "BT.L", 5L, 99.0, 106.0, true, "chris", "GBPUSD", 1.1234, 2.5),
+          ("NYC-0002", 100L, "VOD.L", 6L, 99.0, 102.0, false, "steve", "GBPUSD", 1.1234, 3D),
+          ("NYC-0010", null, "VOD.L", 6L, 99.0, 110.0, true, "steve", "GBPUSD", 1.1234, 3D),
+          ("NYC-0011", null, "VOD/L", 6L, 99.0, 109.0, true, "steve", "GBPUSD", 1.1234, 3D),
+          ("NYC-0012", null, "VOD\\L", 6L, 99.0, 105.11, true, "steve", "GBPUSD", 1.1234, 3D),
+          ("NYC-0013", null, "VOD\\L", 6L, 99.0, 122.0, true, "rahúl", "$GBPUSD", 1.1234, 3D)
         )
       }
     }
@@ -144,17 +144,17 @@ class CalculatedColumnMathTest extends AnyFeatureSpec with Matchers with StrictL
       withCalculatedColumns(sampleRows(), tableColumns,
         CalcColumn("quantityExecutedPerTimeUnit", "Double", "=quantity / tradeTime")) {
         Table(
-          ("orderId", "quantity", "ric", "tradeTime", "quantity", "bid", "ask", "onMkt", "trader", "ccyCross", "vwapPerf", "quantityExecutedPerTimeUnit"),
-          ("NYC-0004", null, "AAPL.L", 5L, null, 99.0, 101.5, false, "chris", "GBPUSD", -0.1234, null),
-          ("LDN-0001", 100L, "VOD.L", 2L, 100L, 99.0, 101.5, true, "chris", "GBPUSD", 1.1234, 50D),
-          ("LDN-0002", 100L, "BT.L", 1L, 100L, 99.0, 101.01, true, "steve", "GBPUSD", 1.1234, 100D),
-          ("LDN-0003", null, "VOD.L", 3L, null, 99.0, 101.3, true, "chris", "GBPUSD", 1.1234, null),
-          ("LDN-0008", 100L, "BT.L", 5L, 100L, 99.0, 106.0, true, "chris", "GBPUSD", 1.1234, 20D),
-          ("NYC-0002", 100L, "VOD.L", 6L, 100L, 99.0, 102.0, false, "steve", "GBPUSD", 1.1234, 16.666666666666668),
-          ("NYC-0010", null, "VOD.L", 6L, null, 99.0, 110.0, true, "steve", "GBPUSD", 1.1234, null),
-          ("NYC-0011", null, "VOD/L", 6L, null, 99.0, 109.0, true, "steve", "GBPUSD", 1.1234, null),
-          ("NYC-0012", null, "VOD\\L", 6L, null, 99.0, 105.11, true, "steve", "GBPUSD", 1.1234, null),
-          ("NYC-0013", null, "VOD\\L", 6L, null, 99.0, 122.0, true, "rahúl", "$GBPUSD", 1.1234, null)
+          ("orderId", "quantity", "ric", "tradeTime", "bid", "ask", "onMkt", "trader", "ccyCross", "vwapPerf", "quantityExecutedPerTimeUnit"),
+          ("NYC-0004", null, "AAPL.L", 5L, 99.0, 101.5, false, "chris", "GBPUSD", -0.1234, null),
+          ("LDN-0001", 100L, "VOD.L", 2L, 99.0, 101.5, true, "chris", "GBPUSD", 1.1234, 50D),
+          ("LDN-0002", 100L, "BT.L", 1L, 99.0, 101.01, true, "steve", "GBPUSD", 1.1234, 100D),
+          ("LDN-0003", null, "VOD.L", 3L, 99.0, 101.3, true, "chris", "GBPUSD", 1.1234, null),
+          ("LDN-0008", 100L, "BT.L", 5L, 99.0, 106.0, true, "chris", "GBPUSD", 1.1234, 20D),
+          ("NYC-0002", 100L, "VOD.L", 6L, 99.0, 102.0, false, "steve", "GBPUSD", 1.1234, 16.666666666666668),
+          ("NYC-0010", null, "VOD.L", 6L, 99.0, 110.0, true, "steve", "GBPUSD", 1.1234, null),
+          ("NYC-0011", null, "VOD/L", 6L, 99.0, 109.0, true, "steve", "GBPUSD", 1.1234, null),
+          ("NYC-0012", null, "VOD\\L", 6L, 99.0, 105.11, true, "steve", "GBPUSD", 1.1234, null),
+          ("NYC-0013", null, "VOD\\L", 6L, 99.0, 122.0, true, "rahúl", "$GBPUSD", 1.1234, null)
         )
       }
     }

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -10,27 +10,49 @@ object TableAsserts {
 
   // #1652 TODO review the different types of genericAssert below and unify them
   def genericAssert(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
-    val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType).map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns))).filter(_.isInstanceOf[RowWithData]).map(_.asInstanceOf[RowWithData].data).toArray
+    val arraysOfMaps = updates
+      .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
+      .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
+      .filter(_.isInstanceOf[RowWithData])
+      .map(_.asInstanceOf[RowWithData].data)
+      .toArray
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
   def genericAssertWithoutEmptyRowDataWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
-    val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType).filter(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData).map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns))).map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name)).toArray
+    val arraysOfMaps = updates
+      .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
+      .filter(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData)
+      .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .toArray
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
   def genericAssertWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
-    val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType).map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns))).filter(_.isInstanceOf[RowWithData]).map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name)).toArray
+    val arraysOfMaps = updates
+      .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
+      .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
+      .filter(_.isInstanceOf[RowWithData])
+      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
+      .toArray
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
   def genericAssertWithoutEmptyRowData(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
-    val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType).filter(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData).map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)).asInstanceOf[RowWithData].data).toArray
+    val arraysOfMaps = updates
+      .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
+      .filter(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData)
+      .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)).asInstanceOf[RowWithData].data)
+      .toArray
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
   def genericAssertWithoutCheckingType(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
-    val arraysOfMaps = updates.filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType).map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)).asInstanceOf[RowWithData].data).toArray
+    val arraysOfMaps = updates
+      .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
+      .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)).asInstanceOf[RowWithData].data)
+      .toArray
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -188,6 +188,10 @@ object TableAsserts {
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
         assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+      case exp: TableFor15[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
+        val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
+        val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor11[_, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -8,7 +8,7 @@ import org.scalatest.prop.*
 
 object TableAsserts {
 
-  // #1652 TODO review the different types of genericAssert below and unify them
+  // #1652 TODO review the different types of assertVpEq below and unify them
   def assertVpEq(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     val arraysOfMaps = updates
       .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -3,7 +3,8 @@ package org.finos.vuu.util.table
 import org.finos.toolbox.collection.MapDiffUtils
 import org.finos.toolbox.text.AsciiUtil
 import org.finos.vuu.core.table.{DefaultColumn, EmptyRowData, RowWithData}
-import org.finos.vuu.viewport.{ViewPortRowUpdateType, ViewPortColumns, ViewPortUpdate}
+import org.finos.vuu.viewport.{ViewPortColumns, ViewPortRowUpdateType, ViewPortUpdate}
+import org.scalatest.matchers.should.Matchers.shouldBe
 import org.scalatest.prop.*
 
 object TableAsserts {
@@ -57,6 +58,12 @@ object TableAsserts {
   }
 
   def genericLogic(heading: Array[String], arraysOfMaps: Array[Map[String, Any]], expectationAsMap: Array[Map[Any, Any]]): Unit = {
+    // validate expectationAsMap has all expected columns in each row
+    val isValidTable: Boolean = expectationAsMap.forall { rowMap =>
+      val columnNames = rowMap.keySet.map(_.toString)
+      columnNames.size == heading.length && heading.forall(columnNames.contains)
+    }
+    isValidTable shouldBe true
 
     val actualAsMap = Map("diff" -> arraysOfMaps)
     val expectAsMap = Map("diff" -> expectationAsMap)

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -18,7 +18,7 @@ object TableAsserts {
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
-  def assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
+  def assertVpEqWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     val arraysOfMaps = updates
       .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
@@ -158,19 +158,19 @@ object TableAsserts {
       case exp: TableFor19[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor17[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor16[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor15[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor11[_, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
@@ -186,11 +186,11 @@ object TableAsserts {
       case exp: TableFor7[_, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor6[_, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor5[_, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -9,7 +9,7 @@ import org.scalatest.prop.*
 object TableAsserts {
 
   // #1652 TODO review the different types of genericAssert below and unify them
-  def genericAssert(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
+  def assertVpEq(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     val arraysOfMaps = updates
       .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
@@ -19,7 +19,7 @@ object TableAsserts {
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
-  def genericAssertWithoutEmptyRowDataWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
+  def assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     val arraysOfMaps = updates
       .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .filter(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData)
@@ -29,7 +29,7 @@ object TableAsserts {
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
-  def genericAssertWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
+  def assertVpEqWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     val arraysOfMaps = updates
       .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
@@ -39,7 +39,7 @@ object TableAsserts {
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
-  def genericAssertWithoutEmptyRowData(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
+  def assertVpEqWithoutEmptyRowData(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     val arraysOfMaps = updates
       .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .filter(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData)
@@ -48,7 +48,7 @@ object TableAsserts {
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
-  def genericAssertWithoutCheckingType(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
+  def assertVpEqWithoutCheckingType(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     val arraysOfMaps = updates
       .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)).asInstanceOf[RowWithData].data)
@@ -165,58 +165,58 @@ object TableAsserts {
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
-  @deprecated("#1652 use genericAssert instead")
+  @deprecated("#1652 use assertVpEq with expectationAsMap instead")
   def assertVpEq(updates: Seq[ViewPortUpdate])(expectation: Any): Unit = {
 
     expectation match {
       case exp: TableFor19[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssertWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor17[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssertWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor16[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssertWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor11[_, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssertWithoutEmptyRowData(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutEmptyRowData(updates, headingAsArray, expectationAsMap)
       case exp: TableFor10[_, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssertWithoutEmptyRowData(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutEmptyRowData(updates, headingAsArray, expectationAsMap)
       case exp: TableFor9[_, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssertWithoutCheckingType(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutCheckingType(updates, headingAsArray, expectationAsMap)
       case exp: TableFor7[_, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssertWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor6[_, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssertWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor5[_, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssert(updates, headingAsArray, expectationAsMap)
+        assertVpEq(updates, headingAsArray, expectationAsMap)
       case exp: TableFor4[_, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssert(updates, headingAsArray, expectationAsMap)
+        assertVpEq(updates, headingAsArray, expectationAsMap)
       case exp: TableFor3[_, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssert(updates, headingAsArray, expectationAsMap)
+        assertVpEq(updates, headingAsArray, expectationAsMap)
       case exp: TableFor2[_, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        genericAssert(updates, headingAsArray, expectationAsMap)
+        assertVpEq(updates, headingAsArray, expectationAsMap)
     }
   }
 

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -23,8 +23,8 @@ object TableAsserts {
   def assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     val arraysOfMaps = updates
       .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
-      .filter(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData)
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
+      .filter(_.isInstanceOf[RowWithData])
       .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
       .toArray
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -2,7 +2,7 @@ package org.finos.vuu.util.table
 
 import org.finos.toolbox.collection.MapDiffUtils
 import org.finos.toolbox.text.AsciiUtil
-import org.finos.vuu.core.table.{DefaultColumn, EmptyRowData, RowWithData}
+import org.finos.vuu.core.table.{DefaultColumn, RowWithData}
 import org.finos.vuu.viewport.{ViewPortColumns, ViewPortRowUpdateType, ViewPortUpdate}
 import org.scalatest.matchers.should.Matchers.shouldBe
 import org.scalatest.prop.*

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -28,14 +28,6 @@ object TableAsserts {
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
-  def assertVpEqWithoutCheckingType(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
-    val arraysOfMaps = updates
-      .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
-      .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)).asInstanceOf[RowWithData].data)
-      .toArray
-    genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
-  }
-
   def genericLogic(heading: Array[String], arraysOfMaps: Array[Map[String, Any]], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     // validate expectationAsMap has all expected columns in each row
     val isValidTable: Boolean = expectationAsMap.forall { rowMap =>
@@ -182,7 +174,7 @@ object TableAsserts {
       case exp: TableFor9[_, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutCheckingType(updates, headingAsArray, expectationAsMap)
+        assertVpEq(updates, headingAsArray, expectationAsMap)
       case exp: TableFor7[_, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -8,8 +8,6 @@ import org.scalatest.matchers.should.Matchers.shouldBe
 import org.scalatest.prop.*
 
 object TableAsserts {
-
-  // #1652 TODO review the different types of assertVpEq below and unify them
   def assertVpEq(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
     val arraysOfMaps = updates
       .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
@@ -26,25 +24,6 @@ object TableAsserts {
       .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
       .filter(_.isInstanceOf[RowWithData])
       .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
-      .toArray
-    genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
-  }
-
-  def assertVpEqWithoutTimestamp(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
-    val arraysOfMaps = updates
-      .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
-      .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)))
-      .filter(_.isInstanceOf[RowWithData])
-      .map(rowWithData => rowWithData.asInstanceOf[RowWithData].data.filter((k, _) => k != DefaultColumn.CreatedTime.name && k != DefaultColumn.LastUpdatedTime.name))
-      .toArray
-    genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
-  }
-
-  def assertVpEqWithoutEmptyRowData(updates: Seq[ViewPortUpdate], headingAsArray: Array[String], expectationAsMap: Array[Map[Any, Any]]): Unit = {
-    val arraysOfMaps = updates
-      .filter(vpu => vpu.vpUpdate == ViewPortRowUpdateType)
-      .filter(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)) != EmptyRowData)
-      .map(vpu => vpu.table.pullRowFiltered(vpu.key.key, getColumns(vpu.vp.getColumns)).asInstanceOf[RowWithData].data)
       .toArray
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
@@ -187,19 +166,19 @@ object TableAsserts {
       case exp: TableFor16[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor15[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor11[_, _, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutEmptyRowData(updates, headingAsArray, expectationAsMap)
+        assertVpEq(updates, headingAsArray, expectationAsMap)
       case exp: TableFor10[_, _, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutEmptyRowData(updates, headingAsArray, expectationAsMap)
+        assertVpEq(updates, headingAsArray, expectationAsMap)
       case exp: TableFor9[_, _, _, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
@@ -207,11 +186,11 @@ object TableAsserts {
       case exp: TableFor7[_, _, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor6[_, _, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray
-        assertVpEqWithoutTimestamp(updates, headingAsArray, expectationAsMap)
+        assertVpEqWithoutEmptyRowDataWithoutTimestamp(updates, headingAsArray, expectationAsMap)
       case exp: TableFor5[_, _, _, _, _] =>
         val headingAsArray = exp.heading.productIterator.map(_.toString).toArray
         val expectationAsMap = exp.map(row => exp.heading.productIterator.zip(row.productIterator).map({ case (head, data) => head -> data }).toMap).toArray

--- a/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/table/TableAsserts.scala
@@ -165,6 +165,7 @@ object TableAsserts {
     genericLogic(headingAsArray, arraysOfMaps, expectationAsMap)
   }
 
+  @deprecated("#1652 use genericAssert instead")
   def assertVpEq(updates: Seq[ViewPortUpdate])(expectation: Any): Unit = {
 
     expectation match {

--- a/vuu/src/test/scala/org/finos/vuu/viewport/AmendViewPortToTreeTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/AmendViewPortToTreeTest.scala
@@ -105,8 +105,8 @@ class AmendViewPortToTreeTest extends AnyFeatureSpec with ViewPortSetup {
 
     assertVpEq(filterByVpId(combineQs(viewPort), viewPort)) {
       Table(
-        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_isOpen", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
-        (1, false, "$root|chris", false, false, "chris", 0, "", "chris", "", "", "", "", "", "", "")
+        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
+        (1, false, "$root|chris", false, "chris", 0, "", "chris", "", "", "", "", "", "", "")
       )
     }
 
@@ -126,9 +126,9 @@ class AmendViewPortToTreeTest extends AnyFeatureSpec with ViewPortSetup {
 
     assertVpEq(combinedUpdates3) {
       Table(
-        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_isOpen", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
-        (1, false, "$root|BT.L", false, false, "BT.L", 0, "", "", "BT.L", "", "", "", "", "", ""),
-        (1, false, "$root|VOD.L", false, false, "VOD.L", 0, "", "", "VOD.L", "", "", "", "", "", "")
+        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
+        (1, false, "$root|BT.L", false, "BT.L", 0, "", "", "BT.L", "", "", "", "", "", ""),
+        (1, false, "$root|VOD.L", false, "VOD.L", 0, "", "", "VOD.L", "", "", "", "", "", "")
       )
     }
 
@@ -229,9 +229,9 @@ class AmendViewPortToTreeTest extends AnyFeatureSpec with ViewPortSetup {
 
     assertVpEq(filterByVpId(combineQs(viewPort), viewPort)) {
       Table(
-        ("_depth"  ,"_isOpen" ,"_treeKey","_isLeaf" ,"_isOpen" ,"_caption","_childCount","orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","bid"     ,"ask"     ,"last"    ,"open"    ),
-        (1         ,false     ,"$root|chris",false     ,false     ,"chris"   ,0         ,""        ,"chris"   ,""        ,""        ,""        ,""        ,""        ,""        ,""        ),
-        (1         ,false     ,"$root|steve",false     ,false     ,"steve"   ,0         ,""        ,"steve"   ,""        ,""        ,""        ,""        ,""        ,""        ,""        )
+        ("_depth"  ,"_isOpen" ,"_treeKey","_isLeaf","_caption","_childCount","orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","bid"     ,"ask"     ,"last"    ,"open"    ),
+        (1         ,false     ,"$root|chris",false     ,"chris"   ,0         ,""        ,"chris"   ,""        ,""        ,""        ,""        ,""        ,""        ,""        ),
+        (1         ,false     ,"$root|steve",false     ,"steve"   ,0         ,""        ,"steve"   ,""        ,""        ,""        ,""        ,""        ,""        ,""        )
       )
     }
 
@@ -252,9 +252,9 @@ class AmendViewPortToTreeTest extends AnyFeatureSpec with ViewPortSetup {
 
     assertVpEq(combinedUpdates3) {
       Table(
-        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_isOpen", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
-        (1, false, "$root|BT.L", false, false, "BT.L", 2, "", "", "BT.L", "", "", "", "", "", ""),
-        (1, false, "$root|VOD.L", false, false, "VOD.L", 1, "", "", "VOD.L", "", "", "", "", "", "")
+        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
+        (1, false, "$root|BT.L", false, "BT.L", 2, "", "", "BT.L", "", "", "", "", "", ""),
+        (1, false, "$root|VOD.L", false, "VOD.L", 1, "", "", "VOD.L", "", "", "", "", "", "")
       )
     }
 
@@ -277,13 +277,13 @@ class AmendViewPortToTreeTest extends AnyFeatureSpec with ViewPortSetup {
 
     assertVpEq(combineQs(viewPort3)) {
       Table(
-        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_isOpen", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
-        (1, true, "$root|BT.L", false, true, "BT.L", 2, "", "", "BT.L", "", "", "", "", "", ""),
-        (2, true, "$root|BT.L|chris", false, true, "chris", 2, "", "chris", "BT.L", "", "", "", "", "", ""),
-        (3, false, "$root|BT.L|chris|NYC-0002", true, false, "NYC-0002", 0, "NYC-0002", "chris", "BT.L", 1437728400000L, 100, 499.0, 501.0, 40, null),
-        (3, false, "$root|BT.L|chris|NYC-0003", true, false, "NYC-0003", 0, "NYC-0003", "chris", "BT.L", 1437728400000L, 100, 499.0, 501.0, 40, null),
-        (2, false, "$root|BT.L|steve", false, false, "steve", 2, "", "steve", "BT.L", "", "", "", "", "", ""),
-        (1, false, "$root|VOD.L", false, false, "VOD.L", 1, "", "", "VOD.L", "", "", "", "", "", "")
+        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
+        (1, true, "$root|BT.L", false, "BT.L", 2, "", "", "BT.L", "", "", "", "", "", ""),
+        (2, true, "$root|BT.L|chris", false, "chris", 2, "", "chris", "BT.L", "", "", "", "", "", ""),
+        (3, false, "$root|BT.L|chris|NYC-0002", true, "NYC-0002", 0, "NYC-0002", "chris", "BT.L", 1437728400000L, 100, 499.0, 501.0, 40, null),
+        (3, false, "$root|BT.L|chris|NYC-0003", true, "NYC-0003", 0, "NYC-0003", "chris", "BT.L", 1437728400000L, 100, 499.0, 501.0, 40, null),
+        (2, false, "$root|BT.L|steve", false, "steve", 2, "", "steve", "BT.L", "", "", "", "", "", ""),
+        (1, false, "$root|VOD.L", false, "VOD.L", 1, "", "", "VOD.L", "", "", "", "", "", "")
       )
     }
 
@@ -294,9 +294,9 @@ class AmendViewPortToTreeTest extends AnyFeatureSpec with ViewPortSetup {
 
     assertVpEq(combineQs(viewPort3)) {
       Table(
-        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_isOpen", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
-        (3, false, "$root|BT.L|chris|NYC-0002", true, false, "NYC-0002", 0, "NYC-0002", "chris", "BT.L", 1437728400000L, 100, 500.0, 502.0, 40, null),
-        (3, false, "$root|BT.L|chris|NYC-0003", true, false, "NYC-0003", 0, "NYC-0003", "chris", "BT.L", 1437728400000L, 100, 500.0, 502.0, 40, null)
+        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
+        (3, false, "$root|BT.L|chris|NYC-0002", true, "NYC-0002", 0, "NYC-0002", "chris", "BT.L", 1437728400000L, 100, 500.0, 502.0, 40, null),
+        (3, false, "$root|BT.L|chris|NYC-0003", true, "NYC-0003", 0, "NYC-0003", "chris", "BT.L", 1437728400000L, 100, 500.0, 502.0, 40, null)
       )
     }
   }

--- a/vuu/src/test/scala/org/finos/vuu/viewport/ChangeViewPortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/ChangeViewPortTest.scala
@@ -168,12 +168,12 @@ class ChangeViewPortTest extends AnyFeatureSpec {
       viewPortContainer.runOnce()
       val combinedUpdates = combineQs(viewPort)
 
-      assertVpEq(combinedUpdates) {
-        Table(
-          ("orderId", "trader"),
-          ("NYC-0001", trader),
+      assertVpEq(combinedUpdates,
+        Array("orderId", "trader"),
+        Array(
+          Map("orderId" -> "NYC-0001", "trader" -> trader)
         )
-      }
+      )
 
       val invalidVpColumns = ViewPortColumnCreator.create(orders, List("invalidColumn"))
       val viewPort2 = viewPortContainer.change(RequestId.oneNew(), session, viewPort.id, DefaultRange, invalidVpColumns)

--- a/vuu/src/test/scala/org/finos/vuu/viewport/ChangeViewPortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/ChangeViewPortTest.scala
@@ -186,12 +186,12 @@ class ChangeViewPortTest extends AnyFeatureSpec {
       viewPortContainer.runOnce()
       val combinedUpdates3 = combineQs(viewPort3)
 
-      assertVpEq(combinedUpdates3) {
-        Table(
-          ("orderId", "trader", "ric"),
-          ("NYC-0001", trader, "VOD.L"),
+      assertVpEq(combinedUpdates,
+        Array("orderId", "trader", "ric"),
+        Array(
+          Map("orderId" -> "NYC-0001", "trader" -> trader, "ric" -> "VOD.L")
         )
-      }
+      )
     }
   }
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/ChangeViewPortTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/ChangeViewPortTest.scala
@@ -167,7 +167,7 @@ class ChangeViewPortTest extends AnyFeatureSpec {
       val viewPort = viewPortContainer.create(RequestId.oneNew(), user, session, outQueue, orders, DefaultRange, vpColumns)
       viewPortContainer.runOnce()
       val combinedUpdates = combineQs(viewPort)
-
+      // verify viewport created with expected columns
       assertVpEq(combinedUpdates,
         Array("orderId", "trader"),
         Array(
@@ -179,13 +179,14 @@ class ChangeViewPortTest extends AnyFeatureSpec {
       val viewPort2 = viewPortContainer.change(RequestId.oneNew(), session, viewPort.id, DefaultRange, invalidVpColumns)
       viewPortContainer.runOnce()
       val combinedUpdates2 = combineQs(viewPort2)
-      // TODO #2171 validate exception/reject here
+      // verify invalid column not added to viewport
+      combinedUpdates2.head.vp.getColumns.getColumns.head shouldBe null
 
       val validVpColumns = ViewPortColumnCreator.create(orders, List("orderId", "trader", "ric"))
       val viewPort3 = viewPortContainer.change(RequestId.oneNew(), session, viewPort.id, DefaultRange, validVpColumns)
       viewPortContainer.runOnce()
       val combinedUpdates3 = combineQs(viewPort3)
-
+      // verify viewport columns changed as requested
       assertVpEq(combinedUpdates,
         Array("orderId", "trader", "ric"),
         Array(

--- a/vuu/src/test/scala/org/finos/vuu/viewport/TreeOnOffTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/TreeOnOffTest.scala
@@ -55,15 +55,15 @@ class TreeOnOffTest extends AnyFeatureSpec with Matchers with ViewPortSetup {
 
       assertVpEq(filterByVpId(combineQs(viewPort), viewPort)) {
         Table(
-          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","quantity","bid"     ,"ask"     ,"last"    ,"open"    ,"close"   ),
-          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,100       ,100       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,200       ,200       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,300       ,300       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,400       ,400       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,500       ,500       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0006","steve"   ,"VOD.L"   ,1311544800000L,600       ,600       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0007","steve"   ,"BT.L"    ,1311544800000L,1000      ,1000      ,500.0     ,501.0     ,null      ,null      ,null      ),
-          ("NYC-0008","steve"   ,"BT.L"    ,1311544800000L,500       ,500       ,500.0     ,501.0     ,null      ,null      ,null      )
+          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","bid"     ,"ask"     ,"last"    ,"open"    ,"close"   ),
+          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,100       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,200       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,300       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,400       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,500       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0006","steve"   ,"VOD.L"   ,1311544800000L,600       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0007","steve"   ,"BT.L"    ,1311544800000L,1000      ,500.0     ,501.0     ,null      ,null      ,null      ),
+          ("NYC-0008","steve"   ,"BT.L"    ,1311544800000L,500       ,500.0     ,501.0     ,null      ,null      ,null      )
         )
       }
 
@@ -91,15 +91,15 @@ class TreeOnOffTest extends AnyFeatureSpec with Matchers with ViewPortSetup {
 
       assertVpEq(filterByVpId(combineQs(viewPortNoGb), viewPortNoGb)) {
         Table(
-          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","quantity","bid"     ,"ask"     ,"last"    ,"open"    ,"close"   ),
-          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,100       ,100       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,200       ,200       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,300       ,300       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,400       ,400       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,500       ,500       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0006","steve"   ,"VOD.L"   ,1311544800000L,600       ,600       ,220.0     ,222.0     ,null      ,null      ,null      ),
-          ("NYC-0007","steve"   ,"BT.L"    ,1311544800000L,1000      ,1000      ,500.0     ,501.0     ,null      ,null      ,null      ),
-          ("NYC-0008","steve"   ,"BT.L"    ,1311544800000L,500       ,500       ,500.0     ,501.0     ,null      ,null      ,null      )
+          ("orderId" ,"trader"  ,"ric"     ,"tradeTime","quantity","bid"     ,"ask"     ,"last"    ,"open"    ,"close"   ),
+          ("NYC-0001","chris"   ,"VOD.L"   ,1311544800000L,100       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0002","chris"   ,"VOD.L"   ,1311544800000L,200       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0003","chris"   ,"VOD.L"   ,1311544800000L,300       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0004","chris"   ,"VOD.L"   ,1311544800000L,400       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0005","chris"   ,"VOD.L"   ,1311544800000L,500       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0006","steve"   ,"VOD.L"   ,1311544800000L,600       ,220.0     ,222.0     ,null      ,null      ,null      ),
+          ("NYC-0007","steve"   ,"BT.L"    ,1311544800000L,1000      ,500.0     ,501.0     ,null      ,null      ,null      ),
+          ("NYC-0008","steve"   ,"BT.L"    ,1311544800000L,500       ,500.0     ,501.0     ,null      ,null      ,null      )
         )
       }
 

--- a/vuu/src/test/scala/org/finos/vuu/viewport/performance/CalculateTreeOptimizationTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/performance/CalculateTreeOptimizationTest.scala
@@ -105,8 +105,8 @@ class CalculateTreeOptimizationTest extends AnyFeatureSpec with ViewPortSetup {
 
     assertVpEq(filterByVpId(combineQs(viewPort), viewPort)) {
       Table(
-        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_isOpen", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
-        (1, false, "$root|chris", false, false, "chris", 0, "", "chris", "", "", "", "", "", "", "")
+        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
+        (1, false, "$root|chris", false, "chris", 0, "", "chris", "", "", "", "", "", "", "")
       )
     }
 
@@ -116,8 +116,8 @@ class CalculateTreeOptimizationTest extends AnyFeatureSpec with ViewPortSetup {
 
     assertVpEq(filterByVpId(combineQs(viewPort), viewPort)) {
       Table(
-        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_isOpen", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
-        (1, false, "$root|chris", false, false, "chris", 2, "", "chris", "", "", "", "", "", "", "")
+        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
+        (1, false, "$root|chris", false, "chris", 2, "", "chris", "", "", "", "", "", "", "")
       )
     }
 
@@ -135,9 +135,9 @@ class CalculateTreeOptimizationTest extends AnyFeatureSpec with ViewPortSetup {
 
     assertVpEq(combinedUpdates3) {
       Table(
-        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_isOpen", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
-        (1, false, "$root|BT.L", false, false, "BT.L", 0, "", "", "BT.L", "", "", "", "", "", ""),
-        (1, false, "$root|VOD.L", false, false, "VOD.L", 0, "", "", "VOD.L", "", "", "", "", "", "")
+        ("_depth", "_isOpen", "_treeKey", "_isLeaf", "_caption", "_childCount", "orderId", "trader", "ric", "tradeTime", "quantity", "bid", "ask", "last", "open"),
+        (1, false, "$root|BT.L", false, "BT.L", 0, "", "", "BT.L", "", "", "", "", "", ""),
+        (1, false, "$root|VOD.L", false, "VOD.L", 0, "", "", "VOD.L", "", "", "", "", "", "")
       )
     }
 

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
@@ -114,7 +114,7 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
 
   private def updateTable(tableName: String): Unit = {
     val newDataSource = new FakeDataSource(ListMap(
-      "row3" -> Map("id" -> "row3", "name" -> "New Name", "account" -> 11111)
+      "row3" -> Map("id" -> "row3", "name" -> "Jim Baker", "account" -> 11111)
     ))
     testProviderFactory.getProvider(tableName).update(newDataSource)
   }

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
@@ -121,8 +121,8 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
 
   @tailrec
   private def waitForTableRowUpdate(rowKey: String): RowUpdate = {
-    val tableSizeResponse = vuuClient.awaitForMsgWithBody[TableRowUpdates]
-    tableSizeResponse match {
+    val tableRowUpdates = vuuClient.awaitForMsgWithBody[TableRowUpdates]
+    tableRowUpdates match {
       case None => fail("No table row updates")
       case Some(value) =>
         val row = value.rows.filter(p => p.updateType == Update)

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
@@ -11,7 +11,7 @@ import org.finos.vuu.net.{ChangeViewPortReject, ChangeViewPortRequest, ChangeVie
 import org.finos.vuu.provider.{Provider, ProviderContainer}
 import org.finos.vuu.viewport.{ViewPortRange, ViewPortTable}
 import org.finos.vuu.wsapi.helpers.TestExtension.ModuleFactoryExtension
-import org.finos.vuu.wsapi.helpers.{FakeDataSource, TestProvider, TestProviderFactory}
+import org.finos.vuu.wsapi.helpers.{FakeDataSource, TestProviderFactory}
 
 import scala.annotation.tailrec
 import scala.collection.immutable.ListMap

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
@@ -17,12 +17,13 @@ import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
 
 class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
-  private val tableName = "ChangeVPTest"
+  private val tableName1 = "ChangeVPTest1"
+  private val tableName2 = "ChangeVPTest2"
   private val moduleName = "TableWSApiTest"
   private val testProviderFactory = new TestProviderFactory
 
   Scenario("Add a valid column to viewport") {
-    val viewPortId: String = createViewPort(tableName)
+    val viewPortId: String = createViewPort(tableName1)
 
     When("Request adding a column to viewport")
     val changeVPRequest = ChangeViewPortRequest(
@@ -36,7 +37,7 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
     responseBody.viewPortId shouldEqual viewPortId
 
     When("A new row is added to table")
-    updateTable(tableName)
+    updateTable(tableName1)
 
     Then("Viewport should have 3 columns now")
     val row3 = waitForTableRowUpdate("row3")
@@ -44,7 +45,7 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
   }
 
   Scenario("Add a invalid column to viewport") {
-    val viewPortId: String = createViewPort(tableName)
+    val viewPortId: String = createViewPort(tableName2)
 
     When("Request adding a column to viewport")
     val changeVPRequest = ChangeViewPortRequest(
@@ -58,15 +59,15 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
     responseBody.viewPortId shouldEqual viewPortId
 
     When("A new row is added to table")
-    updateTable(tableName)
+    updateTable(tableName2)
 
     Then("Viewport still has 2 columns")
     val row3 = waitForTableRowUpdate("row3")
     row3.data.length shouldEqual 2
   }
 
-  protected def defineModuleWithTestTables(): ViewServerModule = {
-    val tableDef = TableDef(
+  private def createTableDef(tableName: String): TableDef = {
+    TableDef(
       name = tableName,
       keyField = "id",
       columns =
@@ -76,7 +77,9 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
           .addInt("account")
           .build()
     )
+  }
 
+  protected def defineModuleWithTestTables(): ViewServerModule = {
     val viewPortDefFactory = (_: DataTable, _: Provider, _: ProviderContainer, tableContainer: TableContainer) =>
       ViewPortDef(
         columns =
@@ -95,7 +98,8 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
     val providerFactory = (table: DataTable, _: AbstractVuuServer) => testProviderFactory.create(table, dataSource)
 
     ModuleFactory.withNamespace(moduleName)
-      .addTableForTest(tableDef, viewPortDefFactory, providerFactory)
+      .addTableForTest(createTableDef(tableName1), viewPortDefFactory, providerFactory)
+      .addTableForTest(createTableDef(tableName2), viewPortDefFactory, providerFactory)
       .asModule()
   }
 

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
@@ -41,7 +41,7 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
       columns = Array("id", "name", "unknown"))
     val requestId = vuuClient.send(sessionId, changeVPRequest)
 
-    Then("viewport is updated")
+    Then("Change viewport request is rejected")
     val changeVPResponse = vuuClient.awaitForResponse(requestId)
     val responseBody = assertBodyIsInstanceOf[ChangeViewPortReject](changeVPResponse)
     responseBody.viewPortId shouldEqual viewPortId
@@ -89,5 +89,4 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
     waitForData(2)
     viewPortId
   }
-
 }

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
@@ -4,38 +4,49 @@ import org.finos.vuu.api.{ColumnBuilder, TableDef, ViewPortDef}
 import org.finos.vuu.core.AbstractVuuServer
 import org.finos.vuu.core.module.{ModuleFactory, ViewServerModule}
 import org.finos.vuu.core.table.{DataTable, TableContainer}
+import org.finos.vuu.net.row.RowUpdate
+import org.finos.vuu.net.row.RowUpdateType.Update
 import org.finos.vuu.net.rpc.DefaultRpcHandler
-import org.finos.vuu.net.{ChangeViewPortReject, ChangeViewPortRequest, ChangeViewPortSuccess, CreateViewPortRequest, CreateViewPortSuccess}
+import org.finos.vuu.net.{ChangeViewPortReject, ChangeViewPortRequest, ChangeViewPortSuccess, CreateViewPortRequest, CreateViewPortSuccess, TableRowUpdates}
 import org.finos.vuu.provider.{Provider, ProviderContainer}
 import org.finos.vuu.viewport.{ViewPortRange, ViewPortTable}
 import org.finos.vuu.wsapi.helpers.TestExtension.ModuleFactoryExtension
-import org.finos.vuu.wsapi.helpers.{FakeDataSource, TestProvider}
+import org.finos.vuu.wsapi.helpers.{FakeDataSource, TestProvider, TestProviderFactory}
 
+import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
 
 class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
   private val tableName = "ChangeVPTest"
   private val moduleName = "TableWSApiTest"
+  private val testProviderFactory = new TestProviderFactory
 
   Scenario("Add a valid column to viewport") {
     val viewPortId: String = createViewPort(tableName)
 
-    When("request adding a column to viewport")
+    When("Request adding a column to viewport")
     val changeVPRequest = ChangeViewPortRequest(
       viewPortId = viewPortId,
       columns = Array("id", "name", "account"))
     val requestId = vuuClient.send(sessionId, changeVPRequest)
 
-    Then("viewport is updated")
+    Then("Viewport is updated successfully")
     val changeVPResponse = vuuClient.awaitForResponse(requestId)
     val responseBody = assertBodyIsInstanceOf[ChangeViewPortSuccess](changeVPResponse)
     responseBody.viewPortId shouldEqual viewPortId
+
+    When("A new row is added to table")
+    updateTable(tableName)
+
+    Then("Viewport should have 3 columns now")
+    val row3 = waitForTableRowUpdate("row3")
+    row3.data.length shouldEqual 3
   }
 
   Scenario("Add a invalid column to viewport") {
     val viewPortId: String = createViewPort(tableName)
 
-    When("request adding a column to viewport")
+    When("Request adding a column to viewport")
     val changeVPRequest = ChangeViewPortRequest(
       viewPortId = viewPortId,
       columns = Array("id", "name", "unknown"))
@@ -45,6 +56,13 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
     val changeVPResponse = vuuClient.awaitForResponse(requestId)
     val responseBody = assertBodyIsInstanceOf[ChangeViewPortReject](changeVPResponse)
     responseBody.viewPortId shouldEqual viewPortId
+
+    When("A new row is added to table")
+    updateTable(tableName)
+
+    Then("Viewport still has 2 columns")
+    val row3 = waitForTableRowUpdate("row3")
+    row3.data.length shouldEqual 2
   }
 
   protected def defineModuleWithTestTables(): ViewServerModule = {
@@ -74,7 +92,7 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
       "row2" -> Map("id" -> "row2", "name" -> "Tom Sawyer", "account" -> 45321)
     ))
 
-    val providerFactory = (table: DataTable, _: AbstractVuuServer) => new TestProvider(table, dataSource)
+    val providerFactory = (table: DataTable, _: AbstractVuuServer) => testProviderFactory.create(table, dataSource)
 
     ModuleFactory.withNamespace(moduleName)
       .addTableForTest(tableDef, viewPortDefFactory, providerFactory)
@@ -82,11 +100,34 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
   }
 
   private def createViewPort(tableName: String): String = {
-    val createViewPortRequest = CreateViewPortRequest(ViewPortTable(tableName, moduleName), ViewPortRange(0, 10), Array("*"))
+    val createViewPortRequest = CreateViewPortRequest(ViewPortTable(tableName, moduleName), ViewPortRange(0, 10), Array("id", "account"))
     vuuClient.send(sessionId, createViewPortRequest)
     val viewPortCreateResponse = vuuClient.awaitForMsgWithBody[CreateViewPortSuccess]
     val viewPortId = viewPortCreateResponse.get.viewPortId
     waitForData(2)
     viewPortId
+  }
+
+  private def updateTable(tableName: String): Unit = {
+    val newDataSource = new FakeDataSource(ListMap(
+      "row3" -> Map("id" -> "row3", "name" -> "New Name", "account" -> 11111)
+    ))
+    testProviderFactory.getProvider(tableName).update(newDataSource)
+  }
+
+  @tailrec
+  private def waitForTableRowUpdate(rowKey: String): RowUpdate = {
+    val tableSizeResponse = vuuClient.awaitForMsgWithBody[TableRowUpdates]
+    tableSizeResponse match {
+      case None => fail("No table row updates")
+      case Some(value) =>
+        val row = value.rows.filter(p => p.updateType == Update)
+          .filter(row => row.rowKey == rowKey)
+        if (row.isEmpty) {
+          waitForTableRowUpdate(rowKey)
+        } else {
+          row.head
+        }
+    }
   }
 }

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
@@ -1,0 +1,93 @@
+package org.finos.vuu.wsapi
+
+import org.finos.vuu.api.{ColumnBuilder, TableDef, ViewPortDef}
+import org.finos.vuu.core.AbstractVuuServer
+import org.finos.vuu.core.module.{ModuleFactory, ViewServerModule}
+import org.finos.vuu.core.table.{DataTable, TableContainer}
+import org.finos.vuu.net.rpc.DefaultRpcHandler
+import org.finos.vuu.net.{ChangeViewPortReject, ChangeViewPortRequest, ChangeViewPortSuccess, CreateViewPortRequest, CreateViewPortSuccess}
+import org.finos.vuu.provider.{Provider, ProviderContainer}
+import org.finos.vuu.viewport.{ViewPortRange, ViewPortTable}
+import org.finos.vuu.wsapi.helpers.TestExtension.ModuleFactoryExtension
+import org.finos.vuu.wsapi.helpers.{FakeDataSource, TestProvider}
+
+import scala.collection.immutable.ListMap
+
+class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
+  private val tableName = "ChangeVPTest"
+  private val moduleName = "TableWSApiTest"
+
+  Scenario("Add a valid column to viewport") {
+    val viewPortId: String = createViewPort(tableName)
+
+    When("request adding a column to viewport")
+    val changeVPRequest = ChangeViewPortRequest(
+      viewPortId = viewPortId,
+      columns = Array("id", "name", "account"))
+    val requestId = vuuClient.send(sessionId, changeVPRequest)
+
+    Then("viewport is updated")
+    val changeVPResponse = vuuClient.awaitForResponse(requestId)
+    val responseBody = assertBodyIsInstanceOf[ChangeViewPortSuccess](changeVPResponse)
+    responseBody.viewPortId shouldEqual viewPortId
+  }
+
+  Scenario("Add a invalid column to viewport") {
+    val viewPortId: String = createViewPort(tableName)
+
+    When("request adding a column to viewport")
+    val changeVPRequest = ChangeViewPortRequest(
+      viewPortId = viewPortId,
+      columns = Array("id", "name", "unknown"))
+    val requestId = vuuClient.send(sessionId, changeVPRequest)
+
+    Then("viewport is updated")
+    val changeVPResponse = vuuClient.awaitForResponse(requestId)
+    val responseBody = assertBodyIsInstanceOf[ChangeViewPortReject](changeVPResponse)
+    responseBody.viewPortId shouldEqual viewPortId
+  }
+
+  protected def defineModuleWithTestTables(): ViewServerModule = {
+    val tableDef = TableDef(
+      name = tableName,
+      keyField = "id",
+      columns =
+        new ColumnBuilder()
+          .addString("id")
+          .addString("name")
+          .addInt("account")
+          .build()
+    )
+
+    val viewPortDefFactory = (_: DataTable, _: Provider, _: ProviderContainer, tableContainer: TableContainer) =>
+      ViewPortDef(
+        columns =
+          new ColumnBuilder()
+            .addString("id")
+            .addInt("account")
+            .build(),
+        service = new DefaultRpcHandler()(tableContainer)
+      )
+
+    val dataSource = new FakeDataSource(ListMap(
+      "row1" -> Map("id" -> "row1", "name" -> "Becky Thatcher", "account" -> 12355),
+      "row2" -> Map("id" -> "row2", "name" -> "Tom Sawyer", "account" -> 45321)
+    ))
+
+    val providerFactory = (table: DataTable, _: AbstractVuuServer) => new TestProvider(table, dataSource)
+
+    ModuleFactory.withNamespace(moduleName)
+      .addTableForTest(tableDef, viewPortDefFactory, providerFactory)
+      .asModule()
+  }
+
+  private def createViewPort(tableName: String): String = {
+    val createViewPortRequest = CreateViewPortRequest(ViewPortTable(tableName, moduleName), ViewPortRange(0, 10), Array("*"))
+    vuuClient.send(sessionId, createViewPortRequest)
+    val viewPortCreateResponse = vuuClient.awaitForMsgWithBody[CreateViewPortSuccess]
+    val viewPortId = viewPortCreateResponse.get.viewPortId
+    waitForData(2)
+    viewPortId
+  }
+
+}

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/ChangeViewPortWSApiTest.scala
@@ -125,12 +125,14 @@ class ChangeViewPortWSApiTest extends WebSocketApiTestBase {
     tableRowUpdates match {
       case None => fail("No table row updates")
       case Some(value) =>
-        val row = value.rows.filter(p => p.updateType == Update)
-          .filter(row => row.rowKey == rowKey)
-        if (row.isEmpty) {
+        val row = value.rows
+          .filter(p => p.updateType == Update)
+          .find(row => row.rowKey == rowKey)
+          .orNull
+        if (row == null) {
           waitForTableRowUpdate(rowKey)
         } else {
-          row.head
+          row
         }
     }
   }


### PR DESCRIPTION
#1652 add a validation in TableAsserts to make sure expectationAsMap is a valid table of data and fix tests accordingly
closes #2171 added tests to verify view port change request is rejected if a column is unknown