### PR TITLE
bug: useEditableTable prevent double call to ensEditSession on cancel

### DIFF
--- a/vuu-ui/packages/vuu-utils/src/data-editing/EditSession.tsx
+++ b/vuu-ui/packages/vuu-utils/src/data-editing/EditSession.tsx
@@ -38,6 +38,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   #sourceTableDataSource?: EditApi;
   #sessionDataSource?: EditApi;
   #inEditMode = false;
+  #endEditModePending = false;
 
   constructor(dataSource: EditApi) {
     super();
@@ -80,6 +81,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     this.#rowEdits.clear();
     this.#editCount = 0;
     this.#inEditMode = false;
+    this.#endEditModePending = false;
   }
 
   async begin(editSessionMode?: EditSessionMode) {
@@ -103,10 +105,12 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   async end(saveChanges = false, force = false) {
     try {
       if (this.#inEditMode) {
+        this.#endEditModePending = true;
         await this.dataSource?.endEditSession?.(saveChanges, force);
         this.clear();
       }
     } catch (e) {
+      this.#endEditModePending = false;
       if (e instanceof StaleUpdateError) {
         this.emit("editState", "stale");
       } else {
@@ -116,7 +120,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   }
 
   get inEditMode() {
-    return this.#inEditMode;
+    return this.#inEditMode === true && this.#endEditModePending === false;
   }
 
   get editState(): EditState {

--- a/vuu-ui/packages/vuu-utils/src/data-editing/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-utils/src/data-editing/useEditableTable.ts
@@ -108,7 +108,7 @@ export const useEditableTable = ({
         // });
         onCancel();
       }
-    } else {
+    } else if (editSession.inEditMode) {
       await editSession.end();
     }
   }, [editSession, editSessionMode, isEditMode, onCancel]);


### PR DESCRIPTION
a bug in useEditableTable causes two calls to be made to EditSession end, second call arrives whilst first call is still in flight, so editSession status is still editing. SessionDataSOurce has been detached  so seconf call is routed to source table datasource