### PR TITLE
Add EpochTimestampNano data type

### DIFF
--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataMapper.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataMapper.scala
@@ -2,9 +2,9 @@ package org.finos.vuu.plugin.clickhouse.provider.data
 
 import com.clickhouse.client.api.query.GenericRecord
 import com.typesafe.scalalogging.StrictLogging
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{Column, DataType, RowWithData}
-import org.finos.vuu.plugin.clickhouse.provider.data.ClickHouseRowDataMapper.EPOCH_NAN_SENTINEL
+import org.finos.vuu.plugin.clickhouse.provider.data.ClickHouseRowDataMapper.{EPOCH_NANO_NAN_SENTINEL, EPOCH_NAN_SENTINEL}
 import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumn
 
 import java.time.ZonedDateTime
@@ -22,6 +22,7 @@ object ClickHouseRowDataMapper {
   val LONG_NAN_SENTINEL: Long = Long.MinValue
   val DOUBLE_NAN_SENTINEL: Double = java.lang.Double.NaN
   val EPOCH_NAN_SENTINEL: EpochTimestamp = EpochTimestamp(0)
+  val EPOCH_NANO_NAN_SENTINEL: EpochTimestampNano = EpochTimestampNano(0)
 
   def apply(): ClickHouseRowDataMapper = ClickHouseRowDataMapperImpl()
 
@@ -82,6 +83,15 @@ private case class ClickHouseRowDataMapperImpl() extends ClickHouseRowDataMapper
               val epochTimestamp = EpochTimestamp(ts)
               if (epochTimestamp != EPOCH_NAN_SENTINEL) {
                 builder.put(name, epochTimestamp)
+              }
+            }
+
+          case DataType.EpochTimestampNanoType =>
+            val ts: ZonedDateTime = v1.getZonedDateTime(remoteName)
+            if (ts != null) {
+              val epochTimestampNano = EpochTimestampNano(ts)
+              if (epochTimestampNano != EPOCH_NANO_NAN_SENTINEL) {
+                builder.put(name, epochTimestampNano)
               }
             }
 

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataMapperTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataMapperTest.scala
@@ -2,7 +2,7 @@ package org.finos.vuu.plugin.clickhouse.provider.data
 
 import com.clickhouse.client.api.metadata.TableSchema
 import com.clickhouse.client.api.query.GenericRecord
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{Column, DataType, SimpleColumn}
 import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumn
 import org.scalamock.scalatest.MockFactory
@@ -220,6 +220,51 @@ class ClickHouseRowDataMapperTest extends AnyFlatSpec with Matchers with MockFac
     Then("the char is omitted")
     row3.key shouldBe "key-8"
     row3.data.contains("epochCol") shouldBe false
+  }
+
+  it should "map EpochTimestampNano only when non 0 zoned datetime provided" in {
+    Given("a GenericRecord with epoch column")
+    val v1 = mock[GenericRecord]
+
+    val columns = List(col("epochNanoCol", DataType.EpochTimestampNanoType))
+
+    (v1.hasValue(_: String)).expects("epochNanoCol").returning(true)
+    (v1.getZonedDateTime(_: String)).expects("epochNanoCol").returning(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1), ZoneId.of("UTC")))
+    (v1.getString(_: String)).expects("pk").returning("key-6")
+
+    When("we map the record with a valid zoned date time")
+    val mapper = ClickHouseRowDataMapper()
+    val row = mapper.mapRowData(v1, "pk", columns)
+
+    Then("the timestamp is present")
+    row.key shouldBe "key-6"
+    row.data("epochNanoCol") shouldBe EpochTimestampNano(1_000_000)
+
+    Given("the GenericRecord returns null")
+    val v2 = mock[GenericRecord]
+    (v2.hasValue(_: String)).expects("epochNanoCol").returning(true)
+    (v2.getZonedDateTime(_: String)).expects("epochNanoCol").returning(null)
+    (v2.getString(_: String)).expects("pk").returning("key-7")
+
+    When("we map the record again")
+    val row2 = mapper.mapRowData(v2, "pk", columns)
+
+    Then("the timestamp is not present")
+    row2.key shouldBe "key-7"
+    row2.data.contains("epochNanoCol") shouldBe false
+
+    Given("the GenericRecord returns Unix Epoch 0")
+    val v3 = mock[GenericRecord]
+    (v3.hasValue(_: String)).expects("epochNanoCol").returning(true)
+    (v3.getZonedDateTime(_: String)).expects("epochNanoCol").returning(ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+    (v3.getString(_: String)).expects("pk").returning("key-8")
+
+    When("we map the record again")
+    val row3 = mapper.mapRowData(v3, "pk", columns)
+
+    Then("the timestamp is omitted")
+    row3.key shouldBe "key-8"
+    row3.data.contains("epochNanoCol") shouldBe false
   }
 
   it should "map scaled decimals from longs and omit sentinels" in {

--- a/plugin/virtualized-table-plugin/src/main/scala/org/finos/vuu/plugin/virtualized/api/VirtualizedSessionTableColumnBuilder.scala
+++ b/plugin/virtualized-table-plugin/src/main/scala/org/finos/vuu/plugin/virtualized/api/VirtualizedSessionTableColumnBuilder.scala
@@ -69,6 +69,15 @@ class VirtualizedSessionTableColumnBuilder {
     this
   }
 
+  def addEpochTimestampNano(columnName: String): VirtualizedSessionTableColumnBuilder = {
+    addEpochTimestampNano(columnName, columnName)
+  }
+
+  def addEpochTimestampNano(columnName: String, remoteName: String): VirtualizedSessionTableColumnBuilder = {
+    columns += s"$columnName:EpochTimestampNano:$remoteName"
+    this
+  }
+
   def addScaledDecimal2(columnName: String): VirtualizedSessionTableColumnBuilder = {
     addScaledDecimal2(columnName, columnName)
   }

--- a/plugin/virtualized-table-plugin/src/test/scala/org/finos/vuu/plugin/virtualized/api/VirtualizedSessionTableColumnBuilderTest.scala
+++ b/plugin/virtualized-table-plugin/src/test/scala/org/finos/vuu/plugin/virtualized/api/VirtualizedSessionTableColumnBuilderTest.scala
@@ -25,6 +25,7 @@ class VirtualizedSessionTableColumnBuilderTest extends AnyFeatureSpec
         .addBoolean("boolCol")
         .addChar("charCol")
         .addEpochTimestamp("timestampCol")
+        .addEpochTimestampNano("nanoTimestampCol")
         .addScaledDecimal2("decimal2Col")
         .addScaledDecimal4("decimal4Col")
         .addScaledDecimal6("decimal6Col")
@@ -39,6 +40,7 @@ class VirtualizedSessionTableColumnBuilderTest extends AnyFeatureSpec
         "boolCol:Boolean:boolCol",
         "charCol:Char:charCol",
         "timestampCol:EpochTimestamp:timestampCol",
+        "nanoTimestampCol:EpochTimestampNano:nanoTimestampCol",
         "decimal2Col:ScaledDecimal2:decimal2Col",
         "decimal4Col:ScaledDecimal4:decimal4Col",
         "decimal6Col:ScaledDecimal6:decimal6Col",
@@ -61,6 +63,7 @@ class VirtualizedSessionTableColumnBuilderTest extends AnyFeatureSpec
         .addBoolean("boolCol", "remoteBool")
         .addChar("charCol", "remoteChar")
         .addEpochTimestamp("timestampCol", "remoteTimestamp")
+        .addEpochTimestampNano("nanoTimestampCol", "remoteNanoTimestamp")
         .addScaledDecimal2("decimal2Col", "remoteDecimal2")
         .addScaledDecimal4("decimal4Col", "remoteDecimal4")
         .addScaledDecimal6("decimal6Col", "remoteDecimal6")
@@ -75,6 +78,7 @@ class VirtualizedSessionTableColumnBuilderTest extends AnyFeatureSpec
         "boolCol:Boolean:remoteBool",
         "charCol:Char:remoteChar",
         "timestampCol:EpochTimestamp:remoteTimestamp",
+        "nanoTimestampCol:EpochTimestampNano:remoteNanoTimestamp",
         "decimal2Col:ScaledDecimal2:remoteDecimal2",
         "decimal4Col:ScaledDecimal4:remoteDecimal4",
         "decimal6Col:ScaledDecimal6:remoteDecimal6",

--- a/vuu/src/main/scala/org/finos/vuu/api/ColumnBuilder.scala
+++ b/vuu/src/main/scala/org/finos/vuu/api/ColumnBuilder.scala
@@ -71,6 +71,15 @@ class ColumnBuilder {
     this
   }
 
+  def addEpochTimestampNano(columnName: String): ColumnBuilder = {
+    addEpochTimestampNano(columnName, false)
+  }
+
+  def addEpochTimestampNano(columnName: String, isEditable: Boolean): ColumnBuilder = {
+    columns += (columnName + ":EpochTimestampNano:" + isEditable)
+    this
+  }
+
   def addScaledDecimal2(columnName: String): ColumnBuilder = {
     addScaledDecimal2(columnName, false)
   }

--- a/vuu/src/main/scala/org/finos/vuu/core/filter/FilterClause.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/filter/FilterClause.scala
@@ -6,7 +6,7 @@ import org.finos.vuu.core.filter.FilterClause.joinResults
 import org.finos.vuu.core.index.*
 import org.finos.vuu.core.table.column.{Error, Result}
 import org.finos.vuu.core.table.datatype.Scale.{Eight, Four, Six, Two}
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{RowData, TablePrimaryKeys}
 import org.finos.vuu.feature.inmem.InMemTablePrimaryKeys
 import org.finos.vuu.viewport.{RowSource, ViewPortColumns}
@@ -177,6 +177,7 @@ case class InClause(columnName: String, values: Set[String]) extends RowFilterCl
   private lazy val booleanValues = values.map(s => s.equalsIgnoreCase("true"))
   private lazy val charValues = values.map(s => s.charAt(0))
   private lazy val epochTimestampValues = values.map(s => EpochTimestamp(s.toLong))
+  private lazy val epochTimestampNanoValues = values.map(s => EpochTimestampNano(s.toLong))
   private lazy val scaledDecimal2Values = values.map(s => ScaledDecimal(s, Two))
   private lazy val scaledDecimal4Values = values.map(s => ScaledDecimal(s, Four))
   private lazy val scaledDecimal6Values = values.map(s => ScaledDecimal(s, Six))
@@ -190,6 +191,7 @@ case class InClause(columnName: String, values: Set[String]) extends RowFilterCl
       case d: Double => doubleValues.contains(d)
       case b: Boolean => booleanValues.contains(b)
       case e: EpochTimestamp => epochTimestampValues.contains(e)
+      case en: EpochTimestampNano => epochTimestampNanoValues.contains(en)
       case sd2: ScaledDecimal2 => scaledDecimal2Values.contains(sd2)
       case sd4: ScaledDecimal4 => scaledDecimal4Values.contains(sd4)
       case sd6: ScaledDecimal6 => scaledDecimal6Values.contains(sd6)
@@ -203,18 +205,19 @@ case class InClause(columnName: String, values: Set[String]) extends RowFilterCl
                          viewPortColumns: ViewPortColumns, firstInChain: Boolean): Iterable[String] = {
     val column = rows.asTable.columnForName(columnName)
     rows.asTable.indexForColumn(column) match {
-      case Some(ix: StringIndexedField)          => hitIndex(rowKeys, values, ix, firstInChain)
-      case Some(ix: DoubleIndexedField)          => hitIndex(rowKeys, doubleValues, ix, firstInChain)
-      case Some(ix: IntIndexedField)             => hitIndex(rowKeys, intValues, ix, firstInChain)
-      case Some(ix: LongIndexedField)            => hitIndex(rowKeys, longValues, ix, firstInChain)
-      case Some(ix: BooleanIndexedField)         => hitIndex(rowKeys, booleanValues, ix, firstInChain)
-      case Some(ix: EpochTimestampIndexedField)  => hitIndex(rowKeys, epochTimestampValues, ix, firstInChain)
-      case Some(ix: CharIndexedField)            => hitIndex(rowKeys, charValues, ix, firstInChain)
-      case Some(ix: ScaledDecimal2IndexedField)  => hitIndex(rowKeys, scaledDecimal2Values, ix, firstInChain)
-      case Some(ix: ScaledDecimal4IndexedField)  => hitIndex(rowKeys, scaledDecimal4Values, ix, firstInChain)
-      case Some(ix: ScaledDecimal6IndexedField)  => hitIndex(rowKeys, scaledDecimal6Values, ix, firstInChain)
-      case Some(ix: ScaledDecimal8IndexedField)  => hitIndex(rowKeys, scaledDecimal8Values, ix, firstInChain)
-      case _                                     => super.filterAll(rows, rowKeys, viewPortColumns, firstInChain)
+      case Some(ix: StringIndexedField) => hitIndex(rowKeys, values, ix, firstInChain)
+      case Some(ix: DoubleIndexedField) => hitIndex(rowKeys, doubleValues, ix, firstInChain)
+      case Some(ix: IntIndexedField) => hitIndex(rowKeys, intValues, ix, firstInChain)
+      case Some(ix: LongIndexedField) => hitIndex(rowKeys, longValues, ix, firstInChain)
+      case Some(ix: BooleanIndexedField) => hitIndex(rowKeys, booleanValues, ix, firstInChain)
+      case Some(ix: EpochTimestampIndexedField) => hitIndex(rowKeys, epochTimestampValues, ix, firstInChain)
+      case Some(ix: EpochTimestampNanoIndexedField) => hitIndex(rowKeys, epochTimestampNanoValues, ix, firstInChain)
+      case Some(ix: CharIndexedField) => hitIndex(rowKeys, charValues, ix, firstInChain)
+      case Some(ix: ScaledDecimal2IndexedField) => hitIndex(rowKeys, scaledDecimal2Values, ix, firstInChain)
+      case Some(ix: ScaledDecimal4IndexedField) => hitIndex(rowKeys, scaledDecimal4Values, ix, firstInChain)
+      case Some(ix: ScaledDecimal6IndexedField) => hitIndex(rowKeys, scaledDecimal6Values, ix, firstInChain)
+      case Some(ix: ScaledDecimal8IndexedField) => hitIndex(rowKeys, scaledDecimal8Values, ix, firstInChain)
+      case _ => super.filterAll(rows, rowKeys, viewPortColumns, firstInChain)
     }
   }
 
@@ -233,6 +236,7 @@ case class EqualsClause(columnName: String, value: String) extends RowFilterClau
   private lazy val booleanValue = value.equalsIgnoreCase("true")
   private lazy val charValue = value.charAt(0)
   private lazy val epochTimestampValue = EpochTimestamp(value.toLong)
+  private lazy val epochTimestampNanoValue = EpochTimestampNano(value.toLong)
   private lazy val scaledDecimal2Value = ScaledDecimal(value, Two)
   private lazy val scaledDecimal4Value = ScaledDecimal(value, Four)
   private lazy val scaledDecimal6Value = ScaledDecimal(value, Six)
@@ -246,6 +250,7 @@ case class EqualsClause(columnName: String, value: String) extends RowFilterClau
       case d: Double => d == doubleValue
       case b: Boolean => b == booleanValue
       case e: EpochTimestamp => e.millis == epochTimestampValue.millis
+      case en: EpochTimestampNano => en.nanos == epochTimestampNanoValue.nanos
       case sd2: ScaledDecimal2 => sd2.scaledValue == scaledDecimal2Value.scaledValue
       case sd4: ScaledDecimal4 => sd4.scaledValue == scaledDecimal4Value.scaledValue
       case sd6: ScaledDecimal6 => sd6.scaledValue == scaledDecimal6Value.scaledValue
@@ -259,18 +264,19 @@ case class EqualsClause(columnName: String, value: String) extends RowFilterClau
                          viewPortColumns: ViewPortColumns, firstInChain: Boolean): Iterable[String] = {
     val column = rows.asTable.columnForName(columnName)
     rows.asTable.indexForColumn(column) match {
-      case Some(ix: StringIndexedField)          => hitIndex(rowKeys, value, ix, firstInChain)
-      case Some(ix: DoubleIndexedField)          => hitIndex(rowKeys, doubleValue, ix, firstInChain)
-      case Some(ix: IntIndexedField)             => hitIndex(rowKeys, intValue, ix, firstInChain)
-      case Some(ix: LongIndexedField)            => hitIndex(rowKeys, longValue, ix, firstInChain)
-      case Some(ix: BooleanIndexedField)         => hitIndex(rowKeys, booleanValue, ix, firstInChain)
-      case Some(ix: EpochTimestampIndexedField)  => hitIndex(rowKeys, epochTimestampValue, ix, firstInChain)
-      case Some(ix: CharIndexedField)            => hitIndex(rowKeys, charValue, ix, firstInChain)
-      case Some(ix: ScaledDecimal2IndexedField)  => hitIndex(rowKeys, scaledDecimal2Value, ix, firstInChain)
-      case Some(ix: ScaledDecimal4IndexedField)  => hitIndex(rowKeys, scaledDecimal4Value, ix, firstInChain)
-      case Some(ix: ScaledDecimal6IndexedField)  => hitIndex(rowKeys, scaledDecimal6Value, ix, firstInChain)
-      case Some(ix: ScaledDecimal8IndexedField)  => hitIndex(rowKeys, scaledDecimal8Value, ix, firstInChain)
-      case _                                     => super.filterAll(rows, rowKeys, viewPortColumns, firstInChain)
+      case Some(ix: StringIndexedField) => hitIndex(rowKeys, value, ix, firstInChain)
+      case Some(ix: DoubleIndexedField) => hitIndex(rowKeys, doubleValue, ix, firstInChain)
+      case Some(ix: IntIndexedField) => hitIndex(rowKeys, intValue, ix, firstInChain)
+      case Some(ix: LongIndexedField) => hitIndex(rowKeys, longValue, ix, firstInChain)
+      case Some(ix: BooleanIndexedField) => hitIndex(rowKeys, booleanValue, ix, firstInChain)
+      case Some(ix: EpochTimestampIndexedField) => hitIndex(rowKeys, epochTimestampValue, ix, firstInChain)
+      case Some(ix: EpochTimestampNanoIndexedField) => hitIndex(rowKeys, epochTimestampNanoValue, ix, firstInChain)
+      case Some(ix: CharIndexedField) => hitIndex(rowKeys, charValue, ix, firstInChain)
+      case Some(ix: ScaledDecimal2IndexedField) => hitIndex(rowKeys, scaledDecimal2Value, ix, firstInChain)
+      case Some(ix: ScaledDecimal4IndexedField) => hitIndex(rowKeys, scaledDecimal4Value, ix, firstInChain)
+      case Some(ix: ScaledDecimal6IndexedField) => hitIndex(rowKeys, scaledDecimal6Value, ix, firstInChain)
+      case Some(ix: ScaledDecimal8IndexedField) => hitIndex(rowKeys, scaledDecimal8Value, ix, firstInChain)
+      case _ => super.filterAll(rows, rowKeys, viewPortColumns, firstInChain)
     }
   }
 
@@ -319,6 +325,7 @@ private abstract class NumericComparisonClause(val columnName: String, val value
   private lazy val longValue: Long = value.toLong
   private lazy val doubleValue: Double = value.toDouble
   private lazy val epochTimestampValue = EpochTimestamp(value.toLong)
+  private lazy val epochTimestampNanoValue = EpochTimestampNano(value.toLong)
   private lazy val scaledDecimal2Value = ScaledDecimal(value, Two)
   private lazy val scaledDecimal4Value = ScaledDecimal(value, Four)
   private lazy val scaledDecimal6Value = ScaledDecimal(value, Six)
@@ -330,30 +337,32 @@ private abstract class NumericComparisonClause(val columnName: String, val value
   protected def indexOp[T](index: IndexedField[T], value: T): ImmutableArraySet[String]
 
   override def applyFilter(datum: Any): Boolean = datum match {
-    case d: Double         => compareDouble(doubleValue, d)
-    case i: Int            => compareInt(intValue, i)
-    case l: Long           => compareLong(longValue, l)
+    case d: Double => compareDouble(doubleValue, d)
+    case i: Int => compareInt(intValue, i)
+    case l: Long => compareLong(longValue, l)
     case e: EpochTimestamp => compareLong(epochTimestampValue.millis, e.millis)
+    case en: EpochTimestampNano => compareLong(epochTimestampNanoValue.nanos, en.nanos)
     case sd2: ScaledDecimal2 => compareLong(scaledDecimal2Value.scaledValue, sd2.scaledValue)
     case sd4: ScaledDecimal4 => compareLong(scaledDecimal4Value.scaledValue, sd4.scaledValue)
     case sd6: ScaledDecimal6 => compareLong(scaledDecimal6Value.scaledValue, sd6.scaledValue)
     case sd8: ScaledDecimal8 => compareLong(scaledDecimal8Value.scaledValue, sd8.scaledValue)
-    case _                 => false
+    case _ => false
   }
 
   override def filterAll(rows: RowSource, rowKeys: Iterable[String],
                          viewPortColumns: ViewPortColumns, firstInChain: Boolean): Iterable[String] = {
     val column = rows.asTable.columnForName(columnName)
     rows.asTable.indexForColumn(column) match {
-      case Some(ix: DoubleIndexedField)         => hitIndex(rowKeys, doubleValue, ix, firstInChain)
-      case Some(ix: IntIndexedField)            => hitIndex(rowKeys, intValue, ix, firstInChain)
-      case Some(ix: LongIndexedField)           => hitIndex(rowKeys, longValue, ix, firstInChain)
+      case Some(ix: DoubleIndexedField) => hitIndex(rowKeys, doubleValue, ix, firstInChain)
+      case Some(ix: IntIndexedField) => hitIndex(rowKeys, intValue, ix, firstInChain)
+      case Some(ix: LongIndexedField) => hitIndex(rowKeys, longValue, ix, firstInChain)
       case Some(ix: EpochTimestampIndexedField) => hitIndex(rowKeys, epochTimestampValue, ix, firstInChain)
+      case Some(ix: EpochTimestampNanoIndexedField) => hitIndex(rowKeys, epochTimestampNanoValue, ix, firstInChain)
       case Some(ix: ScaledDecimal2IndexedField) => hitIndex(rowKeys, scaledDecimal2Value, ix, firstInChain)
       case Some(ix: ScaledDecimal4IndexedField) => hitIndex(rowKeys, scaledDecimal4Value, ix, firstInChain)
       case Some(ix: ScaledDecimal6IndexedField) => hitIndex(rowKeys, scaledDecimal6Value, ix, firstInChain)
       case Some(ix: ScaledDecimal8IndexedField) => hitIndex(rowKeys, scaledDecimal8Value, ix, firstInChain)
-      case _                                    => super.filterAll(rows, rowKeys, viewPortColumns, firstInChain)
+      case _ => super.filterAll(rows, rowKeys, viewPortColumns, firstInChain)
     }
   }
 

--- a/vuu/src/main/scala/org/finos/vuu/core/filter/type/PermissionFilter.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/filter/type/PermissionFilter.scala
@@ -3,8 +3,8 @@ package org.finos.vuu.core.filter.`type`
 import com.typesafe.scalalogging.{LazyLogging, StrictLogging}
 import org.finos.toolbox.collection.array.ImmutableArray
 import org.finos.vuu.core.filter.{CompoundFilter, Filter}
-import org.finos.vuu.core.index.{BooleanIndexedField, CharIndexedField, DoubleIndexedField, EpochTimestampIndexedField, IndexedField, IntIndexedField, LongIndexedField, ScaledDecimal2IndexedField, ScaledDecimal4IndexedField, ScaledDecimal6IndexedField, ScaledDecimal8IndexedField, StringIndexedField}
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.index.{BooleanIndexedField, CharIndexedField, DoubleIndexedField, EpochTimestampIndexedField, EpochTimestampNanoIndexedField, IndexedField, IntIndexedField, LongIndexedField, ScaledDecimal2IndexedField, ScaledDecimal4IndexedField, ScaledDecimal6IndexedField, ScaledDecimal8IndexedField, StringIndexedField}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{Column, DataType, EmptyTablePrimaryKeys, RowData, TablePrimaryKeys}
 import org.finos.vuu.feature.inmem.InMemTablePrimaryKeys
 import org.finos.vuu.viewport.{RowSource, ViewPortColumns}
@@ -62,6 +62,7 @@ private case class ContainsPermissionFilter(columnName: String, allowedValues: S
   private lazy val doubleValues = allowedValues.map(f => f.toDouble)
   private lazy val booleanValues = allowedValues.map(f => f.toBoolean)
   private lazy val epochTimestampValues = allowedValues.map(f => EpochTimestamp(f.toLong))
+  private lazy val epochTimestampNanoValues = allowedValues.map(f => EpochTimestampNano(f.toLong))
   private lazy val charValues = allowedValues.map(f => f.charAt(0))
   private lazy val scaledDecimal2Values = allowedValues.map(s => ScaledDecimal2(s.toLong))
   private lazy val scaledDecimal4Values = allowedValues.map(s => ScaledDecimal4(s.toLong))
@@ -89,6 +90,8 @@ private case class ContainsPermissionFilter(columnName: String, allowedValues: S
           hitIndex(primaryKeys, index, booleanValues, firstInChain)
         case Some(index: EpochTimestampIndexedField) =>
           hitIndex(primaryKeys, index, epochTimestampValues, firstInChain)
+        case Some(index: EpochTimestampNanoIndexedField) =>
+          hitIndex(primaryKeys, index, epochTimestampNanoValues, firstInChain)
         case Some(index: CharIndexedField) =>
           hitIndex(primaryKeys, index, charValues, firstInChain)
         case Some(index: ScaledDecimal2IndexedField) =>
@@ -131,6 +134,8 @@ private case class ContainsPermissionFilter(columnName: String, allowedValues: S
         applyFilter(source, primaryKeys, column, booleanValues)
       case DataType.EpochTimestampType =>
         applyFilter(source, primaryKeys, column, epochTimestampValues)
+      case DataType.EpochTimestampNanoType =>
+        applyFilter(source, primaryKeys, column, epochTimestampNanoValues)
       case DataType.CharDataType =>
         applyFilter(source, primaryKeys,column, charValues)
       case DataType.ScaledDecimal2Type =>

--- a/vuu/src/main/scala/org/finos/vuu/core/filter/type/VisualLinkedFilter.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/filter/type/VisualLinkedFilter.scala
@@ -3,8 +3,8 @@ package org.finos.vuu.core.filter.`type`
 import com.typesafe.scalalogging.LazyLogging
 import org.finos.toolbox.collection.array.ImmutableArray
 import org.finos.vuu.core.filter.ViewPortFilter
-import org.finos.vuu.core.index.{BooleanIndexedField, DoubleIndexedField, EpochTimestampIndexedField, IndexedField, IntIndexedField, LongIndexedField, ScaledDecimal2IndexedField, ScaledDecimal4IndexedField, ScaledDecimal6IndexedField, ScaledDecimal8IndexedField, StringIndexedField}
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.index.{BooleanIndexedField, DoubleIndexedField, EpochTimestampIndexedField, EpochTimestampNanoIndexedField, IndexedField, IntIndexedField, LongIndexedField, ScaledDecimal2IndexedField, ScaledDecimal4IndexedField, ScaledDecimal6IndexedField, ScaledDecimal8IndexedField, StringIndexedField}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{Column, DataType, EmptyTablePrimaryKeys, TablePrimaryKeys, ViewPortColumnCreator}
 import org.finos.vuu.feature.inmem.InMemTablePrimaryKeys
 import org.finos.vuu.viewport.{RowSource, ViewPortColumns, ViewPortVisualLink}
@@ -51,6 +51,9 @@ case class VisualLinkedFilter(viewPortVisualLink: ViewPortVisualLink) extends Vi
         case Some(index: EpochTimestampIndexedField) if childColumn.dataType == DataType.EpochTimestampType =>
           val parentSelField = parentSelectionKeys.map(key => viewPortVisualLink.parentVp.table.pullRow(key).get(parentColumn).asInstanceOf[EpochTimestamp])
           filterIndexByValues(index, parentSelField)
+        case Some(index: EpochTimestampNanoIndexedField) if childColumn.dataType == DataType.EpochTimestampNanoType =>
+          val parentSelField = parentSelectionKeys.map(key => viewPortVisualLink.parentVp.table.pullRow(key).get(parentColumn).asInstanceOf[EpochTimestampNano])
+          filterIndexByValues(index, parentSelField)  
         case Some(index: ScaledDecimal2IndexedField) if childColumn.dataType == DataType.ScaledDecimal2Type =>
           val parentSelField = parentSelectionKeys.map(key => viewPortVisualLink.parentVp.table.pullRow(key).get(parentColumn).asInstanceOf[ScaledDecimal2])
           filterIndexByValues(index, parentSelField)

--- a/vuu/src/main/scala/org/finos/vuu/core/index/InMemColumnIndices.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/index/InMemColumnIndices.scala
@@ -1,7 +1,7 @@
 package org.finos.vuu.core.index
 
 import org.finos.vuu.api.TableDef
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{Column, DataType, RowData}
 
 trait InMemColumnIndices {
@@ -41,6 +41,8 @@ object InMemColumnIndices {
         new SkipListIndexedBooleanField(c)
       case DataType.EpochTimestampType =>
         new SkipListIndexedEpochTimestampField(c)
+      case DataType.EpochTimestampNanoType =>
+        new SkipListIndexedEpochTimestampNanoField(c)
       case DataType.CharDataType =>
         new SkipListIndexedCharField(c)
       case DataType.ScaledDecimal2Type =>
@@ -75,6 +77,7 @@ object InMemColumnIndices {
           case DataType.DoubleDataType => create(index.asInstanceOf[IndexedField[Double]])
           case DataType.BooleanDataType => create(index.asInstanceOf[IndexedField[Boolean]])
           case DataType.EpochTimestampType => create(index.asInstanceOf[IndexedField[EpochTimestamp]])
+          case DataType.EpochTimestampNanoType => create(index.asInstanceOf[IndexedField[EpochTimestampNano]])
           case DataType.CharDataType => create(index.asInstanceOf[IndexedField[Char]])
           case DataType.ScaledDecimal2Type => create(index.asInstanceOf[IndexedField[ScaledDecimal2]])
           case DataType.ScaledDecimal4Type => create(index.asInstanceOf[IndexedField[ScaledDecimal4]])

--- a/vuu/src/main/scala/org/finos/vuu/core/index/IndexedField.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/index/IndexedField.scala
@@ -3,7 +3,7 @@ package org.finos.vuu.core.index
 import com.typesafe.scalalogging.StrictLogging
 import org.finos.toolbox.collection.set.ImmutableArraySet
 import org.finos.vuu.core.table.Column
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentNavigableMap, ConcurrentSkipListMap}
 import scala.jdk.CollectionConverters.*
@@ -57,6 +57,8 @@ trait StringIndexedField extends IndexedField[String]
 
 trait EpochTimestampIndexedField extends IndexedField[EpochTimestamp]
 
+trait EpochTimestampNanoIndexedField extends IndexedField[EpochTimestampNano]
+
 trait CharIndexedField extends IndexedField[Char]
 
 trait ScaledDecimal2IndexedField extends IndexedField[ScaledDecimal2]
@@ -66,6 +68,7 @@ trait ScaledDecimal4IndexedField extends IndexedField[ScaledDecimal4]
 trait ScaledDecimal6IndexedField extends IndexedField[ScaledDecimal6]
 
 trait ScaledDecimal8IndexedField extends IndexedField[ScaledDecimal8]
+
 
 class HashMapIndexedStringField(val column: Column) extends StringIndexedField with StrictLogging {
 
@@ -188,6 +191,8 @@ class SkipListIndexedLongField(column: Column) extends SkipListIndexedField[Long
 class SkipListIndexedBooleanField(column: Column) extends SkipListIndexedField[Boolean](column) with BooleanIndexedField {}
 
 class SkipListIndexedEpochTimestampField(column: Column) extends SkipListIndexedField[EpochTimestamp](column) with EpochTimestampIndexedField {}
+
+class SkipListIndexedEpochTimestampNanoField(column: Column) extends SkipListIndexedField[EpochTimestampNano](column) with EpochTimestampNanoIndexedField {}
 
 class SkipListIndexedCharField(column: Column) extends SkipListIndexedField[Char](column) with CharIndexedField {}
 

--- a/vuu/src/main/scala/org/finos/vuu/core/row/InMemMapRowBuilder.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/row/InMemMapRowBuilder.scala
@@ -1,6 +1,6 @@
 package org.finos.vuu.core.row
 
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal}
 import org.finos.vuu.core.table.{Column, RowData, RowWithData}
 
 import scala.collection.mutable
@@ -36,6 +36,11 @@ class InMemMapRowBuilder extends RowBuilder {
   }
 
   override def setEpochTimestamp(column: Column, v: EpochTimestamp): RowBuilder = {
+    mutableMap.update(column.name, v)
+    this
+  }
+
+  override def setEpochTimestampNano(column: Column, v: EpochTimestampNano): RowBuilder = {
     mutableMap.update(column.name, v)
     this
   }

--- a/vuu/src/main/scala/org/finos/vuu/core/row/RowBuilder.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/row/RowBuilder.scala
@@ -1,6 +1,6 @@
 package org.finos.vuu.core.row
 
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{Column, EmptyRowData, RowData}
 
 trait RowBuilder {
@@ -11,6 +11,7 @@ trait RowBuilder {
   def setString(column: Column, v: String): RowBuilder
   def setBoolean(column: Column, v: Boolean): RowBuilder
   def setEpochTimestamp(column: Column, v: EpochTimestamp): RowBuilder
+  def setEpochTimestampNano(column: Column, v: EpochTimestampNano): RowBuilder
   def setScaledDecimal(column: Column, v: ScaledDecimal): RowBuilder
   def setChar(column: Column, v: Char): RowBuilder
   def build: RowData
@@ -24,6 +25,7 @@ object NoRowBuilder extends RowBuilder {
   override def setString(column: Column, v: String): RowBuilder = this
   override def setBoolean(column: Column, v: Boolean): RowBuilder = this
   override def setEpochTimestamp(column: Column, v: EpochTimestamp): RowBuilder = this
+  override def setEpochTimestampNano(column: Column, v: EpochTimestampNano): RowBuilder = this
   override def setChar(column: Column, v: Char): RowBuilder = this
   override def setScaledDecimal(column: Column, v: ScaledDecimal): RowBuilder = this
   override def build: RowData = EmptyRowData

--- a/vuu/src/main/scala/org/finos/vuu/core/sort/SortProjection.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/sort/SortProjection.scala
@@ -26,7 +26,8 @@ object SortProjectionComparator extends StrictLogging {
       case DataType.StringDataType =>
         if (isAscending) StringColumnSortAsc(index) else StringColumnSortDesc(index)
       case DataType.LongDataType | DataType.IntegerDataType | DataType.DoubleDataType |
-           DataType.BooleanDataType | DataType.CharDataType | DataType.EpochTimestampType |
+           DataType.BooleanDataType | DataType.CharDataType |
+           DataType.EpochTimestampType | DataType.EpochTimestampNanoType |
            DataType.ScaledDecimal2Type | DataType.ScaledDecimal4Type |
            DataType.ScaledDecimal6Type | DataType.ScaledDecimal8Type =>
         if (isAscending) ComparableColumnSortAsc(index) else ComparableColumnSortDesc(index)

--- a/vuu/src/main/scala/org/finos/vuu/core/table/Column.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/Column.scala
@@ -3,7 +3,7 @@ package org.finos.vuu.core.table
 import com.typesafe.scalalogging.StrictLogging
 import org.finos.vuu.api.TableDef
 import org.finos.vuu.core.table.column.CalculatedColumnClause
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.util.schema.ExternalEntitySchema
 import org.finos.vuu.util.types.{DefaultTypeConverters, TypeConverterContainerBuilder}
 
@@ -19,6 +19,7 @@ object DataType {
   final val LongDataType: Class[Long] = classOf[Long]
   final val DoubleDataType: Class[Double] = classOf[Double]
   final val EpochTimestampType: Class[EpochTimestamp] = classOf[EpochTimestamp]
+  final val EpochTimestampNanoType: Class[EpochTimestampNano] = classOf[EpochTimestampNano]
   final val ScaledDecimal2Type: Class[ScaledDecimal2] = classOf[ScaledDecimal2]
   final val ScaledDecimal4Type: Class[ScaledDecimal4] = classOf[ScaledDecimal4]
   final val ScaledDecimal6Type: Class[ScaledDecimal6] = classOf[ScaledDecimal6]
@@ -34,6 +35,7 @@ object DataType {
       case "int" => IntegerDataType
       case "long" => LongDataType
       case "epochtimestamp" => EpochTimestampType
+      case "epochtimestampnano" => EpochTimestampNanoType
       case "scaleddecimal2" => ScaledDecimal2Type
       case "scaleddecimal4" => ScaledDecimal4Type
       case "scaleddecimal6" => ScaledDecimal6Type
@@ -45,6 +47,7 @@ object DataType {
     c.getTypeName match {
       case "java.lang.String" => "string"
       case "org.finos.vuu.core.table.datatype.EpochTimestamp" => "epochtimestamp"
+      case "org.finos.vuu.core.table.datatype.EpochTimestampNano" => "epochtimestampnano"
       case "org.finos.vuu.core.table.datatype.ScaledDecimal2" => "scaleddecimal2"
       case "org.finos.vuu.core.table.datatype.ScaledDecimal4" => "scaleddecimal4"
       case "org.finos.vuu.core.table.datatype.ScaledDecimal6" => "scaleddecimal6"
@@ -65,6 +68,7 @@ object DataType {
     .withConverter(DefaultTypeConverters.stringToLongConverter)
     .withConverter(DefaultTypeConverters.stringToDoubleConverter)
     .withConverter(DefaultTypeConverters.stringToEpochTimestampConverter)
+    .withConverter(DefaultTypeConverters.stringToEpochTimestampNanoConverter)
     .withConverter(DefaultTypeConverters.stringToScaledDecimal2Converter)
     .withConverter(DefaultTypeConverters.stringToScaledDecimal4Converter)
     .withConverter(DefaultTypeConverters.stringToScaledDecimal6Converter)

--- a/vuu/src/main/scala/org/finos/vuu/core/table/datatype/EpochTimestampNano.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/datatype/EpochTimestampNano.scala
@@ -1,0 +1,44 @@
+package org.finos.vuu.core.table.datatype
+
+import org.finos.toolbox.time.Clock
+
+import java.time.{Duration, Instant, ZonedDateTime}
+
+object EpochTimestampNano {
+
+  private val NANOS_IN_A_SECOND: Long = Duration.ofSeconds(1).toNanos
+  private val NANOS_IN_A_MILLI: Long = Duration.ofMillis(1).toNanos
+
+  def apply(): EpochTimestampNano = {
+    EpochTimestampNano(Instant.now())
+  }
+
+  def apply(clock: Clock): EpochTimestampNano = {
+    val nanos = clock.now() * NANOS_IN_A_MILLI
+    EpochTimestampNano(nanos)
+  }
+
+  def apply(instant: Instant): EpochTimestampNano = {
+    val nanos = (instant.getEpochSecond * NANOS_IN_A_SECOND) + instant.getNano
+    EpochTimestampNano(nanos)
+  }
+
+  def apply(zdt: ZonedDateTime): EpochTimestampNano = {
+    val nanos = (zdt.toEpochSecond * NANOS_IN_A_SECOND) + zdt.getNano
+    EpochTimestampNano(nanos)
+  }
+
+}
+
+/**
+ * A class representing an Instant in time
+ * @param nanos the number of nanoseconds since Jan 1st 1970 00:00:00 UTC
+ */
+case class EpochTimestampNano(nanos: Long) extends Ordered[EpochTimestampNano] {
+
+  override def toString: String = nanos.toString
+
+  override def compare(that: EpochTimestampNano): Int =  {
+    java.lang.Long.compare(nanos, that.nanos)
+  }
+}

--- a/vuu/src/main/scala/org/finos/vuu/net/json/mixin/RowUpdateMixin.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/json/mixin/RowUpdateMixin.scala
@@ -1,7 +1,7 @@
 package org.finos.vuu.net.json.mixin
 
 import com.typesafe.scalalogging.StrictLogging
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal}
 import org.finos.vuu.net.row.{RowUpdate, RowUpdateType}
 import org.finos.vuu.viewport.ViewPortMenu
 import tools.jackson.core.{JsonGenerator, JsonParser}
@@ -29,28 +29,40 @@ class RowUpdateSerializer extends StdSerializer[RowUpdate](classOf[ViewPortMenu]
     gen.writeNumberProperty("ts", value.ts)
     gen.writeNumberProperty("sel", value.selected)
     gen.writeStringProperty("vpVersion", value.vpVersion)
-    gen.writeArrayPropertyStart("data")
 
-    value.data.zipWithIndex.foreach {
+    gen.writeArrayPropertyStart("data")
+    val data = value.data
+    val totalElements = data.length
+    var index = 0
+    while (index < totalElements) {
+      val element = data(index)
+      writeElement(gen, element, index)
+      index += 1
+    }
+    gen.writeEndArray()
+
+    gen.writeEndObject()
+  }
+
+  private def writeElement(gen: JsonGenerator, element: Any, index: Int): Unit = {
+    element match {
       case null => gen.writeString("")
-      case (null, _) => gen.writeString("")
-      case (None, _) => gen.writeString("")
-      case (s: String, _) => gen.writeString(s)
-      case (i: Int, _) => gen.writeNumber(i)
-      case (d: Double, _) => gen.writeNumber(d)
-      case (l: Long, _) => gen.writeString(l.toString)
-      case (b: Boolean, _) => gen.writeBoolean(b)
-      case (c: Char, _) => gen.writeString(c.toString)
-      case (epoch: EpochTimestamp, _) => gen.writeNumber(epoch.millis)
-      case (scaledDecimal: ScaledDecimal, _) => gen.writeString(scaledDecimal.scaledValue.toString)
-      case (unknown: Any, index) =>
+      case None => gen.writeString("")
+      case s: String => gen.writeString(s)
+      case i: Int => gen.writeNumber(i)
+      case d: Double => gen.writeNumber(d)
+      case l: Long => gen.writeString(l.toString)
+      case b: Boolean => gen.writeBoolean(b)
+      case c: Char => gen.writeString(c.toString)
+      case epoch: EpochTimestamp => gen.writeNumber(epoch.millis)
+      case epoch: EpochTimestampNano => gen.writeString(epoch.nanos.toString)
+      case scaledDecimal: ScaledDecimal => gen.writeString(scaledDecimal.scaledValue.toString)
+      case unknown: Any =>
         logger.warn(s"Unexpected type ${unknown.getClass} at index $index")
         gen.writeString("")
     }
-
-    gen.writeEndArray()
-    gen.writeEndObject()
   }
+
 }
 
 class RowUpdateDeserializer extends StdDeserializer[RowUpdate](classOf[RowUpdate]) {

--- a/vuu/src/main/scala/org/finos/vuu/util/types/DefaultTypeConverters.scala
+++ b/vuu/src/main/scala/org/finos/vuu/util/types/DefaultTypeConverters.scala
@@ -1,6 +1,6 @@
 package org.finos.vuu.util.types
 
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 
 import java.lang.*
 
@@ -11,6 +11,7 @@ object DefaultTypeConverters {
   val stringToCharConverter: TypeConverter[String, Character] = TypeConverter(classOf[String], classOf[Character], withNullSafety[String, Character](_, _.toCharArray.apply(0)))
   val stringToBooleanConverter: TypeConverter[String, Boolean] = TypeConverter(classOf[String], classOf[Boolean], withNullSafety[String, Boolean](_, _.toBoolean))
   val stringToEpochTimestampConverter: TypeConverter[String, EpochTimestamp] = TypeConverter(classOf[String], classOf[EpochTimestamp], withNullSafety[String, EpochTimestamp](_, f => EpochTimestamp(f.toLong)))
+  val stringToEpochTimestampNanoConverter: TypeConverter[String, EpochTimestampNano] = TypeConverter(classOf[String], classOf[EpochTimestampNano], withNullSafety[String, EpochTimestampNano](_, f => EpochTimestampNano(f.toLong)))
   val stringToScaledDecimal2Converter: TypeConverter[String, ScaledDecimal2] = TypeConverter(classOf[String], classOf[ScaledDecimal2], withNullSafety[String, ScaledDecimal2](_, f => ScaledDecimal2(f.toLong)))
   val stringToScaledDecimal4Converter: TypeConverter[String, ScaledDecimal4] = TypeConverter(classOf[String], classOf[ScaledDecimal4], withNullSafety[String, ScaledDecimal4](_, f => ScaledDecimal4(f.toLong)))
   val stringToScaledDecimal6Converter: TypeConverter[String, ScaledDecimal6] = TypeConverter(classOf[String], classOf[ScaledDecimal6], withNullSafety[String, ScaledDecimal6](_, f => ScaledDecimal6(f.toLong)))
@@ -33,6 +34,7 @@ object DefaultTypeConverters {
   val charToStringConverter: TypeConverter[Character, String] = TypeConverter(classOf[Character], classOf[String], withNullSafety[Character, String](_, _.toString))
 
   val epochTimestampToStringConverter : TypeConverter[EpochTimestamp, String] = TypeConverter(classOf[EpochTimestamp], classOf[String], withNullSafety[EpochTimestamp, String](_, _.toString))
+  val epochTimestampNanoToStringConverter: TypeConverter[EpochTimestampNano, String] = TypeConverter(classOf[EpochTimestampNano], classOf[String], withNullSafety[EpochTimestampNano, String](_, _.toString))
 
   val scaledDecimalToStringConverter : TypeConverter[ScaledDecimal, String] = TypeConverter(classOf[ScaledDecimal], classOf[String], withNullSafety[ScaledDecimal, String](_, _.toString))
 

--- a/vuu/src/test/scala/org/finos/vuu/api/ColumnBuilderTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/api/ColumnBuilderTest.scala
@@ -18,6 +18,7 @@ class ColumnBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen 
       ("Boolean", (cb: ColumnBuilder, n: String) => cb.addBoolean(n), ":Boolean"),
       ("Char", (cb: ColumnBuilder, n: String) => cb.addChar(n), ":Char"),
       ("EpochTimestamp", (cb: ColumnBuilder, n: String) => cb.addEpochTimestamp(n), ":EpochTimestamp"),
+      ("EpochTimestampNano", (cb: ColumnBuilder, n: String) => cb.addEpochTimestampNano(n), ":EpochTimestampNano"),
       ("ScaledDecimal2", (cb: ColumnBuilder, n: String) => cb.addScaledDecimal2(n), ":ScaledDecimal2"),
       ("ScaledDecimal4", (cb: ColumnBuilder, n: String) => cb.addScaledDecimal4(n), ":ScaledDecimal4"),
       ("ScaledDecimal6", (cb: ColumnBuilder, n: String) => cb.addScaledDecimal6(n), ":ScaledDecimal6"),
@@ -61,41 +62,43 @@ class ColumnBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen 
       result should have size 3
       result.map(_.name) should contain theSameElementsInOrderAs Seq("name", "age", "salary")
     }
-  }
 
-  Scenario("Create editable columns") {
-    val columns = Table(
-      ("Type Description", "Builder Method"),
-      ("String", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addString(n, isEditable)),
-      ("Double", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addDouble(n, isEditable)),
-      ("Int", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addInt(n, isEditable)),
-      ("Long", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addLong(n, isEditable)),
-      ("Boolean", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addBoolean(n, isEditable)),
-      ("Char", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addChar(n, isEditable)),
-      ("EpochTimestamp", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addEpochTimestamp(n, isEditable)),
-      ("ScaledDecimal2", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addScaledDecimal2(n, isEditable)),
-      ("ScaledDecimal4", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addScaledDecimal4(n, isEditable)),
-      ("ScaledDecimal6", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addScaledDecimal6(n, isEditable)),
-      ("ScaledDecimal8", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addScaledDecimal8(n, isEditable))
-    )
+    Scenario("Create editable columns") {
+      val columns = Table(
+        ("Type Description", "Builder Method"),
+        ("String", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addString(n, isEditable)),
+        ("Double", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addDouble(n, isEditable)),
+        ("Int", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addInt(n, isEditable)),
+        ("Long", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addLong(n, isEditable)),
+        ("Boolean", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addBoolean(n, isEditable)),
+        ("Char", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addChar(n, isEditable)),
+        ("EpochTimestamp", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addEpochTimestamp(n, isEditable)),
+        ("EpochTimestampNano", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addEpochTimestampNano(n, isEditable)),
+        ("ScaledDecimal2", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addScaledDecimal2(n, isEditable)),
+        ("ScaledDecimal4", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addScaledDecimal4(n, isEditable)),
+        ("ScaledDecimal6", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addScaledDecimal6(n, isEditable)),
+        ("ScaledDecimal8", (cb: ColumnBuilder, n: String, isEditable: Boolean) => cb.addScaledDecimal8(n, isEditable))
+      )
 
-    forAll(columns) { (typeDesc, addFunc) =>
+      forAll(columns) { (typeDesc, addFunc) =>
 
-      Given(s"a new ColumnBuilder and a column named 'testCol'")
-      val builder = new ColumnBuilder()
+        Given(s"a new ColumnBuilder and a column named 'testCol'")
+        val builder = new ColumnBuilder()
 
-      When(s"the $typeDesc column is added")
-      addFunc(builder, "c1", true)
-      addFunc(builder, "c2", false)
+        When(s"the $typeDesc column is added")
+        addFunc(builder, "c1", true)
+        addFunc(builder, "c2", false)
 
-      And("building should produce an array of Columns")
-      val result = builder.build()
-      result should not be null
-      result.length shouldBe 2
-      result(0).name shouldBe "c1"
-      result(0).isEditable shouldBe true
-      result(1).name shouldBe "c2"
-      result(1).isEditable shouldBe false
+        And("building should produce an array of Columns")
+        val result = builder.build()
+        result should not be null
+        result.length shouldBe 2
+        result(0).name shouldBe "c1"
+        result(0).isEditable shouldBe true
+        result(1).name shouldBe "c2"
+        result(1).isEditable shouldBe false
+      }
     }
+
   }
 }

--- a/vuu/src/test/scala/org/finos/vuu/core/filter/FilterClauseTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/filter/FilterClauseTest.scala
@@ -1,7 +1,7 @@
 package org.finos.vuu.core.filter
 
 import org.finos.vuu.core.table.datatype.Scale.{Four, Two}
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, Scale, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, Scale, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{RowWithData, SimpleColumn}
 import org.finos.vuu.viewport.ViewPortColumns
 import org.scalatest.GivenWhenThen
@@ -29,6 +29,7 @@ class FilterClauseTest extends AnyFeatureSpec with Matchers with GivenWhenThen w
       "false-col" -> false,
       "empty-string-col" -> "",
       "epoch-column" -> EpochTimestamp(1L),
+      "epochNano-column" -> EpochTimestampNano(10L),
       "scaled2-column" -> ScaledDecimal("2.22", Scale.Two),
       "scaled4-column" -> ScaledDecimal("4.4444", Scale.Four),
       "scaled6-column" -> ScaledDecimal("6.666666", Scale.Six),
@@ -52,6 +53,8 @@ class FilterClauseTest extends AnyFeatureSpec with Matchers with GivenWhenThen w
         ("Boolean", "true-col", "false", false),
         ("EpochTimestamp", "epoch-column", "1", true),
         ("EpochTimestamp", "epoch-column", "2", false),
+        ("EpochTimestampNano", "epochNano-column", "10", true),
+        ("EpochTimestampNano", "epochNano-column", "20", false),
         ("ScaledDecimal2", "scaled2-column", "2.22", true),
         ("ScaledDecimal2", "scaled2-column", "3.99", false),
         ("ScaledDecimal4", "scaled4-column", "4.4444", true),
@@ -333,6 +336,30 @@ class FilterClauseTest extends AnyFeatureSpec with Matchers with GivenWhenThen w
         (LessThanOrEqualsClause.apply _, "9", EpochTimestamp(10L), false, "LessThanOrEquals: Higher"),
         (LessThanOrEqualsClause.apply _, "11", EpochTimestamp(10L), true, "LessThanOrEquals: Lower"),
         (LessThanOrEqualsClause.apply _, "10", EpochTimestamp(10L), true, "LessThanOrEquals: Equal"),
+      )
+
+      forAll(comparisonTable) { (constructor, filterStr, datum, expected, description) =>
+        performValidation(constructor, filterStr, datum, expected, description)
+      }
+
+    }
+
+    Scenario("Validating EpochTimestampNano across all clauses") {
+
+      val comparisonTable = Table(
+        ("Clause Factory", "Filter Val", "Input Datum", "Expected", "Type Description"),
+        (GreaterThanClause.apply _, "9", EpochTimestampNano(10L), true, "GreaterThan: Higher"),
+        (GreaterThanClause.apply _, "11", EpochTimestampNano(10L), false, "GreaterThan: Lower"),
+        (GreaterThanClause.apply _, "10", EpochTimestampNano(10L), false, "GreaterThan: Equal"),
+        (GreaterThanOrEqualsClause.apply _, "9", EpochTimestampNano(10L), true, "GreaterThanOrEquals: Higher"),
+        (GreaterThanOrEqualsClause.apply _, "11", EpochTimestampNano(10L), false, "GreaterThanOrEquals: Lower"),
+        (GreaterThanOrEqualsClause.apply _, "10", EpochTimestampNano(10L), true, "GreaterThanOrEquals: Equal"),
+        (LessThanClause.apply _, "9", EpochTimestampNano(10L), false, "LessThan: Higher"),
+        (LessThanClause.apply _, "11", EpochTimestampNano(10L), true, "LessThan: Lower"),
+        (LessThanClause.apply _, "10", EpochTimestampNano(10L), false, "LessThan: Equal"),
+        (LessThanOrEqualsClause.apply _, "9", EpochTimestampNano(10L), false, "LessThanOrEquals: Higher"),
+        (LessThanOrEqualsClause.apply _, "11", EpochTimestampNano(10L), true, "LessThanOrEquals: Lower"),
+        (LessThanOrEqualsClause.apply _, "10", EpochTimestampNano(10L), true, "LessThanOrEquals: Equal"),
       )
 
       forAll(comparisonTable) { (constructor, filterStr, datum, expected, description) =>

--- a/vuu/src/test/scala/org/finos/vuu/core/filter/type/PermissionFilterTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/filter/type/PermissionFilterTest.scala
@@ -444,7 +444,7 @@ class PermissionFilterTest extends AnyFeatureSpec with Matchers {
 
   }
 
-  Feature("Contains filter - Epoch Timestamp") {
+  Feature("Contains filter - EpochTimestamp") {
 
     Scenario("Contains filter with no index") {
       val clock = TestFriendlyClock(1000L)
@@ -489,6 +489,54 @@ class PermissionFilterTest extends AnyFeatureSpec with Matchers {
       val filter = PermissionFilter(DefaultColumn.CreatedTime.name, Set(now.toString))
 
       val result = filter.doFilter(table, InMemTablePrimaryKeys(ImmutableArray.from(Array("LDN-0001", "LDN-0003", "NYC-0002", "NYC-0004"))), false)
+
+      result.size shouldEqual 1
+      result.toSet shouldEqual Set("LDN-0001")
+    }
+
+  }
+
+  Feature("Contains filter - EpochTimestampNano") {
+
+    Scenario("Contains filter with no index") {
+      val clock = TestFriendlyClock(1000L)
+      val table = setupTableWithCreationTime(List())(using clock)
+      val filter = PermissionFilter("nano", Set(1111.toString))
+
+      val result = filter.doFilter(table, table.primaryKeys, true)
+
+      result.size shouldEqual 2
+      result.toSet shouldEqual Set("LDN-0001", "NYC-0004")
+    }
+
+    Scenario("Contains filter with no index, not first in chain") {
+      val clock = TestFriendlyClock(1000L)
+      val table = setupTableWithCreationTime(List())(using clock)
+      val filter = PermissionFilter("nano", Set(1111.toString))
+
+      val result = filter.doFilter(table, InMemTablePrimaryKeys(ImmutableArray.from(Array("LDN-0001", "LDN-0003"))), false)
+
+      result.size shouldEqual 1
+      result.toSet shouldEqual Set("LDN-0001")
+    }
+
+    Scenario("Contains filter with index") {
+      val clock = new TestFriendlyClock(1000L)
+      val table = setupTableWithCreationTime(List("nano"))(using clock)
+      val filter = PermissionFilter("nano", Set(1111.toString))
+
+      val result = filter.doFilter(table, table.primaryKeys, true)
+
+      result.size shouldEqual 2
+      result.toSet shouldEqual Set("LDN-0001", "NYC-0004")
+    }
+
+    Scenario("Contains filter with index, not first in chain") {
+      val clock = new TestFriendlyClock(1000L)
+      val table = setupTableWithCreationTime(List("nano"))(using clock)
+      val filter = PermissionFilter("nano", Set(1111.toString))
+
+      val result = filter.doFilter(table, InMemTablePrimaryKeys(ImmutableArray.from(Array("LDN-0001", "LDN-0003"))), false)
 
       result.size shouldEqual 1
       result.toSet shouldEqual Set("LDN-0001")

--- a/vuu/src/test/scala/org/finos/vuu/core/index/InMemColumnIndicesTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/index/InMemColumnIndicesTest.scala
@@ -1,7 +1,7 @@
 package org.finos.vuu.core.index
 
 import org.finos.vuu.api.{Index, Indices, TableDef}
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.core.table.{Column, DataType, RowData, RowWithData, SimpleColumn}
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
@@ -336,6 +336,42 @@ class InMemColumnIndicesTest extends AnyFeatureSpec with Matchers with TableDriv
       result6.length shouldEqual 0
     }
 
+    Scenario("Correctly route data through IndexUpdaters for EpochTimestampNano") {
+      val (column, indices) = createIndices("testCol", DataType.EpochTimestampNanoType)
+      val rowKey = "row-1"
+      val indexField = indices.indexForColumn(column).get.asInstanceOf[IndexedField[EpochTimestampNano]]
+
+      // 1. Insert
+      indices.insert(createRow(rowKey, column, EpochTimestampNano(1L)))
+      val result = indexField.find(EpochTimestampNano(1L))
+      result.length shouldEqual 1
+      result.head shouldEqual rowKey
+
+      // 2. Update to new value
+      indices.update(createRow(rowKey, column, EpochTimestampNano(1L)), createRow(rowKey, column, EpochTimestampNano(2L)))
+      val result2 = indexField.find(EpochTimestampNano(1L))
+      result2.length shouldEqual 0
+      val result3 = indexField.find(EpochTimestampNano(2L))
+      result3.length shouldEqual 1
+      result3.head shouldEqual rowKey
+
+      // 3. Update to null
+      indices.update(createRow(rowKey, column, EpochTimestampNano(2L)), createRow(rowKey, column, null))
+      val result4 = indexField.find(EpochTimestampNano(2L))
+      result4.length shouldEqual 0
+
+      // 4. Update from null to value
+      indices.update(createRow(rowKey, column, null), createRow(rowKey, column, EpochTimestampNano(3L)))
+      val result5 = indexField.find(EpochTimestampNano(3L))
+      result5.length shouldEqual 1
+      result5.head shouldEqual rowKey
+
+      // 5. Remove
+      indices.remove(createRow(rowKey, column, EpochTimestampNano(3L)))
+      val result6 = indexField.find(EpochTimestampNano(3L))
+      result6.length shouldEqual 0
+    }
+    
     Scenario("Correctly route data through IndexUpdaters for ScaledDecimal") {
       val scaledDecimalVariants = Table(
         ("typeName", "dataType", "factory"),

--- a/vuu/src/test/scala/org/finos/vuu/core/index/IndexedFieldTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/index/IndexedFieldTest.scala
@@ -1,7 +1,7 @@
 package org.finos.vuu.core.index
 
 import com.typesafe.scalalogging.StrictLogging
-import org.finos.vuu.core.table.datatype.EpochTimestamp
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano}
 import org.finos.vuu.core.table.{DataType, SimpleColumn}
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
@@ -166,5 +166,59 @@ class IndexedFieldTest extends AnyFeatureSpec with Matchers with StrictLogging {
       values.toSet shouldEqual Set("20", "21", "22", "23", "24", "25", "10", "11", "12", "13", "14", "15")
 
     }
+
+    Scenario("Create a EpochTimestampNano based index using SkipList") {
+
+      val index = new SkipListIndexedEpochTimestampNanoField(SimpleColumn("Timestamp", 0, DataType.EpochTimestampNanoType))
+
+      val times = List(EpochTimestampNano(1), EpochTimestampNano(2), EpochTimestampNano(3), EpochTimestampNano(4), EpochTimestampNano(5), EpochTimestampNano(6))
+
+      times.foreach(time => {
+        (0 to 5).foreach(i => index.insert(time, time.toString + i.toString))
+      })
+
+      val values = index.find(EpochTimestampNano(1))
+
+      values.toList shouldEqual List("10", "11", "12", "13", "14", "15")
+
+      index.remove(EpochTimestampNano(1), "15")
+
+      val values2 = index.find(EpochTimestampNano(1))
+
+      values2.toList shouldEqual List("10", "11", "12", "13", "14")
+
+      val values3 = index.find(EpochTimestampNano(-1))
+
+      values3.toList shouldEqual List()
+
+      val values4 = index.find(Set(EpochTimestampNano(2), EpochTimestampNano(3)))
+
+      values4.toList shouldEqual List("20", "21", "22", "23", "24", "25", "30", "31", "32", "33", "34", "35")
+    }
+
+    Scenario("Check ordered operations on EpochTimestampNano index") {
+
+      val index = new SkipListIndexedEpochTimestampNanoField(SimpleColumn("Timestamp", 0, DataType.EpochTimestampNanoType))
+
+      val times = List(EpochTimestampNano(1), EpochTimestampNano(2), EpochTimestampNano(3), EpochTimestampNano(4), EpochTimestampNano(5), EpochTimestampNano(6))
+
+      times.foreach(time => {
+        (0 to 5).foreach(i => index.insert(time, time.toString + i.toString))
+      })
+
+      var values = index.greaterThan(EpochTimestampNano(5))
+      values.toSet shouldEqual Set("60", "61", "62", "63", "64", "65")
+
+      values = index.greaterThanOrEqual(EpochTimestampNano(5))
+      values.toSet shouldEqual Set("60", "61", "62", "63", "64", "65", "50", "51", "52", "53", "54", "55")
+
+      values = index.lessThan(EpochTimestampNano(2))
+      values.toSet shouldEqual Set("10", "11", "12", "13", "14", "15")
+
+      values = index.lessThanOrEqual(EpochTimestampNano(2))
+      values.toSet shouldEqual Set("20", "21", "22", "23", "24", "25", "10", "11", "12", "13", "14", "15")
+
+    }
+
   }
 }

--- a/vuu/src/test/scala/org/finos/vuu/core/row/RowBuilderTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/row/RowBuilderTest.scala
@@ -5,7 +5,7 @@ import org.finos.toolbox.lifecycle.LifecycleContainer
 import org.finos.toolbox.time.{Clock, TestFriendlyClock}
 import org.finos.vuu.api.TableDef
 import org.finos.vuu.core.table.datatype.Scale.{EIGHT, Eight, FOUR, Four, Six, Two}
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal, ScaledDecimal2}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal, ScaledDecimal2}
 import org.finos.vuu.core.table.{Columns, InMemDataTable}
 import org.finos.vuu.provider.{JoinTableProvider, JoinTableProviderImpl}
 import org.scalatest.GivenWhenThen
@@ -24,12 +24,13 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
           "currency: String",
           "exchange:String",
           "lotSize:Double",
-          "lastUpdated:EpochTimeStamp",
+          "lastUpdated:EpochTimestamp",
           "shortSellRestriction:Char",
           "delta:ScaledDecimal2",
           "tau:ScaledDecimal4",
           "gamma:ScaledDecimal6",
           "theta:ScaledDecimal8",
+          "nano:EpochTimestampNano",
         ),
         joinFields = "ric"
       )
@@ -47,7 +48,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
       val joinTableProvider: JoinTableProvider = JoinTableProviderImpl()
 
       val (ricColumn, descColumn, currColumn, exchangeColumn, lotSizeColumn, lastUpdatedColumn, shortSellRestrictionColumn,
-        deltaColumn, tauColumn, gammaColumn, thetaColumn) =
+        deltaColumn, tauColumn, gammaColumn, thetaColumn, nanoColumn) =
         (
           tableDef.columnForName("ric"),
           tableDef.columnForName("description"),
@@ -60,6 +61,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
           tableDef.columnForName("tau"),
           tableDef.columnForName("gamma"),
           tableDef.columnForName("theta"),
+          tableDef.columnForName("nano"),
         )
 
       val table = new InMemDataTable(tableDef, joinTableProvider)
@@ -77,6 +79,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
         .setScaledDecimal(tauColumn, ScaledDecimal(1.02, Four))
         .setScaledDecimal(gammaColumn, ScaledDecimal(1.03, Six))
         .setScaledDecimal(thetaColumn, ScaledDecimal(1.04, Eight))
+        .setEpochTimestampNano(nanoColumn, EpochTimestampNano(1_000_000))
         .build
 
       row.key should equal("FOO.L")
@@ -91,6 +94,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
       row.get(tauColumn) should equal(ScaledDecimal(1.02, Four))
       row.get(gammaColumn) should equal(ScaledDecimal(1.03, Six))
       row.get(thetaColumn) should equal(ScaledDecimal(1.04, Eight))
+      row.get(nanoColumn) should equal(EpochTimestampNano(1_000_000))
     }
 
     Scenario("Test Reuse of Row Builder"){
@@ -103,7 +107,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
       val joinTableProvider: JoinTableProvider = JoinTableProviderImpl()
 
       val (ricColumn, descColumn, currColumn, exchangeColumn, lotSizeColumn, lastUpdatedColumn, shortSellRestrictionColumn,
-      deltaColumn, tauColumn, gammaColumn, thetaColumn) =
+      deltaColumn, tauColumn, gammaColumn, thetaColumn, nanoColumn) =
         (
           tableDef.columnForName("ric"),
           tableDef.columnForName("description"),
@@ -116,6 +120,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
           tableDef.columnForName("tau"),
           tableDef.columnForName("gamma"),
           tableDef.columnForName("theta"),
+          tableDef.columnForName("nano"),
         )
 
       val table = new InMemDataTable(tableDef, joinTableProvider)
@@ -134,6 +139,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
         .setScaledDecimal(tauColumn, ScaledDecimal(1.02, Four))
         .setScaledDecimal(gammaColumn, ScaledDecimal(1.03, Six))
         .setScaledDecimal(thetaColumn, ScaledDecimal(1.04, Eight))
+        .setEpochTimestampNano(nanoColumn, EpochTimestampNano(1_000_000))
         .build
 
       row.key should equal("FOO.L")
@@ -148,6 +154,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
       row.get(tauColumn) should equal(ScaledDecimal(1.02, Four))
       row.get(gammaColumn) should equal(ScaledDecimal(1.03, Six))
       row.get(thetaColumn) should equal(ScaledDecimal(1.04, Eight))
+      row.get(nanoColumn) should equal(EpochTimestampNano(1_000_000))
 
       intercept[RuntimeException]{
         builder.build
@@ -165,6 +172,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
         .setScaledDecimal(tauColumn, ScaledDecimal(2.02, Four))
         .setScaledDecimal(gammaColumn, ScaledDecimal(2.03, Six))
         .setScaledDecimal(thetaColumn, ScaledDecimal(2.04, Eight))
+        .setEpochTimestampNano(nanoColumn, EpochTimestampNano(2_000_000))
         .build
 
       row2.key should equal("BAR.L")
@@ -179,7 +187,7 @@ class RowBuilderTest extends AnyFeatureSpec with Matchers with GivenWhenThen{
       row2.get(tauColumn) should equal(ScaledDecimal(2.02, Four))
       row2.get(gammaColumn) should equal(ScaledDecimal(2.03, Six))
       row2.get(thetaColumn) should equal(ScaledDecimal(2.04, Eight))
-
+      row2.get(nanoColumn) should equal(EpochTimestampNano(2_000_000))
     }
 
 

--- a/vuu/src/test/scala/org/finos/vuu/core/sort/FilterAndSortFixture.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/sort/FilterAndSortFixture.scala
@@ -8,7 +8,7 @@ import org.finos.vuu.api.{Index, Indices, TableDef}
 import org.finos.vuu.core.filter.FilterClause
 import org.finos.vuu.core.filter.`type`.AntlrBasedFilter
 import org.finos.vuu.core.table.datatype.Scale.{EIGHT, FOUR, Six, Two}
-import org.finos.vuu.core.table.datatype.{ScaledDecimal, ScaledDecimal2}
+import org.finos.vuu.core.table.datatype.{EpochTimestampNano, ScaledDecimal, ScaledDecimal2}
 import org.finos.vuu.core.table.{Columns, InMemDataTable, RowWithData, TablePrimaryKeys, ViewPortColumnCreator}
 import org.finos.vuu.test.TestFriendlyJoinTableProvider
 import org.scalatest.Assertions.fail
@@ -103,12 +103,12 @@ object FilterAndSortFixture {
   def setupTableWithCreationTime(indices: List[String])(using clock: TestFriendlyClock): InMemDataTable = {
     val now: Long = clock.now();
     val table: InMemDataTable = setupTable(indices,
-      row("tradeTime" -> 5L, "quantity" -> 500, "price" -> 283.10, "side" -> 'B', "ric" -> "AAPL.L", "orderId" -> "NYC-0004", "onMkt" -> false, "trader" -> "chris", "ccyCross" -> "GBPUSD", "delta" -> ScaledDecimal(1.01, Two), "tau" -> ScaledDecimal(1.0001, FOUR),"gamma" -> ScaledDecimal(1.000001, Six),"theta" -> ScaledDecimal(1.00000001, EIGHT)),
-      row("tradeTime" -> 3L, "quantity" -> 100, "price" -> 94.12, "side" -> 'S', "ric" -> "VOD.L", "orderId" -> "LDN-0003", "onMkt" -> true, "trader" -> "steve", "ccyCross" -> "GBPUSD", "delta" -> ScaledDecimal(2.01, Two), "tau" -> ScaledDecimal(2.0001, FOUR),"gamma" -> ScaledDecimal(2.000001, Six),"theta" -> ScaledDecimal(2.00000001, EIGHT)),
+      row("tradeTime" -> 5L, "quantity" -> 500, "price" -> 283.10, "side" -> 'B', "ric" -> "AAPL.L", "orderId" -> "NYC-0004", "onMkt" -> false, "trader" -> "chris", "ccyCross" -> "GBPUSD", "delta" -> ScaledDecimal(1.01, Two), "tau" -> ScaledDecimal(1.0001, FOUR),"gamma" -> ScaledDecimal(1.000001, Six),"theta" -> ScaledDecimal(1.00000001, EIGHT), "nano" -> EpochTimestampNano(1111)),
+      row("tradeTime" -> 3L, "quantity" -> 100, "price" -> 94.12, "side" -> 'S', "ric" -> "VOD.L", "orderId" -> "LDN-0003", "onMkt" -> true, "trader" -> "steve", "ccyCross" -> "GBPUSD", "delta" -> ScaledDecimal(2.01, Two), "tau" -> ScaledDecimal(2.0001, FOUR),"gamma" -> ScaledDecimal(2.000001, Six),"theta" -> ScaledDecimal(2.00000001, EIGHT), "nano" -> EpochTimestampNano(2111)),
     )(using clock)
     clock.advanceBy(1000L)
-    table.processUpdate("LDN-0001", row("tradeTime" -> 2L, "quantity" -> 100, "price" -> 94.12, "side" -> 'S', "ric" -> "VOD.L", "orderId" -> "LDN-0001", "onMkt" -> true, "trader" -> "chris", "ccyCross" -> "GBPUSD", "delta" -> ScaledDecimal(1.01, Two), "tau" -> ScaledDecimal(1.0001, FOUR),"gamma" -> ScaledDecimal(1.000001, Six),"theta" -> ScaledDecimal(1.00000001, EIGHT)))
-    table.processUpdate("LDN-0008", row("tradeTime" -> 5L, "quantity" -> 100, "price" -> 180.50, "side" -> 'B', "ric" -> "BT.L", "orderId" -> "LDN-0008", "onMkt" -> true, "trader" -> "steve", "ccyCross" -> "GBPUSD", "delta" -> ScaledDecimal(2.01, Two), "tau" -> ScaledDecimal(2.0001, FOUR),"gamma" -> ScaledDecimal(2.000001, Six),"theta" -> ScaledDecimal(2.00000001, EIGHT)))
+    table.processUpdate("LDN-0001", row("tradeTime" -> 2L, "quantity" -> 100, "price" -> 94.12, "side" -> 'S', "ric" -> "VOD.L", "orderId" -> "LDN-0001", "onMkt" -> true, "trader" -> "chris", "ccyCross" -> "GBPUSD", "delta" -> ScaledDecimal(1.01, Two), "tau" -> ScaledDecimal(1.0001, FOUR),"gamma" -> ScaledDecimal(1.000001, Six),"theta" -> ScaledDecimal(1.00000001, EIGHT), "nano" -> EpochTimestampNano(1111)))
+    table.processUpdate("LDN-0008", row("tradeTime" -> 5L, "quantity" -> 100, "price" -> 180.50, "side" -> 'B', "ric" -> "BT.L", "orderId" -> "LDN-0008", "onMkt" -> true, "trader" -> "steve", "ccyCross" -> "GBPUSD", "delta" -> ScaledDecimal(2.01, Two), "tau" -> ScaledDecimal(2.0001, FOUR),"gamma" -> ScaledDecimal(2.000001, Six),"theta" -> ScaledDecimal(2.00000001, EIGHT), "nano" -> EpochTimestampNano(2111)))
     table
   }
 
@@ -127,6 +127,7 @@ object FilterAndSortFixture {
       "tau:ScaledDecimal4",
       "gamma:ScaledDecimal6",
       "theta:ScaledDecimal8",
+      "nano:EpochTimestampNano"
     )
     val tableDef = TableDef(
       name = "orders",

--- a/vuu/src/test/scala/org/finos/vuu/core/table/ColumnTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/ColumnTest.scala
@@ -2,7 +2,7 @@ package org.finos.vuu.core.table
 
 import org.finos.vuu.api.{ColumnBuilder, TableDef}
 import org.finos.vuu.core.table.column.NullCalculatedColumnClause
-import org.finos.vuu.core.table.datatype.EpochTimestamp
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano}
 import org.finos.vuu.util.types.TypeUtils
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
@@ -20,6 +20,7 @@ class ColumnTest extends AnyFeatureSpec with Matchers {
       (DataType.LongDataType, "33", 33L),
       (DataType.DoubleDataType, "33.55", 33.55),
       (DataType.EpochTimestampType, "100000000", EpochTimestamp.apply(100_000_000L)),
+      (DataType.EpochTimestampNanoType, "100000000", EpochTimestampNano.apply(100_000_000L)),
     ))((dataType, stringInput, expectedOutput) => {
       Scenario(s"can parse string '$stringInput' to `$dataType` type") {
         val parsedValue = DataType.parseToDataType(stringInput, dataType)
@@ -36,6 +37,7 @@ class ColumnTest extends AnyFeatureSpec with Matchers {
       (DataType.LongDataType, "33.5"),
       (DataType.DoubleDataType, "12x1"),
       (DataType.EpochTimestampType, "44.5"),
+      (DataType.EpochTimestampNanoType, "54.6"),
     ))((dataType, stringInput) => {
       Scenario(s"should return empty when string '$stringInput' cannot be parsed to `$dataType` type") {
         val parsedValue = DataType.parseToDataType(stringInput, dataType)

--- a/vuu/src/test/scala/org/finos/vuu/core/table/DataTypesTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/DataTypesTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 
 class DataTypesTest extends AnyFeatureSpec with Matchers with TableDrivenPropertyChecks {
 
-  Feature("Check data type roundtripping") {
+  Feature("Check data type round trip") {
 
     Scenario("Data types should correctly serialize to and from strings") {
 
@@ -19,6 +19,7 @@ class DataTypesTest extends AnyFeatureSpec with Matchers with TableDrivenPropert
         "double",
         "char",
         "epochtimestamp",
+        "epochtimestampnano",
         "scaleddecimal2",
         "scaleddecimal4",
         "scaleddecimal6",

--- a/vuu/src/test/scala/org/finos/vuu/core/table/datatype/EpochTimestampNanoTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/datatype/EpochTimestampNanoTest.scala
@@ -1,0 +1,85 @@
+package org.finos.vuu.core.table.datatype
+
+import org.finos.toolbox.time.TestFriendlyClock
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+import java.lang.System.currentTimeMillis
+import java.time.{Duration, Instant, ZoneId, ZonedDateTime}
+
+class EpochTimestampNanoTest extends AnyFeatureSpec with Matchers with TableDrivenPropertyChecks {
+
+  Feature("Check creation") {
+
+    Scenario("Check default creation") {
+
+      val nanos = Duration.ofMillis(currentTimeMillis).toNanos
+
+      val epochTimestamp = EpochTimestampNano()
+
+      epochTimestamp.nanos should be (nanos +- Duration.ofMillis(100).toNanos)
+    }
+
+    Scenario("Check creation via Instant") {
+
+      val millis = currentTimeMillis
+      val instant = Instant.ofEpochMilli(millis)
+
+      val epochTimestamp = EpochTimestampNano(instant)
+
+      epochTimestamp.nanos shouldEqual Duration.ofMillis(millis).toNanos
+    }
+
+    Scenario("Check creation via Clock") {
+
+      val millis = currentTimeMillis
+      val clock = new TestFriendlyClock(millis)
+
+      val epochTimestamp = EpochTimestampNano(clock)
+
+      epochTimestamp.nanos shouldEqual Duration.ofMillis(millis).toNanos
+    }
+
+    Scenario("Check creation via ZonedDateTime") {
+      val millis = currentTimeMillis
+      val zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.of("UTC"))
+
+      val epochTimestamp = EpochTimestampNano(zonedDateTime)
+
+      epochTimestamp.nanos shouldEqual Duration.ofMillis(millis).toNanos
+    }
+
+  }
+
+  Feature("Other") {
+
+    Scenario("To String matches Long") {
+
+      val nanos = System.nanoTime()
+      val epochTimestamp = EpochTimestampNano(nanos)
+
+      epochTimestamp.toString.toLong shouldEqual nanos
+    }
+
+    Scenario("Comparing EpochTimestampNano instances") {
+      val comparisonTable = Table(
+        ("val1", "val2", "isGreater", "isEqual"),
+        (1000L, 2000L, false, false),
+        (2000L, 1000L, true, false),
+        (1000L, 1000L, false, true)
+      )
+
+      forAll(comparisonTable) { (v1, v2, isGreater, isEqual) =>
+        val sd1 = EpochTimestampNano(v1)
+        val sd2 = EpochTimestampNano(v2)
+
+        (sd1 > sd2) shouldBe isGreater
+        (sd1 == sd2) shouldBe isEqual
+        if (!isEqual) (sd1 < sd2) shouldBe !isGreater
+      }
+    }
+
+  }
+
+}

--- a/vuu/src/test/scala/org/finos/vuu/net/json/mixin/RowUpdateMixinTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/net/json/mixin/RowUpdateMixinTest.scala
@@ -1,7 +1,7 @@
 package org.finos.vuu.net.json.mixin
 
 import com.typesafe.scalalogging.StrictLogging
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal2}
 import org.finos.vuu.net.row.RowUpdate
 import org.finos.vuu.net.row.RowUpdateType.Update
 import org.scalatest.featurespec.AnyFeatureSpec
@@ -37,6 +37,7 @@ class RowUpdateMixinTest extends AnyFeatureSpec with Matchers with StrictLogging
           EpochTimestamp(456L),
           ScaledDecimal2(567L),
           678L,
+          EpochTimestampNano(789L)
         )
       )
 
@@ -44,7 +45,7 @@ class RowUpdateMixinTest extends AnyFeatureSpec with Matchers with StrictLogging
 
       serialized shouldEqual "{\"viewPortId\":\"Vp1\",\"vpSize\":1,\"rowIndex\":0,\"rowKey\":\":KEY1\"," +
         "\"updateType\":\"U\",\"ts\":100,\"sel\":0,\"vpVersion\":\"Request1\"," +
-        "\"data\":[\"foo\",\"bar\",1,\"\",456,\"567\",\"678\"]}"
+        "\"data\":[\"foo\",\"bar\",1,\"\",456,\"567\",\"678\",\"789\"]}"
 
       val deserialized = mapper.readValue(serialized, classOf[RowUpdate])
 
@@ -57,7 +58,7 @@ class RowUpdateMixinTest extends AnyFeatureSpec with Matchers with StrictLogging
       deserialized.ts shouldEqual rowUpdate.ts
       deserialized.selected shouldEqual rowUpdate.selected
 
-      deserialized.data.length shouldEqual 7
+      deserialized.data.length shouldEqual 8
       deserialized.data(0) shouldEqual "foo"
       deserialized.data(1) shouldEqual "bar"
       deserialized.data(2) shouldEqual "1"
@@ -65,6 +66,7 @@ class RowUpdateMixinTest extends AnyFeatureSpec with Matchers with StrictLogging
       deserialized.data(4) shouldEqual "456"
       deserialized.data(5) shouldEqual "567"
       deserialized.data(6) shouldEqual "678"
+      deserialized.data(7) shouldEqual "789"
     }
 
   }

--- a/vuu/src/test/scala/org/finos/vuu/util/types/DefaultTypeConvertersTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/util/types/DefaultTypeConvertersTest.scala
@@ -1,6 +1,6 @@
 package org.finos.vuu.util.types
 
-import org.finos.vuu.core.table.datatype.{EpochTimestamp, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
+import org.finos.vuu.core.table.datatype.{EpochTimestamp, EpochTimestampNano, ScaledDecimal2, ScaledDecimal4, ScaledDecimal6, ScaledDecimal8}
 import org.finos.vuu.util.types.DefaultTypeConverters.*
 import org.finos.vuu.util.types.TypeConverter
 import org.scalatest.featurespec.AnyFeatureSpec
@@ -35,6 +35,7 @@ class DefaultTypeConvertersTest extends AnyFeatureSpec with Matchers {
       ("Boolean to String", booleanToStringConverter, true, "true"),
       ("Char to String", charToStringConverter, 'Z', "Z"),
       ("EpochTimestamp to String", epochTimestampToStringConverter, EpochTimestamp(20_000), "20000"),
+      ("EpochTimestampNano to String", epochTimestampNanoToStringConverter, EpochTimestampNano(20_000), "20000"),
       ("ScaledDecimal to String", scaledDecimalToStringConverter, ScaledDecimal2(30_000L), "30000"),
     ))((title, converter, input, expectedOutput) => {
       Scenario(title) {
@@ -71,6 +72,7 @@ class DefaultTypeConvertersTest extends AnyFeatureSpec with Matchers {
       ("Boolean to String", booleanToStringConverter),
       ("Char to String", charToStringConverter),
       ("EpochTimestamp to String", epochTimestampToStringConverter),
+      ("EpochTimestampNano to String", epochTimestampNanoToStringConverter),
       ("ScaledDecimal to String", scaledDecimalToStringConverter),
     ))((title, converter) => {
       Scenario(title) {


### PR DESCRIPTION
Trading systems are generally required to support Nanosecond level precision on timestamps. 

I've added support for this alongside our existing millisecond level type.

I also refactored the JSON serializer for RowData to make it allocate less.