### PR TITLE
add new default column vuuMsg to test tables

### DIFF
--- a/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
+++ b/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
@@ -99,15 +99,13 @@ const toDataSourceRow =
     ];
   };
 
-// const isError = (err: unknown): err is { message: string } =>
-//   typeof err === "object" && err !== null && err.hasOwnProperty("message");
-
 const buildTableSchema = (
   columns: readonly ColumnDescriptor[],
   keyColumn?: string,
 ): TableSchema => {
   const schema: TableSchema = {
-    columns: columns.map(({ name, serverDataType = "string" }) => ({
+    columns: columns.map(({ editable, name, serverDataType = "string" }) => ({
+      editable, 
       name,
       serverDataType,
     })),

--- a/vuu-ui/packages/vuu-data-remote/src/message-utils.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/message-utils.ts
@@ -64,15 +64,25 @@ export const groupRowsByViewport = (rows: VuuRow[]): ViewportRowMap => {
 export const createSchemaFromTableMetadata = ({
   columns,
   dataTypes,
+  editableColumns,
   key,
   table,
 }: Omit<VuuTableMetaResponse, "type">): Readonly<TableSchema> => {
   return {
     table,
-    columns: columns.map((col, idx) => ({
-      name: col,
-      serverDataType: dataTypes[idx],
-    })),
+    columns: columns.map((col, idx) => {
+      if (editableColumns.includes(col)){
+        return {
+          editable: true,
+          name: col,
+          serverDataType: dataTypes[idx],
+        };
+      }
+      return {
+        name: col,
+        serverDataType: dataTypes[idx],
+      };
+  }),
     key,
   };
 };

--- a/vuu-ui/packages/vuu-data-remote/test/test-utils.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/test-utils.ts
@@ -262,6 +262,7 @@ export const createSubscription = ({
       columns: ['col-1', 'col-2', 'col-3', 'col-4'],
       key: 'col-1',
       dataTypes: ['string','string','string','string'],
+      editableColumns: [],
       table: {module: "TEST", table: "test-table"},
       type: "TABLE_META_RESP"
     },

--- a/vuu-ui/packages/vuu-data-test/src/default-column-definitions.ts
+++ b/vuu-ui/packages/vuu-data-test/src/default-column-definitions.ts
@@ -1,0 +1,7 @@
+import { SchemaColumn } from "@vuu-ui/vuu-data-types";
+
+export const VUU_DEFAULT_COLUMNS: SchemaColumn[] = [
+  { name: "vuuCreatedTimestamp", serverDataType: "epochtimestamp" },
+  { name: "vuuUpdatedTimestamp", serverDataType: "epochtimestamp" },
+  { name: "vuuMsg", serverDataType: "string" },
+];

--- a/vuu-ui/packages/vuu-data-test/src/simul/reference-data/instruments.ts
+++ b/vuu-ui/packages/vuu-data-test/src/simul/reference-data/instruments.ts
@@ -40,6 +40,7 @@ export type InstrumentsDataRow = [
   ric,
   date,
   date,
+  string
 ];
 
 export const InstrumentColumnMap = {
@@ -52,6 +53,7 @@ export const InstrumentColumnMap = {
   ric: 6,
   vuuCreatedTimestamp: 7,
   vuuUpdatedTimestamp: 8,
+  vuuMsg: 9
 } as const;
 
 const instrumentsData: InstrumentsDataRow[] = [];
@@ -106,6 +108,7 @@ for (const char1 of chars1) {
           ric,
           timestamp,
           timestamp,
+          ''
         ]);
         count++;
         clock.advance(random(0, 10000));

--- a/vuu-ui/packages/vuu-data-test/src/simul/reference-data/parent-child-orders.ts
+++ b/vuu-ui/packages/vuu-data-test/src/simul/reference-data/parent-child-orders.ts
@@ -114,6 +114,7 @@ function createParentAndChildOrders() {
         volLimit,
         lastUpdate,
         created,
+        ''
       ],
       notifyNewOrders,
     );
@@ -139,6 +140,7 @@ function createParentAndChildOrders() {
       volLimit,
       lastUpdate,
       created,
+      ''
     ],
     notifyNewOrders,
   );

--- a/vuu-ui/packages/vuu-data-test/src/simul/reference-data/prices.ts
+++ b/vuu-ui/packages/vuu-data-test/src/simul/reference-data/prices.ts
@@ -18,6 +18,7 @@ type ric = string;
 type scenario = "close";
 type lastUpdate = number;
 type created = number;
+type vuuMsg = string;
 
 export type PricesDataRow = [
   ask,
@@ -32,6 +33,7 @@ export type PricesDataRow = [
   scenario,
   lastUpdate,
   created,
+  vuuMsg
 ];
 
 const { bid, bidSize, ask, askSize } = buildDataColumnMap(schemas, "prices");
@@ -77,6 +79,7 @@ const pricesData: Array<PricesDataRow> = instrumentsData.map((instrument) => {
     scenario,
     lastUpdate,
     created,
+    ''
   ];
 });
 
@@ -106,7 +109,8 @@ for (const [,,,lastTrade,ric] of basketConstituentData) {
       ric as string,
       scenario,
       lastUpdate,
-      created
+      created,
+      ''
     ]);
   }
 }

--- a/vuu-ui/packages/vuu-data-test/src/simul/simul-schemas.ts
+++ b/vuu-ui/packages/vuu-data-test/src/simul/simul-schemas.ts
@@ -1,10 +1,7 @@
-import { SchemaColumn, TableSchema } from "@vuu-ui/vuu-data-types";
+import { TableSchema } from "@vuu-ui/vuu-data-types";
 import { VuuTable } from "@vuu-ui/vuu-protocol-types";
+import { VUU_DEFAULT_COLUMNS } from "../default-column-definitions";
 
-const VUU_TIMESTAMP_COLUMNS: SchemaColumn[] = [
-  { name: "vuuCreatedTimestamp", serverDataType: "epochtimestamp" },
-  { name: "vuuUpdatedTimestamp", serverDataType: "epochtimestamp" },
-];
 
 export type SimulTableName =
   | "instruments"
@@ -28,7 +25,7 @@ export const schemas: Readonly<Record<SimulTableName, Readonly<TableSchema>>> =
         { name: "isin", serverDataType: "string" },
         { name: "lotSize", serverDataType: "int" },
         { name: "ric", serverDataType: "string" },
-        ...VUU_TIMESTAMP_COLUMNS,
+        ...VUU_DEFAULT_COLUMNS,
       ],
       key: "ric",
       table: { module: "SIMUL", table: "instruments" },
@@ -47,7 +44,7 @@ export const schemas: Readonly<Record<SimulTableName, Readonly<TableSchema>>> =
         { name: "lastUpdated", serverDataType: "long" },
         { name: "price", serverDataType: "double" },
         { name: "date", serverDataType: "long" },
-        ...VUU_TIMESTAMP_COLUMNS,
+        ...VUU_DEFAULT_COLUMNS,
       ],
       key: "ric",
       table: { module: "SIMUL", table: "instrumentsExtended" },
@@ -70,7 +67,7 @@ export const schemas: Readonly<Record<SimulTableName, Readonly<TableSchema>>> =
         { name: "phase", serverDataType: "string" },
         { name: "ric", serverDataType: "string" },
         { name: "scenario", serverDataType: "string" },
-        ...VUU_TIMESTAMP_COLUMNS,
+        ...VUU_DEFAULT_COLUMNS,
       ],
       key: "ric",
       table: { module: "SIMUL", table: "instrumentPrices" },
@@ -86,7 +83,7 @@ export const schemas: Readonly<Record<SimulTableName, Readonly<TableSchema>>> =
         { name: "ric", serverDataType: "string" },
         { name: "side", serverDataType: "string" },
         { name: "trader", serverDataType: "string" },
-        ...VUU_TIMESTAMP_COLUMNS,
+        ...VUU_DEFAULT_COLUMNS,
       ],
       key: "orderId",
       table: { module: "SIMUL", table: "orders" },
@@ -109,7 +106,7 @@ export const schemas: Readonly<Record<SimulTableName, Readonly<TableSchema>>> =
         { name: "status", serverDataType: "string" },
         { name: "strategy", serverDataType: "string" },
         { name: "volLimit", serverDataType: "int" },
-        ...VUU_TIMESTAMP_COLUMNS,
+        ...VUU_DEFAULT_COLUMNS,
       ],
       key: "id",
       table: { module: "SIMUL", table: "childOrders" },
@@ -132,7 +129,7 @@ export const schemas: Readonly<Record<SimulTableName, Readonly<TableSchema>>> =
         { name: "side", serverDataType: "string" },
         { name: "status", serverDataType: "string" },
         { name: "volLimit", serverDataType: "int" },
-        ...VUU_TIMESTAMP_COLUMNS,
+        ...VUU_DEFAULT_COLUMNS,
       ],
       key: "id",
       table: { module: "SIMUL", table: "parentOrders" },
@@ -149,7 +146,7 @@ export const schemas: Readonly<Record<SimulTableName, Readonly<TableSchema>>> =
         { name: "phase", serverDataType: "string" },
         { name: "ric", serverDataType: "string" },
         { name: "scenario", serverDataType: "string" },
-        ...VUU_TIMESTAMP_COLUMNS,
+        ...VUU_DEFAULT_COLUMNS,
       ],
       key: "ric",
       table: { module: "SIMUL", table: "prices" },

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -381,6 +381,7 @@ export declare type ConfigChangeMessage =
 export declare type ConfigChangeHandler = (msg: ConfigChangeMessage) => void;
 
 export declare type SchemaColumn = {
+  editable?: boolean;
   name: string;
   serverDataType: VuuColumnDataType;
 };

--- a/vuu-ui/packages/vuu-protocol-types/index.d.ts
+++ b/vuu-ui/packages/vuu-protocol-types/index.d.ts
@@ -89,6 +89,7 @@ export interface VuuTableMetaRequest {
 export interface VuuTableMetaResponse {
   columns: VuuColumns;
   dataTypes: VuuColumnDataType[];
+  editableColumns: string[];
   key: string;
   table: VuuTable;
   type: "TABLE_META_RESP";

--- a/vuu-ui/packages/vuu-table-extras/test/column-picker/ColumnModel.test.ts
+++ b/vuu-ui/packages/vuu-table-extras/test/column-picker/ColumnModel.test.ts
@@ -6,7 +6,8 @@ import {
 } from "../../src/column-picker/ColumnModel";
 import { getSchema } from "@vuu-ui/vuu-data-test";
 
-const { columns } = getSchema("parentOrders");
+const { columns: parentOrderColumns } = getSchema("parentOrders");
+const columns = parentOrderColumns.filter(col => col.name !== 'vuuMsg')
 
 function shuffle<T>(arr: T[]) {
   const shuffledArray = arr.slice();

--- a/vuu-ui/packages/vuu-utils/src/column-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/column-utils.ts
@@ -1253,20 +1253,20 @@ export function replaceColumn<
   return columns.map((col) => (col.name === column.name ? column : col));
 }
 
-const vuuTimestampColumns = ["vuuCreatedTimestamp", "vuuUpdatedTimestamp"];
+const vuuDefaultColumns = ["vuuCreatedTimestamp", "vuuUpdatedTimestamp","vuuMsg"];
 
-const notVuuTimestamps = (column: { name: string }) =>
-  !vuuTimestampColumns.includes(column.name);
+const notVuuDefaultColumns = (column: { name: string }) =>
+  !vuuDefaultColumns.includes(column.name);
 
 export const applyDefaultColumnConfig = (
   { columns: columnsProp, table }: TableSchema,
   getDefaultColumnConfig?: DefaultColumnConfiguration,
-  includeVuuTimestampColumns = false,
+  includeVuuDefaultColumns = false,
 ) => {
   if (typeof getDefaultColumnConfig === "function") {
-    const columns = includeVuuTimestampColumns
+    const columns = includeVuuDefaultColumns
       ? columnsProp
-      : columnsProp.filter(notVuuTimestamps);
+      : columnsProp.filter(notVuuDefaultColumns);
 
     return columns.map((column) => {
       const config = getDefaultColumnConfig(table.table, column.name);

--- a/vuu-ui/showcase/src/examples/Table/TableLayout.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/TableLayout.examples.tsx
@@ -41,7 +41,7 @@ const DataTableTemplate = ({
   const tableConfig = useMemo<TableConfig>(() => {
     return {
       ...props.config,
-      columns: schema.columns,
+      columns: schema.columns.filter(col => col.name !== 'vuuMsg'),
       rowSeparators: true,
       zebraStripes: true,
     };

--- a/vuu-ui/showcase/src/examples/Table/TableSelection.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/TableSelection.examples.tsx
@@ -56,7 +56,7 @@ const DataTableTemplate = ({
       rowSeparators: true,
       zebraStripes: true,
       ...configProp,
-      columns: schema.columns.map<ColumnDescriptor>((col) =>
+      columns: schema.columns.filter(col => col.name !== 'vuuMsg').map<ColumnDescriptor>((col) =>
         selectedColumn.includes(col.name)
           ? {
               ...col,


### PR DESCRIPTION
a new default column vuuMsg is defined on all tables
added this column to the local test SIMUL tables (others still need updating but are not used in tests, so can be deferred)
a new property is returned on GET_TABLE_META requests - editableColumns. This tells ui that a column is defined as editable on server. Incorporate this into the TableSchema that we build on front end. 
More work required to fully integrate the 'editableColumns' with locally defined test tables. 