### PR TITLE
Update CH plugin to expect DateTime for EpochTimestamp columns

### DIFF
--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataMapper.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataMapper.scala
@@ -4,7 +4,9 @@ import com.clickhouse.client.api.query.GenericRecord
 import com.typesafe.scalalogging.StrictLogging
 import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{Column, DataType, RowWithData}
+import org.finos.vuu.plugin.clickhouse.provider.data.ClickHouseRowDataMapper.EPOCH_NAN_SENTINEL
 
+import java.time.ZonedDateTime
 import scala.collection.mutable
 
 trait ClickHouseRowDataMapper {
@@ -17,6 +19,8 @@ object ClickHouseRowDataMapper {
 
   val INT_NAN_SENTINEL: Int = Int.MinValue
   val LONG_NAN_SENTINEL: Long = Long.MinValue
+  val DOUBLE_NAN_SENTINEL: Double = java.lang.Double.NaN
+  val EPOCH_NAN_SENTINEL: EpochTimestamp = EpochTimestamp(0)
 
   def apply(): ClickHouseRowDataMapper = ClickHouseRowDataMapperImpl()
 
@@ -70,9 +74,12 @@ private case class ClickHouseRowDataMapperImpl() extends ClickHouseRowDataMapper
             }
 
           case DataType.EpochTimestampType =>
-            val ts: Long = v1.getLong(name)
-            if (ts != ClickHouseRowDataMapper.LONG_NAN_SENTINEL) {
-              builder.put(name, EpochTimestamp(ts))
+            val ts: ZonedDateTime = v1.getZonedDateTime(name)
+            if (ts != null) {
+              val epochTimestamp = EpochTimestamp(ts)
+              if (epochTimestamp != EPOCH_NAN_SENTINEL) {
+                builder.put(name, epochTimestamp)
+              }
             }
 
           case DataType.ScaledDecimal2Type =>

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/ClickHouseVirtualizedDataProviderTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/ClickHouseVirtualizedDataProviderTest.scala
@@ -105,8 +105,8 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         |  price Int64,
         |  side String,
         |  trader String,
-        |  vuuCreatedTimestamp Int64,
-        |  vuuUpdatedTimestamp Int64,
+        |  vuuCreatedTimestamp DateTime64(3, 'UTC'),
+        |  vuuUpdatedTimestamp DateTime64(3, 'UTC'),
         |  vuuMsg String
         |) ENGINE = MergeTree() ORDER BY orderId
         |""".stripMargin

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataMapperTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataMapperTest.scala
@@ -9,6 +9,8 @@ import org.scalatest.GivenWhenThen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
 class ClickHouseRowDataMapperTest extends AnyFlatSpec with Matchers with MockFactory with GivenWhenThen {
   behavior of "ClickHouseRowDataMapper (per-type tests)"
 
@@ -174,12 +176,56 @@ class ClickHouseRowDataMapperTest extends AnyFlatSpec with Matchers with MockFac
     row2.data.contains("charCol") shouldBe false
   }
 
-  it should "map epoch and scaled decimals from longs and omit sentinels" in {
+  it should "map EpochTimestamp only when non 0 zoned datetime provided" in {
+    Given("a GenericRecord with char column")
+    val v1 = mock[GenericRecord]
+
+    val columns = List(col("epochCol", DataType.EpochTimestampType))
+
+    (v1.hasValue(_: String)).expects("epochCol").returning(true)
+    (v1.getZonedDateTime(_: String)).expects("epochCol").returning(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1), ZoneId.of("UTC")))
+    (v1.getString(_: String)).expects("pk").returning("key-6")
+
+    When("we map the record with single-character string")
+    val mapper = ClickHouseRowDataMapper()
+    val row = mapper.mapRowData(v1, "pk", columns)
+
+    Then("the char is present")
+    row.key shouldBe "key-6"
+    row.data("epochCol") shouldBe EpochTimestamp(1)
+
+    Given("the GenericRecord returns null")
+    val v2 = mock[GenericRecord]
+    (v2.hasValue(_: String)).expects("epochCol").returning(true)
+    (v2.getZonedDateTime(_: String)).expects("epochCol").returning(null)
+    (v2.getString(_: String)).expects("pk").returning("key-7")
+
+    When("we map the record again")
+    val row2 = mapper.mapRowData(v2, "pk", columns)
+
+    Then("the char is omitted")
+    row2.key shouldBe "key-7"
+    row2.data.contains("epochCol") shouldBe false
+
+    Given("the GenericRecord returns Unix Epoch 0")
+    val v3 = mock[GenericRecord]
+    (v3.hasValue(_: String)).expects("epochCol").returning(true)
+    (v3.getZonedDateTime(_: String)).expects("epochCol").returning(ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+    (v3.getString(_: String)).expects("pk").returning("key-8")
+
+    When("we map the record again")
+    val row3 = mapper.mapRowData(v3, "pk", columns)
+
+    Then("the char is omitted")
+    row3.key shouldBe "key-8"
+    row3.data.contains("epochCol") shouldBe false
+  }
+
+  it should "map scaled decimals from longs and omit sentinels" in {
     Given("a GenericRecord with epoch and scaled decimal columns")
     val v1 = mock[GenericRecord]
 
     val columns = List(
-      col("epochCol", DataType.EpochTimestampType),
       col("dec2Col", DataType.ScaledDecimal2Type),
       col("dec4Col", DataType.ScaledDecimal4Type),
       col("dec6Col", DataType.ScaledDecimal6Type),
@@ -192,7 +238,6 @@ class ClickHouseRowDataMapperTest extends AnyFlatSpec with Matchers with MockFac
     }
     
 
-    (v1.getLong(_:String)).expects("epochCol").returning(1600000000000L)
     (v1.getLong(_:String)).expects("dec2Col").returning(250L)
     (v1.getLong(_:String)).expects("dec4Col").returning(25000L)
     (v1.getLong(_:String)).expects("dec6Col").returning(2500000L)
@@ -206,7 +251,6 @@ class ClickHouseRowDataMapperTest extends AnyFlatSpec with Matchers with MockFac
 
     Then("epoch and scaled decimals are converted and sentinel omitted")
     row.key shouldBe "key-8"
-    row.data("epochCol") shouldBe EpochTimestamp(1600000000000L)
     row.data("dec2Col") shouldBe ScaledDecimal2(250L)
     row.data("dec4Col") shouldBe ScaledDecimal4(25000L)
     row.data("dec6Col") shouldBe ScaledDecimal6(2500000L)

--- a/vuu/src/main/scala/org/finos/vuu/core/table/datatype/EpochTimestamp.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/datatype/EpochTimestamp.scala
@@ -2,20 +2,24 @@ package org.finos.vuu.core.table.datatype
 
 import org.finos.toolbox.time.Clock
 
-import java.time.Instant
+import java.time.{Instant, ZonedDateTime}
 
 object EpochTimestamp {
 
   def apply(): EpochTimestamp = {
     EpochTimestamp(System.currentTimeMillis())
   }
-  
+
   def apply(clock: Clock): EpochTimestamp = {
     EpochTimestamp(clock.now())
   }
 
   def apply(instant: Instant): EpochTimestamp = {
     EpochTimestamp(instant.toEpochMilli)
+  }
+
+  def apply(zdt: ZonedDateTime): EpochTimestamp = {
+    EpochTimestamp((zdt.toEpochSecond * 1_000) + (zdt.getNano / 1_000_000))
   }
 
 }

--- a/vuu/src/test/scala/org/finos/vuu/core/table/datatype/EpochTimestampTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/datatype/EpochTimestampTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 import java.lang.System.currentTimeMillis
-import java.time.Instant
+import java.time.{Instant, ZoneId, ZonedDateTime}
 
 class EpochTimestampTest extends AnyFeatureSpec with Matchers with TableDrivenPropertyChecks {
 
@@ -42,6 +42,15 @@ class EpochTimestampTest extends AnyFeatureSpec with Matchers with TableDrivenPr
 
       epochTimestamp.millis shouldEqual millis
 
+    }
+
+    Scenario("Check creation via ZonedDateTime") {
+      val millis = currentTimeMillis
+      val zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.of("UTC"))
+
+      val epochTimestamp = EpochTimestamp(zonedDateTime)
+
+      epochTimestamp.millis shouldEqual millis
     }
 
   }


### PR DESCRIPTION
Clickhouse supports better date querying if we use a proper DateTime type rather than just Longs.