### PR TITLE
#2169 copy data to session table when handling CreateSessionTableRpc

### DIFF
--- a/benchmark/src/main/java/org/finos/vuu/benchmark/BenchmarkHelper.java
+++ b/benchmark/src/main/java/org/finos/vuu/benchmark/BenchmarkHelper.java
@@ -5,6 +5,7 @@ import org.finos.toolbox.jmx.MetricsProviderImpl;
 import org.finos.toolbox.lifecycle.LifecycleContainer;
 import org.finos.toolbox.time.Clock;
 import org.finos.toolbox.time.DefaultClock;
+import org.finos.vuu.core.VuuRpcOptions;
 import org.finos.vuu.core.filter.type.AllowAllPermissionFilter$;
 import org.finos.vuu.core.table.Column;
 import org.finos.vuu.core.table.DataTable;
@@ -36,7 +37,7 @@ public class BenchmarkHelper {
     private final LifecycleContainer lifecycleContainer = new LifecycleContainer(clock);
     private final MetricsProvider metricsProvider = new MetricsProviderImpl();
     private final JoinTableProvider joinProvider = JoinTableProviderImpl.apply(lifecycleContainer);
-    private final TableContainer tableContainer = new TableContainer(joinProvider, metricsProvider, clock);
+    private final TableContainer tableContainer = new TableContainer(joinProvider, VuuRpcOptions.apply(), metricsProvider, clock);
 
     public BenchmarkHelper() {
         tableContainer.createTable(CURRENCIES);

--- a/example/main-java/src/main/java/org/finos/vuu/VuuExampleMain.java
+++ b/example/main-java/src/main/java/org/finos/vuu/VuuExampleMain.java
@@ -5,13 +5,7 @@ import org.finos.toolbox.jmx.MetricsProviderImpl;
 import org.finos.toolbox.lifecycle.LifecycleContainer;
 import org.finos.toolbox.time.Clock;
 import org.finos.toolbox.time.DefaultClock;
-import org.finos.vuu.core.VuuClientConnectionOptions;
-import org.finos.vuu.core.VuuJoinTableProviderOptions;
-import org.finos.vuu.core.VuuSecurityOptions;
-import org.finos.vuu.core.VuuServer;
-import org.finos.vuu.core.VuuServerConfig;
-import org.finos.vuu.core.VuuThreadingOptions;
-import org.finos.vuu.core.VuuWebSocketOptions;
+import org.finos.vuu.core.*;
 import org.finos.vuu.core.module.TableDefContainer;
 import org.finos.vuu.core.module.ViewServerModule;
 import org.finos.vuu.core.module.authn.AuthNModule;
@@ -70,13 +64,14 @@ public class VuuExampleMain {
                 VuuHttp2ServerFactory.apply(VuuHttp2ServerOptions.apply()
                         .withWebRoot(new AbsolutePathWebRoot(webRoot, true))
                         .withSsl(new VuuSSLByCertAndKey(certPath, keyPath, Option.empty(), VuuSSLCipherSuiteOptions.apply()))
-                        .withPort(8443))
-                ).withModule(PriceModule.apply(clock, lifecycle, tableDefContainer))
-         .withModule(SimulationModule.apply(clock, lifecycle, tableDefContainer))
-         .withModule(MetricsModule.apply(clock, lifecycle, metrics, tableDefContainer))
-         .withModule(AuthNModule.apply(loginTokenService, Option.empty(), clock, lifecycle, tableDefContainer))
-         //the modules above are scala, the modules below are java...
-         .withModule(new JavaExampleModule().create(tableDefContainer, clock))       ;
+                        .withPort(8443)),
+                VuuRpcOptions.apply())
+                .withModule(PriceModule.apply(clock, lifecycle, tableDefContainer))
+                .withModule(SimulationModule.apply(clock, lifecycle, tableDefContainer))
+                .withModule(MetricsModule.apply(clock, lifecycle, metrics, tableDefContainer))
+                .withModule(AuthNModule.apply(loginTokenService, Option.empty(), clock, lifecycle, tableDefContainer))
+                //the modules above are scala, the modules below are java...
+                .withModule(new JavaExampleModule().create(tableDefContainer, clock));
 
         final VuuServer vuuServer = new VuuServer(config, lifecycle, clock, metrics);
 

--- a/example/main-java/src/main/java/org/finos/vuu/VuuExampleMain.java
+++ b/example/main-java/src/main/java/org/finos/vuu/VuuExampleMain.java
@@ -59,14 +59,14 @@ public class VuuExampleMain {
                 VuuClientConnectionOptions.apply()
                         .withHeartbeatEnabled(),
                 VuuJoinTableProviderOptions.apply(),
+                VuuRpcOptions.apply(),
                 new scala.collection.mutable.ListBuffer<ViewServerModule>().toList(),
                 new scala.collection.mutable.ListBuffer<Plugin>().toList(),
                 VuuHttp2ServerFactory.apply(VuuHttp2ServerOptions.apply()
                         .withWebRoot(new AbsolutePathWebRoot(webRoot, true))
                         .withSsl(new VuuSSLByCertAndKey(certPath, keyPath, Option.empty(), VuuSSLCipherSuiteOptions.apply()))
-                        .withPort(8443)),
-                VuuRpcOptions.apply())
-                .withModule(PriceModule.apply(clock, lifecycle, tableDefContainer))
+                        .withPort(8443))
+        ).withModule(PriceModule.apply(clock, lifecycle, tableDefContainer))
                 .withModule(SimulationModule.apply(clock, lifecycle, tableDefContainer))
                 .withModule(MetricsModule.apply(clock, lifecycle, metrics, tableDefContainer))
                 .withModule(AuthNModule.apply(loginTokenService, Option.empty(), clock, lifecycle, tableDefContainer))

--- a/example/permission/src/test/scala/org/finos/vuu/core/module/authn/AuthNServerTest.scala
+++ b/example/permission/src/test/scala/org/finos/vuu/core/module/authn/AuthNServerTest.scala
@@ -10,7 +10,7 @@ import org.finos.toolbox.thread.Async
 import org.finos.toolbox.time.{Clock, DefaultClock}
 import org.finos.vuu.core.auths.VuuUser
 import org.finos.vuu.core.module.TableDefContainer
-import org.finos.vuu.core.{VuuClientConnectionOptions, VuuJoinTableProviderOptions, VuuSecurityOptions, VuuServer, VuuServerConfig, VuuThreadingOptions, VuuWebSocketOptions}
+import org.finos.vuu.core.{VuuClientConnectionOptions, VuuJoinTableProviderOptions, VuuRpcOptions, VuuSecurityOptions, VuuServer, VuuServerConfig, VuuThreadingOptions, VuuWebSocketOptions}
 import org.finos.vuu.http2.server.VuuHttp2ServerFactory
 import org.finos.vuu.http2.server.config.VuuHttp2ServerOptions
 import org.finos.vuu.net.auth.LoginTokenService
@@ -49,6 +49,7 @@ class AuthNServerTest extends AnyFeatureSpec with Matchers with StrictLogging {
         VuuThreadingOptions(),
         VuuClientConnectionOptions(),
         VuuJoinTableProviderOptions(),
+        VuuRpcOptions(),
         List(AuthNModule(loginTokenService, Option(Map(username -> password)))),
         List.empty,
         VuuHttp2ServerFactory(VuuHttp2ServerOptions()

--- a/vuu-java/src/test/java/org/finos/vuu/net/rpc/RpcMethodHandlerTest.java
+++ b/vuu-java/src/test/java/org/finos/vuu/net/rpc/RpcMethodHandlerTest.java
@@ -6,6 +6,7 @@ import org.finos.toolbox.jmx.MetricsProviderImpl;
 import org.finos.toolbox.lifecycle.LifecycleContainer;
 import org.finos.toolbox.time.Clock;
 import org.finos.toolbox.time.DefaultClock;
+import org.finos.vuu.core.VuuRpcOptions;
 import org.finos.vuu.core.table.TableContainer;
 import org.finos.vuu.provider.JoinTableProviderImpl;
 import org.finos.vuu.util.ScalaCollectionConverter;
@@ -23,7 +24,7 @@ public class RpcMethodHandlerTest {
         Clock clock = new DefaultClock();
         LifecycleContainer lifecycleContainer = new LifecycleContainer(clock);
         MetricsProvider metricsProvider = new MetricsProviderImpl();
-        TableContainer tableContainer = new TableContainer(JoinTableProviderImpl.apply(lifecycleContainer), metricsProvider, clock);
+        TableContainer tableContainer = new TableContainer(JoinTableProviderImpl.apply(lifecycleContainer), VuuRpcOptions.apply(), metricsProvider, clock);
         final DefaultRpcHandler defaultRpcHandler = new DefaultRpcHandler(tableContainer);
         defaultRpcHandler.registerRpc("helloWorld", rpcService::rpcFunction);
 

--- a/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/CoreServerApiHandler.scala
@@ -150,8 +150,9 @@ class CoreServerApiHandler(val viewPortContainer: ViewPortContainer,
       val viewPortDef = viewPortContainer.getViewPortDefinition(table)
       val columns = viewPortDef.columns.sortBy(_.index)
       val columnNames = columns.map(_.name)
+      val editableColumns = columns.filter(c => table.getTableDef.columnForName(c.name).isEditable).map(_.name)
       val dataTypes = columns.map(col => DataType.asString(col.dataType))
-      GetTableMetaResponse(msg.table, columnNames, dataTypes, table.getTableDef.keyField)
+      GetTableMetaResponse(msg.table, columnNames, dataTypes, table.getTableDef.keyField, editableColumns)
     } else {
       throw new RuntimeException(s"Failed to find table ${msg.table.table} in module ${msg.table.module}. (${ctx.requestId})")
     }

--- a/vuu/src/main/scala/org/finos/vuu/core/VuuServer.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/VuuServer.scala
@@ -42,7 +42,7 @@ class VuuServer(config: VuuServerConfig)
 
   final val joinProvider: JoinTableProvider = JoinTableProviderImpl(config.joinProvider)
 
-  final val tableContainer = new TableContainer(joinProvider)
+  final val tableContainer = new TableContainer(joinProvider, config.rpcOptions)
 
   final val providerContainer = new ProviderContainer(joinProvider)
   lifecycle(this).dependsOn(providerContainer)

--- a/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
@@ -8,10 +8,11 @@ import org.finos.vuu.plugin.Plugin
 
 trait VuuSecurityOptions {
   def loginTokenService: LoginTokenService
+
   def withLoginTokenService(tokenValidator: LoginTokenService): VuuSecurityOptions
 }
 
-object VuuSecurityOptions{
+object VuuSecurityOptions {
   def apply(): VuuSecurityOptions = {
     VuuSecurityOptionsImpl(LoginTokenService())
   }
@@ -39,106 +40,144 @@ object VuuClientConnectionOptions {
 }
 
 object VuuJoinTableProviderOptions {
-  def apply() : VuuJoinTableProviderOptions = {
+  def apply(): VuuJoinTableProviderOptions = {
     VuuJoinProviderOptionsImpl.apply(batchSize = 16_384, maxQueueSize = 32_768)
   }
 }
 
 object VuuRpcOptions {
-  def apply() : VuuRpcOptions = {
+  def apply(): VuuRpcOptions = {
     VuuRpcOptionsImpl.apply(maxCopySize = 10_000)
   }
 }
 
 trait VuuWebSocketOptions {
   def wsPort: Int
+
   def uri: String
+
   def bindAddress: String
+
   def sslOptions: VuuSSLOptions
+
   def compressionEnabled: Boolean
+
   def nativeTransportEnabled: Boolean
+
   def maxSessionsPerUser: Int
+
   def withWsPort(port: Int): VuuWebSocketOptions
+
   def withUri(uri: String): VuuWebSocketOptions
+
   def withBindAddress(address: String): VuuWebSocketOptions
+
   def withSslDisabled(): VuuWebSocketOptions
+
   def withSsl(vuuSSLOptions: VuuSSLOptions): VuuWebSocketOptions
+
   def withCompression(withCompression: Boolean): VuuWebSocketOptions
+
   def withNativeTransport(withNativeTransport: Boolean): VuuWebSocketOptions
+
   def withMaxSessionsPerUser(maxSessionsPerUser: Int): VuuWebSocketOptions
 }
 
-trait VuuThreadingOptions{
-  def withViewPortThreads(threads:Int): VuuThreadingOptions
-  def withTreeThreads(threads:Int): VuuThreadingOptions
+trait VuuThreadingOptions {
+  def withViewPortThreads(threads: Int): VuuThreadingOptions
+
+  def withTreeThreads(threads: Int): VuuThreadingOptions
+
   def viewportThreads: Int
+
   def treeThreads: Int
 }
 
 trait VuuClientConnectionOptions {
   def hasHeartbeat: Boolean
+
   def withHeartbeat(hasHeartbeat: Boolean): VuuClientConnectionOptions
+
   def withHeartbeatEnabled(): VuuClientConnectionOptions
+
   def withHeartbeatDisabled(): VuuClientConnectionOptions
 }
 
 trait VuuJoinTableProviderOptions {
   def batchSize: Int
+
   def maxQueueSize: Int
+
   def withBatchSize(maxQueueDepth: Int): VuuJoinTableProviderOptions
+
   def withMaxQueueDepth(maxQueueDepth: Int): VuuJoinTableProviderOptions
 }
 
 trait VuuRpcOptions {
-  def maxCopySize: Long
+  def maxCopySize: Int
+
+  def withMaxCopySize(maxCopySize: Int): VuuRpcOptions
 }
 
 private case class VuuWebSocketOptionsImpl(wsPort: Int,
-                                   uri: String,
-                                   bindAddress: String,
-                                   sslOptions: VuuSSLOptions,
-                                   compressionEnabled: Boolean,
-                                   nativeTransportEnabled: Boolean,
-                                   maxSessionsPerUser: Int
-                                   ) extends VuuWebSocketOptions {
+                                           uri: String,
+                                           bindAddress: String,
+                                           sslOptions: VuuSSLOptions,
+                                           compressionEnabled: Boolean,
+                                           nativeTransportEnabled: Boolean,
+                                           maxSessionsPerUser: Int
+                                          ) extends VuuWebSocketOptions {
   override def withWsPort(port: Int): VuuWebSocketOptions = this.copy(wsPort = port)
+
   override def withUri(uri: String): VuuWebSocketOptions = this.copy(uri = uri)
+
   override def withBindAddress(address: String): VuuWebSocketOptions = this.copy(bindAddress = bindAddress)
+
   override def withSslDisabled(): VuuWebSocketOptions = this.withSsl(VuuSSLDisabled)
+
   override def withSsl(sslOptions: VuuSSLOptions): VuuWebSocketOptions =
     this.copy(sslOptions = sslOptions)
-  override def withCompression(compressionEnabled: Boolean): VuuWebSocketOptions = 
+
+  override def withCompression(compressionEnabled: Boolean): VuuWebSocketOptions =
     this.copy(compressionEnabled = compressionEnabled)
+
   override def withNativeTransport(nativeTransportEnabled: Boolean): VuuWebSocketOptions =
-      this.copy(nativeTransportEnabled = nativeTransportEnabled)
+    this.copy(nativeTransportEnabled = nativeTransportEnabled)
+
   override def withMaxSessionsPerUser(maxSessionsPerUser: Int): VuuWebSocketOptions =
     this.copy(maxSessionsPerUser = maxSessionsPerUser)
 }
 
 case class VuuThreadingOptionsImpl(viewPortThreads: Int = 1, treeViewPortThreads: Int = 1) extends VuuThreadingOptions {
   override def withViewPortThreads(threads: Int): VuuThreadingOptions = this.copy(viewPortThreads = threads)
+
   override def withTreeThreads(threads: Int): VuuThreadingOptions = this.copy(treeViewPortThreads = threads)
+
   override def viewportThreads: Int = viewPortThreads
+
   override def treeThreads: Int = treeViewPortThreads
 }
 
 case class VuuClientConnectionOptionsImpl(hasHeartbeat: Boolean) extends VuuClientConnectionOptions {
   override def withHeartbeat(hasHeartbeat: Boolean): VuuClientConnectionOptions = this.copy(hasHeartbeat = hasHeartbeat)
+
   override def withHeartbeatEnabled(): VuuClientConnectionOptions = this.copy(true)
+
   override def withHeartbeatDisabled(): VuuClientConnectionOptions = this.copy(false)
 }
 
 
 case class VuuJoinProviderOptionsImpl(batchSize: Int, maxQueueSize: Int) extends VuuJoinTableProviderOptions {
   override def withBatchSize(batchSize: Int): VuuJoinTableProviderOptions = this.copy(batchSize = batchSize)
+
   override def withMaxQueueDepth(maxQueueSize: Int): VuuJoinTableProviderOptions = this.copy(maxQueueSize = maxQueueSize)
 }
 
-case class VuuRpcOptionsImpl(maxCopySize: Long) extends VuuRpcOptions {
+case class VuuRpcOptionsImpl(maxCopySize: Int) extends VuuRpcOptions {
   override def withMaxCopySize(maxCopySize: Int): VuuRpcOptions = this.copy(maxCopySize = maxCopySize)
 }
 
-case class VuuSecurityOptionsImpl(loginTokenService: LoginTokenService) extends VuuSecurityOptions{
+case class VuuSecurityOptionsImpl(loginTokenService: LoginTokenService) extends VuuSecurityOptions {
   override def withLoginTokenService(loginTokenService: LoginTokenService): VuuSecurityOptions =
     this.copy(loginTokenService = loginTokenService)
 }

--- a/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
@@ -187,10 +187,10 @@ case class VuuServerConfig(wsOptions: VuuWebSocketOptions = VuuWebSocketOptions(
                            threading: VuuThreadingOptions = VuuThreadingOptions(),
                            clientConnection: VuuClientConnectionOptions = VuuClientConnectionOptions(),
                            joinProvider: VuuJoinTableProviderOptions = VuuJoinTableProviderOptions(),
+                           rpcOptions: VuuRpcOptions = VuuRpcOptions(),
                            modules: List[ViewServerModule] = List(),
                            plugins: List[Plugin] = List(),
-                           httpServerFactory: HttpServerFactory = NoHttpServerFactory,
-                           rpcOptions: VuuRpcOptions) {
+                           httpServerFactory: HttpServerFactory = NoHttpServerFactory) {
   def withModule(module: ViewServerModule): VuuServerConfig = {
     this.copy(modules = modules ++ List(module))
   }

--- a/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
@@ -44,7 +44,11 @@ object VuuJoinTableProviderOptions {
   }
 }
 
-
+object VuuRpcOptions {
+  def apply() : VuuRpcOptions = {
+    VuuRpcOptionsImpl.apply(maxCopySize = 10_000)
+  }
+}
 
 trait VuuWebSocketOptions {
   def wsPort: Int
@@ -83,6 +87,10 @@ trait VuuJoinTableProviderOptions {
   def maxQueueSize: Int
   def withBatchSize(maxQueueDepth: Int): VuuJoinTableProviderOptions
   def withMaxQueueDepth(maxQueueDepth: Int): VuuJoinTableProviderOptions
+}
+
+trait VuuRpcOptions {
+  def maxCopySize: Long
 }
 
 private case class VuuWebSocketOptionsImpl(wsPort: Int,
@@ -126,6 +134,10 @@ case class VuuJoinProviderOptionsImpl(batchSize: Int, maxQueueSize: Int) extends
   override def withMaxQueueDepth(maxQueueSize: Int): VuuJoinTableProviderOptions = this.copy(maxQueueSize = maxQueueSize)
 }
 
+case class VuuRpcOptionsImpl(maxCopySize: Long) extends VuuRpcOptions {
+  override def withMaxCopySize(maxCopySize: Int): VuuRpcOptions = this.copy(maxCopySize = maxCopySize)
+}
+
 case class VuuSecurityOptionsImpl(loginTokenService: LoginTokenService) extends VuuSecurityOptions{
   override def withLoginTokenService(loginTokenService: LoginTokenService): VuuSecurityOptions =
     this.copy(loginTokenService = loginTokenService)
@@ -138,7 +150,8 @@ case class VuuServerConfig(wsOptions: VuuWebSocketOptions = VuuWebSocketOptions(
                            joinProvider: VuuJoinTableProviderOptions = VuuJoinTableProviderOptions(),
                            modules: List[ViewServerModule] = List(),
                            plugins: List[Plugin] = List(),
-                           httpServerFactory: HttpServerFactory = NoHttpServerFactory) {
+                           httpServerFactory: HttpServerFactory = NoHttpServerFactory,
+                           rpcOptions: VuuRpcOptions) {
   def withModule(module: ViewServerModule): VuuServerConfig = {
     this.copy(modules = modules ++ List(module))
   }

--- a/vuu/src/main/scala/org/finos/vuu/core/table/TableContainer.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/TableContainer.scala
@@ -5,6 +5,7 @@ import org.finos.toolbox.jmx.{JmxAble, MetricsProvider}
 import org.finos.toolbox.time.Clock
 import org.finos.vuu.api.TableVisibility.Private
 import org.finos.vuu.api.{JoinSessionTableDef, JoinTableDef, SessionTableDef, TableDef}
+import org.finos.vuu.core.VuuRpcOptions
 import org.finos.vuu.core.table.TableContainer.{isSessionTable, isSessionTableBlueprint, moduleName}
 import org.finos.vuu.core.tree.TreeSessionTableImpl
 import org.finos.vuu.net.ClientSessionId
@@ -26,12 +27,10 @@ trait TableContainerMBean {
   def getSubscribedKeys(name: String): String
 }
 
-class TableContainer(val joinTableProvider: JoinTableProvider)(implicit val metrics: MetricsProvider, val timeProvider: Clock) extends JmxAble with TableContainerMBean with StrictLogging {
+class TableContainer(val joinTableProvider: JoinTableProvider, val rpcOptions: VuuRpcOptions)(implicit val metrics: MetricsProvider, val timeProvider: Clock) extends JmxAble with TableContainerMBean with StrictLogging {
 
   private val tables = new ConcurrentHashMap[String, DataTable]()
-
-  //private val sessionTables = new ConcurrentHashMap[String, GroupBySessionTable]()
-
+  
   override def getSubscribedKeys(name: String): String = {
     val table = tables.get(name)
 

--- a/vuu/src/main/scala/org/finos/vuu/core/table/TableContainer.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/TableContainer.scala
@@ -27,10 +27,10 @@ trait TableContainerMBean {
   def getSubscribedKeys(name: String): String
 }
 
-class TableContainer(val joinTableProvider: JoinTableProvider, val rpcOptions: VuuRpcOptions)(implicit val metrics: MetricsProvider, val timeProvider: Clock) extends JmxAble with TableContainerMBean with StrictLogging {
+class TableContainer(val joinTableProvider: JoinTableProvider, val rpcOptions: VuuRpcOptions = VuuRpcOptions.apply())(implicit val metrics: MetricsProvider, val timeProvider: Clock) extends JmxAble with TableContainerMBean with StrictLogging {
 
   private val tables = new ConcurrentHashMap[String, DataTable]()
-  
+
   override def getSubscribedKeys(name: String): String = {
     val table = tables.get(name)
 

--- a/vuu/src/main/scala/org/finos/vuu/net/Messages.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/Messages.scala
@@ -44,7 +44,7 @@ case class GetTableListResponse(tables: Array[ViewPortTable]) extends MessageBod
 
 case class GetTableMetaRequest(table: ViewPortTable) extends MessageBody
 
-case class GetTableMetaResponse(table: ViewPortTable, columns: Array[String], dataTypes: Array[String], key: String) extends MessageBody
+case class GetTableMetaResponse(table: ViewPortTable, columns: Array[String], dataTypes: Array[String], key: String, editableColumns: Array[String]) extends MessageBody
 
 case class GetViewPortMenusRequest(vpId: String) extends MessageBody
 

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -1,8 +1,9 @@
 package org.finos.vuu.net.rpc
 
-import org.finos.vuu.core.table.{TableContainer, ViewPortColumnCreator}
+import org.finos.vuu.core.table.{InMemSessionDataTable, TableContainer, ViewPortColumnCreator}
 import org.finos.vuu.net.ClientSessionId
 import org.finos.vuu.net.rpc.SessionTableCopyOption.{All, Empty, Selected}
+import org.finos.vuu.viewport.{RowSource, ViewPort, ViewPortColumns}
 
 class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) extends DefaultRpcHandler {
   registerRpc(RpcNames.CreateSessionTableRpc, this.createSessionTable)
@@ -32,31 +33,26 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
     copyOption match {
       case All =>
         val vp = params.viewPort
-        val to = if (vp.getKeys.length > tableContainer.rpcOptions.maxCopySize) tableContainer.rpcOptions.maxCopySize else vp.getKeys.length
-        var i = 0
         val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy)
-        while (i < to) {
-          if (columnsToCopy.isEmpty) {
-            sessionTable.processUpdate(vp.table.pullRow(vp.getKeys.get(i)))
-          } else {
-            sessionTable.processUpdate(vp.table.pullRow(vp.getKeys.get(i), vpColumns))
-          }
-          i += 1
-        }
+        val iterator = vp.getKeys.iterator.take(tableContainer.rpcOptions.maxCopySize)
+        copyRows(iterator, sessionTable, vp.table, vpColumns, columnsToCopy)
       case Selected =>
         val vp = params.viewPort
-        val vpKeys = vp.getKeys
-        val selection = vp.getSelection
-        val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy.toList)
-        for (key <- selection) {
-          if (columnsToCopy.isEmpty) {
-            sessionTable.processUpdate(vp.table.pullRow(key))
-          } else {
-            sessionTable.processUpdate(vp.table.pullRow(key, vpColumns))
-          }
-        }
+        val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy)
+        val iterator = vp.getSelection.iterator.take(tableContainer.rpcOptions.maxCopySize)
+        copyRows(iterator, sessionTable, vp.table, vpColumns, columnsToCopy)
       case Empty =>
     }
     RpcFunctionSuccess(Some(Map("sessionTable" -> sessionTable.name, "module" -> sessionTable.tableDef.getModule().name)))
+  }
+
+  private def copyRows(iterator: Iterator[String], sessionTable: InMemSessionDataTable, sourceTable: RowSource, vpColumns: ViewPortColumns, columnsToCopy: List[String]): Unit = {
+    while (iterator.hasNext) {
+      if (columnsToCopy.isEmpty) {
+        sessionTable.processUpdate(sourceTable.pullRow(iterator.next()))
+      } else {
+        sessionTable.processUpdate(sourceTable.pullRow(iterator.next(), vpColumns))
+      }
+    }
   }
 }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -31,21 +31,26 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
     val sessionTableSource = tableContainer.getTable(sessionTableName)
     val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
 
-    // TODO 2169 send column isEditable to UI via table meta data
-    // validate changes are not done on non-editable columns
     copyOption match {
       case All =>
-        val size = sourceTable.asTable.size()
-        val keys = sourceTable.asTable.primaryKeys
-      //TODO #2169 add a config to limit the max rows to copy
-      // TODO #2169 copy all/max rows rows to session table
-      // when copying data, the data has to be pulled from view port keys not from base table , in case it's not visible to user.
-      // we need the column to be aviailable in view port - how do we handle it if it's not there
+        val vp = params.viewPort
+        val vpKeys = vp.getKeys
+        val to = if (vp.getKeys.length > tableContainer.rpcOptions.maxCopySize) tableContainer.rpcOptions.maxCopySize else vp.getKeys.length
+        var i = 0
+        while (i < to) {
+          sessionTable.processUpdate(vp.table.pullRow(vpKeys.get(i))) // TODO 2169 copy all columns but allow user to subscribe to a subset in session table??
+          // we need the column to be aviailable in view port - how do we handle it if it's not there
+          // make sure keys are sorted in vp?
+          i += 1
+        }
       case Selected =>
-      //TODO #2169 copy selected rows
-      // sort keys? val keys = aSort.doSort(table.sourceTable, filteredKeys, vpColumns)
+        val vp = params.viewPort
+        val vpKeys = vp.getKeys
+        val selection = vp.getSelection
+        for (key <- selection) { // TODO 2169 do we care about sorting???
+          sessionTable.processUpdate(vp.table.pullRow(key))
+        }
       case Empty =>
-
     }
     RpcFunctionSuccess(Some(ViewPortTable(sessionTable.name, sessionTable.tableDef.getModule().name)))
   }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -49,8 +49,13 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
         val vp = params.viewPort
         val vpKeys = vp.getKeys
         val selection = vp.getSelection
+        val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy.toList)
         for (key <- selection) {
-          sessionTable.processUpdate(vp.table.pullRow(key))
+          if (columnsToCopy.isEmpty) {
+            sessionTable.processUpdate(vp.table.pullRow(key))
+          } else {
+            sessionTable.processUpdate(vp.table.pullRow(key, vpColumns))
+          }
         }
       case Empty =>
     }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -14,14 +14,15 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
     val session: ClientSessionId = params.ctx.session
     val sourceTable = params.viewPort.table
     val copyOption = SessionTableCopyOption.fromString(params.namedParams("copyOption").asInstanceOf[String])
-    val columnsToCopy = params.namedParams("columnsToCopy").asInstanceOf[String].split(",")
+    val columnsToCopyStr = params.namedParams("columnsToCopy").asInstanceOf[String]
+    val columnsToCopy = if (columnsToCopyStr.equals("*")) List.empty[String] else columnsToCopyStr.split(",").toList
     val sessionTableName = params.namedParams("sessionTableName").asInstanceOf[String]
 
     if (!sourceTable.asTable.getTableDef.isEditable) {
       return new RpcFunctionFailure(s"Table ${sourceTable.name} is not editable")
     }
 
-    val columnsInSource = sourceTable.asTable.columnsForNames(columnsToCopy.toList)
+    val columnsInSource = sourceTable.asTable.columnsForNames(columnsToCopy)
       .map(_.name)
     val columnsNotInSource = columnsToCopy.filterNot(columnsInSource.contains)
     if (columnsNotInSource.nonEmpty) {
@@ -36,7 +37,7 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
         val vp = params.viewPort
         val to = if (vp.getKeys.length > tableContainer.rpcOptions.maxCopySize) tableContainer.rpcOptions.maxCopySize else vp.getKeys.length
         var i = 0
-        val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy.toList)
+        val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy)
         while (i < to) {
           if (columnsToCopy.isEmpty) {
             sessionTable.processUpdate(vp.table.pullRow(vp.getKeys.get(i)))
@@ -59,6 +60,6 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
         }
       case Empty =>
     }
-    RpcFunctionSuccess(Some(ViewPortTable(sessionTable.name, sessionTable.tableDef.getModule().name)))
+    RpcFunctionSuccess(Some(Map("sessionTable" -> sessionTable.name, "module" -> sessionTable.tableDef.getModule().name)))
   }
 }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -2,10 +2,7 @@ package org.finos.vuu.net.rpc
 
 import org.finos.vuu.core.table.{TableContainer, ViewPortColumnCreator}
 import org.finos.vuu.net.ClientSessionId
-import org.finos.vuu.net.rpc.SessionTableCopyOption.All
-import org.finos.vuu.net.rpc.SessionTableCopyOption.Empty
-import org.finos.vuu.net.rpc.SessionTableCopyOption.Selected
-import org.finos.vuu.viewport.ViewPortTable
+import org.finos.vuu.net.rpc.SessionTableCopyOption.{All, Empty, Selected}
 
 class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) extends DefaultRpcHandler {
   registerRpc(RpcNames.CreateSessionTableRpc, this.createSessionTable)

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -1,6 +1,6 @@
 package org.finos.vuu.net.rpc
 
-import org.finos.vuu.core.table.TableContainer
+import org.finos.vuu.core.table.{TableContainer, ViewPortColumnCreator}
 import org.finos.vuu.net.ClientSessionId
 import org.finos.vuu.net.rpc.SessionTableCopyOption.All
 import org.finos.vuu.net.rpc.SessionTableCopyOption.Empty
@@ -21,11 +21,11 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
       return new RpcFunctionFailure(s"Table ${sourceTable.name} is not editable")
     }
 
-    val validColumns = sourceTable.asTable.columnsForNames(columnsToCopy.toList)
+    val columnsInSource = sourceTable.asTable.columnsForNames(columnsToCopy.toList)
       .map(_.name)
-    val invalidColumns = columnsToCopy.filterNot(validColumns.contains)
-    if (invalidColumns.nonEmpty) {
-      return new RpcFunctionFailure(s"Column(s) [${invalidColumns.mkString(", ")} not found in table ${sourceTable.name}]")
+    val columnsNotInSource = columnsToCopy.filterNot(columnsInSource.contains)
+    if (columnsNotInSource.nonEmpty) {
+      return new RpcFunctionFailure(s"Column(s) [${columnsNotInSource.mkString(", ")} not found in table ${sourceTable.name}]")
     }
 
     val sessionTableSource = tableContainer.getTable(sessionTableName)
@@ -34,20 +34,22 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
     copyOption match {
       case All =>
         val vp = params.viewPort
-        val vpKeys = vp.getKeys
         val to = if (vp.getKeys.length > tableContainer.rpcOptions.maxCopySize) tableContainer.rpcOptions.maxCopySize else vp.getKeys.length
         var i = 0
+        val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy.toList)
         while (i < to) {
-          sessionTable.processUpdate(vp.table.pullRow(vpKeys.get(i))) // TODO 2169 copy all columns but allow user to subscribe to a subset in session table??
-          // we need the column to be aviailable in view port - how do we handle it if it's not there
-          // make sure keys are sorted in vp?
+          if (columnsToCopy.isEmpty) {
+            sessionTable.processUpdate(vp.table.pullRow(vp.getKeys.get(i)))
+          } else {
+            sessionTable.processUpdate(vp.table.pullRow(vp.getKeys.get(i), vpColumns))
+          }
           i += 1
         }
       case Selected =>
         val vp = params.viewPort
         val vpKeys = vp.getKeys
         val selection = vp.getSelection
-        for (key <- selection) { // TODO 2169 do we care about sorting???
+        for (key <- selection) {
           sessionTable.processUpdate(vp.table.pullRow(key))
         }
       case Empty =>

--- a/vuu/src/test/scala/org/finos/vuu/api/CoreServerApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/api/CoreServerApiTest.scala
@@ -22,7 +22,7 @@ class CoreServerApiTest extends AnyFeatureSpec with BeforeAndAfterEach with Give
     implicit val lifecycle: LifecycleContainer = new LifecycleContainer
     implicit val metrics: MetricsProvider = new MetricsProviderImpl
     val joinTableProvider = JoinTableProviderImpl()
-    val rpcOptions: VuuRpcOptions = VuuRpcOptionsImpl(100)
+    val rpcOptions: VuuRpcOptions = VuuRpcOptionsImpl(10)
     val tableContainer = new TableContainer(joinTableProvider, rpcOptions)
     val providerContainer = new ProviderContainer(joinTableProvider)
     val pluginRegistry = new DefaultPluginRegistry

--- a/vuu/src/test/scala/org/finos/vuu/api/CoreServerApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/api/CoreServerApiTest.scala
@@ -3,7 +3,7 @@ package org.finos.vuu.api
 import org.finos.toolbox.jmx.{MetricsProvider, MetricsProviderImpl}
 import org.finos.toolbox.lifecycle.LifecycleContainer
 import org.finos.toolbox.time.TestFriendlyClock
-import org.finos.vuu.core.CoreServerApiHandler
+import org.finos.vuu.core.{CoreServerApiHandler, VuuRpcOptions, VuuRpcOptionsImpl}
 import org.finos.vuu.core.auths.VuuUser
 import org.finos.vuu.core.table.TableContainer
 import org.finos.vuu.feature.inmem.{VuuInMemPlugin, VuuInMemPluginType}
@@ -22,7 +22,8 @@ class CoreServerApiTest extends AnyFeatureSpec with BeforeAndAfterEach with Give
     implicit val lifecycle: LifecycleContainer = new LifecycleContainer
     implicit val metrics: MetricsProvider = new MetricsProviderImpl
     val joinTableProvider = JoinTableProviderImpl()
-    val tableContainer = new TableContainer(joinTableProvider)
+    val rpcOptions: VuuRpcOptions = VuuRpcOptionsImpl(100)
+    val tableContainer = new TableContainer(joinTableProvider, rpcOptions)
     val providerContainer = new ProviderContainer(joinTableProvider)
     val pluginRegistry = new DefaultPluginRegistry
     pluginRegistry.registerPlugin(new VuuInMemPlugin)

--- a/vuu/src/test/scala/org/finos/vuu/core/module/modulefrommodule/ModuleConstructorTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/module/modulefrommodule/ModuleConstructorTest.scala
@@ -4,7 +4,6 @@ import org.finos.toolbox.lifecycle.LifecycleContainer
 import org.finos.toolbox.time.{Clock, DefaultClock}
 import org.finos.vuu.core.module.TableDefContainer
 import org.finos.vuu.core.{VuuSecurityOptions, VuuServerConfig, VuuThreadingOptions, VuuWebSocketOptions}
-import org.finos.vuu.net.auth.Authenticator
 import org.finos.vuu.net.ssl.VuuSSLByCertAndKey
 import org.scalatest.GivenWhenThen
 import org.scalatest.featurespec.AnyFeatureSpec

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -6,7 +6,7 @@ import org.finos.vuu.core.AbstractVuuServer
 import org.finos.vuu.core.module.{ModuleFactory, ViewServerModule}
 import org.finos.vuu.core.table.{DataTable, TableContainer}
 import org.finos.vuu.net.{CreateViewPortRequest, CreateViewPortSuccess, RpcRequest, RpcResponseNew}
-import org.finos.vuu.net.rpc.{CreateSessionTableRpcHandler, EndEditSessionRpcHandler, RpcErrorResult, RpcFunctionFailure, RpcNames, RpcSuccessResult, ViewPortContext}
+import org.finos.vuu.net.rpc.{CreateSessionTableRpcHandler, EndEditSessionRpcHandler, RpcErrorResult, RpcNames, RpcSuccessResult, ViewPortContext}
 import org.finos.vuu.provider.{Provider, ProviderContainer}
 import org.finos.vuu.viewport.{ViewPortRange, ViewPortTable}
 import org.finos.vuu.wsapi.helpers.TestExtension.ModuleFactoryExtension
@@ -32,11 +32,11 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   // test vp is sorted, the data copied to session table is also sorted
   // TODO 2169 do we care about sorting of viewport selection???
   Feature("[Web Socket API] create a session table and copy data from source table") {
-    Scenario("edit in an empty session table") {
+    Scenario("create an empty session table from source table") {
       Given("a view port exist")
       val viewPortId = createViewPort(tableName1)
 
-      When("request createSessionTable with empty table")
+      When("request creating an empty session table")
       val createSessionTableRequest = RpcRequest(
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
@@ -52,6 +52,57 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
       responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+
+      val sessionTableName = rpcResult.data.asInstanceOf[ViewPortTable].table
+      val sessionTableViewPortId = createViewPort(tableName1)
+      // todo verify session table is empty
+    }
+
+    Scenario("create a session table and copy all rows from all columns from source table") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(tableName1)
+
+      When("request creating a session table and copy all rows from all columns")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionTableName" -> sessionTableName1,
+          "copyOption" -> "All",
+          "columnsToCopy" -> ""
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("empty session table is created")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+      // TODO verify session table has all 3 columns and all rows of data
+    }
+
+    Scenario("create a session table and copy all rows from some columns from source table") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(tableName1)
+
+      When("request creating a session table and copy all rows from some columns")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionTableName" -> sessionTableName1,
+          "copyOption" -> "All",
+          "columnsToCopy" -> "Id,Name"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("empty session table is created")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+
+      // TODO verify session table has all rows but only 2 columns
     }
 
     Scenario("Request to create a session table failed for non-editable table") {

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -6,7 +6,7 @@ import org.finos.vuu.core.AbstractVuuServer
 import org.finos.vuu.core.module.{ModuleFactory, ViewServerModule}
 import org.finos.vuu.core.table.{DataTable, TableContainer}
 import org.finos.vuu.net.{CreateViewPortRequest, CreateViewPortSuccess, RpcRequest, RpcResponseNew}
-import org.finos.vuu.net.rpc.{CreateSessionTableRpcHandler, EndEditSessionRpcHandler, RpcNames, RpcSuccessResult, ViewPortContext}
+import org.finos.vuu.net.rpc.{CreateSessionTableRpcHandler, EndEditSessionRpcHandler, RpcErrorResult, RpcFunctionFailure, RpcNames, RpcSuccessResult, ViewPortContext}
 import org.finos.vuu.provider.{Provider, ProviderContainer}
 import org.finos.vuu.viewport.{ViewPortRange, ViewPortTable}
 import org.finos.vuu.wsapi.helpers.TestExtension.ModuleFactoryExtension
@@ -15,17 +15,23 @@ import org.finos.vuu.wsapi.helpers.{FakeDataSource, TestProviderFactory}
 import scala.collection.immutable.ListMap
 
 class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
+  private val allColumns = new ColumnBuilder()
+    .addString("Id")
+    .addString("Name")
+    .addInt("Account")
+    .build();
   private val tableName1 = "EditInSessionTest1"
+  private val nonEditableTableName = "NonEditableTable"
   private val sessionTableName1 = "EditInSessionTest1Session"
   private val moduleName = "EditInSessionTableRpcTest"
   private val testProviderFactory = new TestProviderFactory
 
-  // TODO 2069 add more scenarios, test non-editable table and column
+  // TODO 2069
   // test with large data, have 10 in base table, 5 in vp, add filter and sort
   // test table size over max copy size
   // test vp is sorted, the data copied to session table is also sorted
   // TODO 2169 do we care about sorting of viewport selection???
-  Feature("[Web Socket API] begin and end edit in a session table") {
+  Feature("[Web Socket API] create a session table and copy data from source table") {
     Scenario("edit in an empty session table") {
       Given("a view port exist")
       val viewPortId = createViewPort(tableName1)
@@ -42,24 +48,63 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
       Then("empty session table is created")
-      val beginEditResponse = vuuClient.awaitForResponse(requestId)
-      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](beginEditResponse)
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
       responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
     }
+
+    Scenario("Request to create a session table failed for non-editable table") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(nonEditableTableName)
+
+      When("request createSessionTable for non-editable source table")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionTableName" -> sessionTableName1,
+          "copyOption" -> "Empty",
+          "columnsToCopy" -> ""
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is not created")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
+    }
+
+    Scenario("Request to create a session table failed for copying from columns not in source table") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(nonEditableTableName)
+
+      When("request createSessionTable and copy from columns not in source table")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionTableName" -> sessionTableName1,
+          "copyOption" -> "Empty",
+          "columnsToCopy" -> "DUMMY"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is not created")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
+    }
   }
 
-  private def createTableDef(tableName: String): TableDef = {
+  private def createTableDef(tableName: String, isEditable: Boolean): TableDef = {
     TableDef(
       name = tableName,
       keyField = "Id",
-      columns =
-        new ColumnBuilder()
-          .addString("Id")
-          .addString("Name")
-          .addInt("Account")
-          .build(),
-      isEditable = true
+      columns = allColumns,
+      isEditable = isEditable
     )
   }
 
@@ -73,37 +118,23 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
 
     val viewPortDefFactory = (_: DataTable, _: Provider, _: ProviderContainer, tableContainer: TableContainer) =>
       ViewPortDef(
-        columns =
-          new ColumnBuilder()
-            .addString("Id")
-            .addString("Name")
-            .addInt("Account")
-            .build(),
+        columns = allColumns,
         service = new CreateSessionTableRpcHandler(using tableContainer)
       )
 
     val viewPortDefFactoryForSessionTable = (_: DataTable, _: Provider, _: ProviderContainer, tableContainer: TableContainer) =>
       ViewPortDef(
-        columns =
-          new ColumnBuilder()
-            .addString("Id")
-            .addString("Name")
-            .addInt("Account")
-            .build(),
+        columns = allColumns,
         service = new TestHandler(using tableContainer)
       )
 
     ModuleFactory.withNamespace(moduleName)
-      .addTableForTest(createTableDef(tableName1), viewPortDefFactory, providerFactory)
+      .addTableForTest(createTableDef(tableName1, true), viewPortDefFactory, providerFactory)
+      .addTableForTest(createTableDef(nonEditableTableName, false), viewPortDefFactory, providerFactory)
       .addSessionTable(SessionTableDef(
         name = sessionTableName1,
         keyField = "Id",
-        columns =
-          new ColumnBuilder()
-            .addString("Id")
-            .addString("Name", true)
-            .addInt("Account")
-            .build()
+        columns = allColumns
       ), viewPortDefFactoryForSessionTable)
       .asModule()
   }

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -6,7 +6,7 @@ import org.finos.vuu.core.AbstractVuuServer
 import org.finos.vuu.core.module.{ModuleFactory, ViewServerModule}
 import org.finos.vuu.core.table.{DataTable, TableContainer}
 import org.finos.vuu.net.{CreateViewPortRequest, CreateViewPortSuccess, RpcRequest, RpcResponseNew}
-import org.finos.vuu.net.rpc.{CreateSessionTableRpcHandler, EndEditSessionRpcHandler, RpcHandler, RpcNames, RpcSuccessResult, ViewPortContext}
+import org.finos.vuu.net.rpc.{CreateSessionTableRpcHandler, EndEditSessionRpcHandler, RpcNames, RpcSuccessResult, ViewPortContext}
 import org.finos.vuu.provider.{Provider, ProviderContainer}
 import org.finos.vuu.viewport.{ViewPortRange, ViewPortTable}
 import org.finos.vuu.wsapi.helpers.TestExtension.ModuleFactoryExtension
@@ -21,7 +21,10 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   private val testProviderFactory = new TestProviderFactory
 
   // TODO 2069 add more scenarios, test non-editable table and column
-
+  // test with large data, have 10 in base table, 5 in vp, add filter and sort
+  // test table size over max copy size
+  // test vp is sorted, the data copied to session table is also sorted
+  // TODO 2169 do we care about sorting of viewport selection???
   Feature("[Web Socket API] begin and end edit in a session table") {
     Scenario("edit in an empty session table") {
       Given("a view port exist")
@@ -53,7 +56,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       columns =
         new ColumnBuilder()
           .addString("Id")
-          .addString("Name", true)
+          .addString("Name")
           .addInt("Account")
           .build(),
       isEditable = true

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -52,10 +52,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
       responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
-
-      val sessionTableName = rpcResult.data.asInstanceOf[ViewPortTable].table
-      val sessionTableViewPortId = createViewPort(tableName1)
-      // todo verify session table is empty
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, 0)
     }
 
     Scenario("create a session table and copy all rows from all columns from source table") {
@@ -69,16 +67,17 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         params = Map(
           "sessionTableName" -> sessionTableName1,
           "copyOption" -> "All",
-          "columnsToCopy" -> ""
+          "columnsToCopy" -> "*"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
-      Then("empty session table is created")
+      Then("session table is created with all data")
       val response = vuuClient.awaitForResponse(requestId)
       val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
       responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
-      // TODO verify session table has all 3 columns and all rows of data
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, 3)
     }
 
     Scenario("create a session table and copy all rows from some columns from source table") {
@@ -96,13 +95,13 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
-      Then("empty session table is created")
+      Then("session table is created with all data")
       val response = vuuClient.awaitForResponse(requestId)
       val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
       responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
-
-      // TODO verify session table has all rows but only 2 columns
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, 0)
     }
 
     Scenario("Request to create a session table failed for non-editable table") {
@@ -129,7 +128,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
 
     Scenario("Request to create a session table failed for copying from columns not in source table") {
       Given("a view port exist")
-      val viewPortId = createViewPort(nonEditableTableName)
+      val viewPortId = createViewPortAndVerifyDataSize(tableName1, 3)
 
       When("request createSessionTable and copy from columns not in source table")
       val createSessionTableRequest = RpcRequest(
@@ -191,11 +190,15 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   }
 
   private def createViewPort(tableName: String) = {
-    val createViewPortRequest = CreateViewPortRequest(ViewPortTable(tableName, moduleName), ViewPortRange(0, 100), columns = Array("Id", "Name", "Account"))
+    createViewPortAndVerifyDataSize(tableName, 3)
+  }
+
+  private def createViewPortAndVerifyDataSize(tableName: String, expectedRowCount: Int) = {
+    val createViewPortRequest = CreateViewPortRequest(ViewPortTable(tableName, moduleName), ViewPortRange(0, 100), columns = Array("*"))
     vuuClient.send(sessionId, createViewPortRequest)
     val viewPortCreateResponse = vuuClient.awaitForMsgWithBody[CreateViewPortSuccess]
     val viewPortId = viewPortCreateResponse.get.viewPortId
-    waitForData(3)
+    waitForData(expectedRowCount)
     viewPortId
   }
 }

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -52,9 +52,9 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       keyField = "Id",
       columns =
         new ColumnBuilder()
-          .addString("Id", true)
+          .addString("Id")
           .addString("Name", true)
-          .addInt("Account", true)
+          .addInt("Account")
           .build(),
       isEditable = true
     )
@@ -98,7 +98,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         columns =
           new ColumnBuilder()
             .addString("Id")
-            .addString("Name")
+            .addString("Name", true)
             .addInt("Account")
             .build()
       ), viewPortDefFactoryForSessionTable)

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -32,6 +32,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   // test with large data, have 10 in base table, 5 in vp, add filter and sort
   // test vp is sorted, the data copied to session table is also sorted
   // TODO 2169 do we care about sorting of viewport selection???
+  // add a test for selected rows more than max size
   Feature("[Web Socket API] create a session table and copy data from source table") {
     Scenario("create an empty session table from source table") {
       Given("a view port exist")

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -22,13 +22,14 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
     .build();
   private val tableName1 = "EditInSessionTest1"
   private val nonEditableTableName = "NonEditableTable"
-  private val sessionTableName1 = "EditInSessionTest1Session"
+  private val largeTableName = "LargeTable"
+  private val sessionTableDefName = "EditInSessionTest1Session"
   private val moduleName = "EditInSessionTableRpcTest"
   private val testProviderFactory = new TestProviderFactory
+  private val maxCopySize = 10 // configured in CoreServerApiTest
 
-  // TODO 2069
+  // TODO 2069 add test scenarios for empty but all columns, selection with all columns, selection with some columns
   // test with large data, have 10 in base table, 5 in vp, add filter and sort
-  // test table size over max copy size
   // test vp is sorted, the data copied to session table is also sorted
   // TODO 2169 do we care about sorting of viewport selection???
   Feature("[Web Socket API] create a session table and copy data from source table") {
@@ -41,7 +42,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableName1,
+          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "Empty",
           "columnsToCopy" -> "Id,Name"
         ))
@@ -65,7 +66,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableName1,
+          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "All",
           "columnsToCopy" -> "*"
         ))
@@ -89,7 +90,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableName1,
+          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "All",
           "columnsToCopy" -> "Id,Name"
         ))
@@ -104,6 +105,30 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, 0)
     }
 
+    Scenario("create a session table and copy all rows up to max threshold from source table") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(largeTableName)
+
+      When("request creating a session table and copy all rows")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionTableName" -> sessionTableDefName,
+          "copyOption" -> "All",
+          "columnsToCopy" -> "*"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is created with max number of rows")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, maxCopySize)
+    }
+
     Scenario("Request to create a session table failed for non-editable table") {
       Given("a view port exist")
       val viewPortId = createViewPort(nonEditableTableName)
@@ -113,7 +138,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableName1,
+          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "Empty",
           "columnsToCopy" -> ""
         ))
@@ -135,7 +160,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableName1,
+          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "Empty",
           "columnsToCopy" -> "DUMMY"
         ))
@@ -165,13 +190,26 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       "row3" -> Map("Id" -> "row3", "Name" -> "Huckleberry Finn", "Account" -> 789),
     ))
     val providerFactory = (table: DataTable, _: AbstractVuuServer) => testProviderFactory.create(table, dataSource)
+    val largeDataSource = new FakeDataSource(ListMap(
+      "row1" -> Map("Id" -> "row1", "Name" -> "user1", "Account" -> 1),
+      "row2" -> Map("Id" -> "row2", "Name" -> "user1", "Account" -> 2),
+      "row3" -> Map("Id" -> "row3", "Name" -> "user1", "Account" -> 3),
+      "row4" -> Map("Id" -> "row4", "Name" -> "user1", "Account" -> 4),
+      "row5" -> Map("Id" -> "row5", "Name" -> "user1", "Account" -> 5),
+      "row6" -> Map("Id" -> "row6", "Name" -> "user1", "Account" -> 6),
+      "row7" -> Map("Id" -> "row7", "Name" -> "user1", "Account" -> 7),
+      "row8" -> Map("Id" -> "row8", "Name" -> "user1", "Account" -> 8),
+      "row9" -> Map("Id" -> "row9", "Name" -> "user1", "Account" -> 9),
+      "row10" -> Map("Id" -> "row10", "Name" -> "user1", "Account" -> 10),
+      "row11" -> Map("Id" -> "row11", "Name" -> "user1", "Account" -> 11),
+    ))
+    val largeProviderFactory = (table: DataTable, _: AbstractVuuServer) => testProviderFactory.create(table, largeDataSource)
 
     val viewPortDefFactory = (_: DataTable, _: Provider, _: ProviderContainer, tableContainer: TableContainer) =>
       ViewPortDef(
         columns = allColumns,
         service = new CreateSessionTableRpcHandler(using tableContainer)
       )
-
     val viewPortDefFactoryForSessionTable = (_: DataTable, _: Provider, _: ProviderContainer, tableContainer: TableContainer) =>
       ViewPortDef(
         columns = allColumns,
@@ -181,8 +219,9 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
     ModuleFactory.withNamespace(moduleName)
       .addTableForTest(createTableDef(tableName1, true), viewPortDefFactory, providerFactory)
       .addTableForTest(createTableDef(nonEditableTableName, false), viewPortDefFactory, providerFactory)
+      .addTableForTest(createTableDef(largeTableName, true), viewPortDefFactory, largeProviderFactory)
       .addSessionTable(SessionTableDef(
-        name = sessionTableName1,
+        name = sessionTableDefName,
         keyField = "Id",
         columns = allColumns
       ), viewPortDefFactoryForSessionTable)

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/TableWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/TableWSApiTest.scala
@@ -28,6 +28,7 @@ class TableWSApiTest extends WebSocketApiTestBase {
       val responseBody = assertBodyIsInstanceOf[GetTableMetaResponse](response)
       responseBody.columns.length shouldEqual 2
       responseBody.columns shouldEqual Array("id", "account")
+      responseBody.editableColumns shouldEqual Array("account")
     }
 
     Scenario("For a table with no view port def defined") {
@@ -115,7 +116,7 @@ class TableWSApiTest extends WebSocketApiTestBase {
         new ColumnBuilder()
           .addString("id")
           .addString("name")
-          .addInt("account")
+          .addInt("account", true)
           .build()
     )
 


### PR DESCRIPTION
Part 2 of #2169 

Changes:
- add editable columns to GetTableMetaResponse
- add VuuRpcOptions and max copy size
- implement CreateSessionTableRpcHandler to copy data from source table to session table. If rpc params specify the list of columns to copy from, then data is copied only for these columns. Otherwise if "*" is used, all columns are copied.