### PR TITLE
#2214 Add new RPC deleteSelectedRows and undoRowChange

### DIFF
--- a/example/basket/src/main/scala/org/finos/vuu/core/module/basket/service/BasketTradingConstituentJoinService.scala
+++ b/example/basket/src/main/scala/org/finos/vuu/core/module/basket/service/BasketTradingConstituentJoinService.scala
@@ -217,9 +217,13 @@ class BasketTradingConstituentJoinService(val table: DataTable)(using tableConta
 
   override def deleteRow(params: RpcParams): RpcFunctionResult = ???
 
+  override def deleteSelectedRows(params: RpcParams): RpcFunctionResult = ???
+
   override def deleteCell(params: RpcParams): RpcFunctionResult = ???
 
   override def addRow(params: RpcParams): RpcFunctionResult = ???
 
   override def closeForm(params: RpcParams): RpcFunctionResult = ???
+
+  override def undoRowChange(params: RpcParams): RpcFunctionResult = ???
 }

--- a/example/basket/src/main/scala/org/finos/vuu/core/module/basket/service/BasketTradingConstituentService.scala
+++ b/example/basket/src/main/scala/org/finos/vuu/core/module/basket/service/BasketTradingConstituentService.scala
@@ -54,9 +54,13 @@ class BasketTradingConstituentService(val table: DataTable)(using tableContainer
 
   override def deleteRow(params: RpcParams): RpcFunctionResult = ???
 
+  override def deleteSelectedRows(params: RpcParams): RpcFunctionResult = ???
+
   override def deleteCell(params: RpcParams): RpcFunctionResult = ???
 
   override def addRow(params: RpcParams): RpcFunctionResult = ???
 
   override def closeForm(params: RpcParams): RpcFunctionResult = ???
+
+  override def undoRowChange(params: RpcParams): RpcFunctionResult = ???
 }

--- a/example/basket/src/main/scala/org/finos/vuu/core/module/basket/service/BasketTradingService.scala
+++ b/example/basket/src/main/scala/org/finos/vuu/core/module/basket/service/BasketTradingService.scala
@@ -130,6 +130,8 @@ class BasketTradingService(val table: DataTable, val omsApi: OmsApi)(using table
 
   override def deleteRow(params: RpcParams): RpcFunctionResult = ???
 
+  override def deleteSelectedRows(params: RpcParams): RpcFunctionResult = ???
+
   override def deleteCell(params: RpcParams): RpcFunctionResult = ???
 
   override def addRow(params: RpcParams): RpcFunctionResult = ???
@@ -139,4 +141,6 @@ class BasketTradingService(val table: DataTable, val omsApi: OmsApi)(using table
   override def submitForm(params: RpcParams): RpcFunctionResult = ???
 
   override def closeForm(params: RpcParams): RpcFunctionResult = ???
+
+  override def undoRowChange(params: RpcParams): RpcFunctionResult = ???
 }

--- a/example/editable/src/main/scala/org/finos/vuu/core/module/editable/FixSequenceRpcService.scala
+++ b/example/editable/src/main/scala/org/finos/vuu/core/module/editable/FixSequenceRpcService.scala
@@ -3,7 +3,7 @@ package org.finos.vuu.core.module.editable
 import org.finos.vuu.core.table.{RowWithData, TableContainer}
 import org.finos.vuu.net.rpc.*
 
-class FixSequenceRpcService()(using tableContainer: TableContainer) extends EditTableRpcHandler{
+class FixSequenceRpcService()(using tableContainer: TableContainer) extends EditTableRpcHandler {
 
   override def editCell(params: RpcParams): RpcFunctionResult = {
     val key: String = params.namedParams("key").asInstanceOf[String]
@@ -37,9 +37,13 @@ class FixSequenceRpcService()(using tableContainer: TableContainer) extends Edit
 
   override def deleteRow(params: RpcParams): RpcFunctionResult = ???
 
+  override def deleteSelectedRows(params: RpcParams): RpcFunctionResult = ???
+
   override def deleteCell(params: RpcParams): RpcFunctionResult = ???
 
   override def addRow(params: RpcParams): RpcFunctionResult = ???
 
   override def closeForm(params: RpcParams): RpcFunctionResult = ???
+
+  override def undoRowChange(params: RpcParams): RpcFunctionResult = ???
 }

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
@@ -166,8 +166,7 @@ class EditableTest extends VuuServerTestCase {
     }
 
     Scenario("Undo row change") {
-      val module = EditTableTestModule()
-      withVuuServer(module) {
+      withVuuServer(EditTableTestModule()) {
         vuuServer =>
           vuuServer.login("testUser")
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
@@ -183,7 +182,7 @@ class EditableTest extends VuuServerTestCase {
           undoRowChangeResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(module.originalData))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(EditTableTestModule.originalData))
       }
     }
   }

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
@@ -12,91 +12,181 @@ import org.finos.vuu.util.table.TableAsserts.assertVpEq
 import org.scalatest.prop.Tables.Table
 
 class EditableTest extends VuuServerTestCase {
+  given clock: Clock = new TestFriendlyClock(10001L)
 
-  Feature("Editable Test Case") {
+  given lifecycle: LifecycleContainer = new LifecycleContainer()
 
-    Scenario("Check the editable functionality with EditTableRpcHandler") {
+  given tableDefContainer: TableDefContainer = new TableDefContainer(Map())
 
-      given clock: Clock = new TestFriendlyClock(10001L)
+  given metricsProvider: MetricsProvider = new MetricsProviderImpl
 
-      given lifecycle: LifecycleContainer = new LifecycleContainer()
+  Feature("Check the editable functionality with EditTableRpcHandler") {
 
-      given tableDefContainer: TableDefContainer = new TableDefContainer(Map())
-
-      given metricsProvider: MetricsProvider = new MetricsProviderImpl
-
+    Scenario("Add row") {
       withVuuServer(EditTableTestModule()) {
         vuuServer =>
           vuuServer.login("testUser")
-
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
           val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
 
-          val addRowResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)), viewport, ctx))
+          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val addRowResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
           addRowResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
+      }
+    }
 
-          assertVpEq(combineQsForVp(viewport)) {
-            Table(
-              ("rowId", "A", "B", "C", "D"),
-              ("key1", "TEST", 1001.0, 500, true)
-            )
-          }
+    Scenario("Edit row and edit cell") {
+      withVuuServer(EditTableTestModule()) {
+        vuuServer =>
+          vuuServer.login("testUser")
+          val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
+          val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
+          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
+          vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
 
-          val editRowResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.EditRowRpc, new RpcParams(Map("key" -> "key1", "data" -> Map("rowId" -> "key1", "A" -> "TEST2", "B" -> 2002D, "C" -> 600, "D" -> false)), viewport, ctx))
+          val data2 = Map("rowId" -> "key1", "A" -> "TEST2", "B" -> 2002D, "C" -> 600, "D" -> false)
+          val editRowResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.EditRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data2), viewport, ctx))
           editRowResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data2))
+      }
+    }
 
-          assertVpEq(combineQsForVp(viewport)) {
-            Table(
-              ("rowId", "A", "B", "C", "D"),
-              ("key1", "TEST2", 2002.0, 600, false)
-            )
-          }
+    Scenario("Edit cell") {
+      withVuuServer(EditTableTestModule()) {
+        vuuServer =>
+          vuuServer.login("testUser")
+          val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
+          val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
+          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
+          vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
 
           val editCellResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.EditCellRpc, new RpcParams(Map("key" -> "key1", "column" -> "A", "data" -> "TEST3"), viewport, ctx))
           editCellResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"),
+            Array(Map("rowId" -> "key1", "A" -> "TEST3", "B" -> 1001D, "C" -> 500, "D" -> true)))
+      }
+    }
 
-          assertVpEq(combineQsForVp(viewport)) {
-            Table(
-              ("rowId", "A", "B", "C", "D"),
-              ("key1", "TEST3", 2002.0, 600, false)
-            )
-          }
-
-          val deleteCellResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.DeleteCellRpc, new RpcParams(Map("key" -> "key1", "column" -> "A"), viewport, ctx))
-          deleteCellResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
-
+    Scenario("Delete row") {
+      withVuuServer(EditTableTestModule()) {
+        vuuServer =>
+          vuuServer.login("testUser")
+          val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
+          val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
+          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
           vuuServer.runOnce()
-
-          assertVpEq(combineQsForVp(viewport)) {
-            Table(
-              ("rowId", "A", "B", "C", "D"),
-              ("key1", null, 2002.0, 600, false)
-            )
-          }
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
 
           val deleteRowResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.DeleteRowRpc, new RpcParams(Map("key" -> "key1"), viewport, ctx))
           deleteRowResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array())
+        )
+      }
+    }
 
-          assertVpEq(combineQsForVp(viewport)) {
-            Table(
-              ("rowId", "A", "B", "C", "D"),
-            )
-          }
+    Scenario("Delete selected rows") {
+      withVuuServer(EditTableTestModule()) {
+        vuuServer =>
+          vuuServer.login("testUser")
+          val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
+          val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
+          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val data2 = Map("rowId" -> "key2", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
+          viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key2", "data" -> data2), viewport, ctx))
+          vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data, data2))
+
+          viewport.selectRow("key1", false)
+
+          val deleteSelectedRowsResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.DeleteSelectedRowsRpc, new RpcParams(Map("key" -> "key1"), viewport, ctx))
+          deleteSelectedRowsResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
+
+          vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data2))
+        )
+      }
+    }
+
+    Scenario("Delete cell") {
+      withVuuServer(EditTableTestModule()) {
+        vuuServer =>
+          vuuServer.login("testUser")
+          val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
+          val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
+          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
+          vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
+
+          val deleteCellResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.DeleteCellRpc, new RpcParams(Map("key" -> "key1", "column" -> "A"), viewport, ctx))
+          deleteCellResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
+
+          vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"),
+            Array(Map("rowId" -> "key1", "A" -> null, "B" -> 1001D, "C" -> 500, "D" -> true)))
+        )
+      }
+    }
+
+    Scenario("Submit form") {
+      withVuuServer(EditTableTestModule()) {
+        vuuServer =>
+          vuuServer.login("testUser")
+          val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
+          val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
 
           val submitFormResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.SubmitFormRpc, new RpcParams(Map("comment" -> "Some comment"), viewport, ctx))
           submitFormResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
           submitFormResult.asInstanceOf[RpcFunctionSuccess].optionalResult.get shouldBe "Some comment"
+      }
+    }
+
+    Scenario("Close form") {
+      withVuuServer(EditTableTestModule()) {
+        vuuServer =>
+          vuuServer.login("testUser")
+          val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
+          val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
 
           val closeFormResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.CloseFormRpc, new RpcParams(Map.empty, viewport, ctx))
           closeFormResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
+      }
+    }
+
+    Scenario("Undo row change") {
+      withVuuServer(EditTableTestModule()) {
+        vuuServer =>
+          vuuServer.login("testUser")
+          val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
+          val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
+          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
+          vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
+
+          viewport.selectRow("key1", false)
+
+          val undoRowChangeResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.UndoRowChangeRpc, new RpcParams(Map("key" -> "key1"), viewport, ctx))
+          undoRowChangeResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
+
+          vuuServer.runOnce()
+          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array())
+        )
       }
     }
   }

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
@@ -182,7 +182,7 @@ class EditableTest extends VuuServerTestCase {
           undoRowChangeResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array())
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(Map("rowId" -> "key1", "A" -> null, "B" -> null, "C" -> null, "D" -> null)))
       }
     }
   }

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
@@ -29,12 +29,12 @@ class EditableTest extends VuuServerTestCase {
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
           val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
 
-          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val data: Map[Any, Any] = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
           val addRowResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
           addRowResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(data))
       }
     }
 
@@ -44,17 +44,17 @@ class EditableTest extends VuuServerTestCase {
           vuuServer.login("testUser")
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
           val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
-          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val data: Map[Any, Any] = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
           viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(data))
 
-          val data2 = Map("rowId" -> "key1", "A" -> "TEST2", "B" -> 2002D, "C" -> 600, "D" -> false)
+          val data2: Map[Any, Any] = Map("rowId" -> "key1", "A" -> "TEST2", "B" -> 2002D, "C" -> 600, "D" -> false)
           val editRowResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.EditRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data2), viewport, ctx))
           editRowResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data2))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(data2))
       }
     }
 
@@ -64,16 +64,16 @@ class EditableTest extends VuuServerTestCase {
           vuuServer.login("testUser")
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
           val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
-          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val data: Map[Any, Any] = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
           viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(data))
 
           val editCellResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.EditCellRpc, new RpcParams(Map("key" -> "key1", "column" -> "A", "data" -> "TEST3"), viewport, ctx))
           editCellResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"),
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"),
             Array(Map("rowId" -> "key1", "A" -> "TEST3", "B" -> 1001D, "C" -> 500, "D" -> true)))
       }
     }
@@ -84,17 +84,16 @@ class EditableTest extends VuuServerTestCase {
           vuuServer.login("testUser")
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
           val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
-          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val data: Map[Any, Any] = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
           viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(data))
 
           val deleteRowResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.DeleteRowRpc, new RpcParams(Map("key" -> "key1"), viewport, ctx))
           deleteRowResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array())
-        )
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array())
       }
     }
 
@@ -104,12 +103,12 @@ class EditableTest extends VuuServerTestCase {
           vuuServer.login("testUser")
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
           val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
-          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
-          val data2 = Map("rowId" -> "key2", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val data: Map[Any, Any] = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val data2: Map[Any, Any] = Map("rowId" -> "key2", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
           viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
           viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key2", "data" -> data2), viewport, ctx))
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data, data2))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(data, data2))
 
           viewport.selectRow("key1", false)
 
@@ -117,8 +116,7 @@ class EditableTest extends VuuServerTestCase {
           deleteSelectedRowsResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data2))
-        )
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(data2))
       }
     }
 
@@ -128,18 +126,17 @@ class EditableTest extends VuuServerTestCase {
           vuuServer.login("testUser")
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
           val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
-          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val data: Map[Any, Any] = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
           viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(data))
 
           val deleteCellResult = viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.DeleteCellRpc, new RpcParams(Map("key" -> "key1", "column" -> "A"), viewport, ctx))
           deleteCellResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"),
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"),
             Array(Map("rowId" -> "key1", "A" -> null, "B" -> 1001D, "C" -> 500, "D" -> true)))
-        )
       }
     }
 
@@ -174,10 +171,10 @@ class EditableTest extends VuuServerTestCase {
           vuuServer.login("testUser")
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
           val ctx = RequestContext("", VuuUser(""), ClientSessionId("", ""), null)
-          val data = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
+          val data: Map[Any, Any] = Map("rowId" -> "key1", "A" -> "TEST", "B" -> 1001D, "C" -> 500, "D" -> true)
           viewport.getStructure.viewPortDef.service.processRpcRequest(RpcNames.AddRowRpc, new RpcParams(Map("key" -> "key1", "data" -> data), viewport, ctx))
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array(data))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(data))
 
           viewport.selectRow("key1", false)
 
@@ -185,8 +182,7 @@ class EditableTest extends VuuServerTestCase {
           undoRowChangeResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), ("rowId", "A", "B", "C", "D"), Array())
-        )
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array())
       }
     }
   }

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTest.scala
@@ -166,7 +166,8 @@ class EditableTest extends VuuServerTestCase {
     }
 
     Scenario("Undo row change") {
-      withVuuServer(EditTableTestModule()) {
+      val module = EditTableTestModule()
+      withVuuServer(module) {
         vuuServer =>
           vuuServer.login("testUser")
           val viewport = vuuServer.createViewPort(EditTableTestModule.NAME, "editTestTable")
@@ -182,7 +183,7 @@ class EditableTest extends VuuServerTestCase {
           undoRowChangeResult.isInstanceOf[RpcFunctionSuccess] shouldBe true
 
           vuuServer.runOnce()
-          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(Map("rowId" -> "key1", "A" -> null, "B" -> null, "C" -> null, "D" -> null)))
+          assertVpEq(combineQsForVp(viewport), Array("rowId", "A", "B", "C", "D"), Array(module.originalData))
       }
     }
   }

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
@@ -13,6 +13,8 @@ import org.finos.vuu.viewport.ViewPort
 
 class EditTableTestService()(using tableContainer: TableContainer) extends EditTableRpcHandler with StrictLogging {
 
+  val originalData: Map[String, Any] = Map("A" -> null, "B" -> null, "C" -> null, "D" -> null)
+  
   override def deleteRow(params: RpcParams): RpcFunctionResult = {
     val key: String = params.namedParams("key").asInstanceOf[String]
     val vp: ViewPort = params.viewPort
@@ -92,7 +94,6 @@ class EditTableTestService()(using tableContainer: TableContainer) extends EditT
     val key: String = params.namedParams("key").asInstanceOf[String]
     val vp: ViewPort = params.viewPort
     val session: ClientSessionId = params.ctx.session
-    val originalData: Map[String, Any] = Map("A" -> null, "B" -> null, "C" -> null, "D" -> null)
 
     vp.table.asTable.processUpdate(key, RowWithData(key, originalData))
     RpcFunctionSuccess(None)

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
@@ -22,6 +22,18 @@ class EditTableTestService()(using tableContainer: TableContainer) extends EditT
     RpcFunctionSuccess(None)
   }
 
+  override def deleteSelectedRows(params: RpcParams): RpcFunctionResult = {
+    val vp: ViewPort = params.viewPort
+    val session: ClientSessionId = params.ctx.session
+    val selection = vp.getSelection
+
+    val iterator = selection.iterator
+    while (iterator.hasNext) {
+      vp.table.asTable.processDelete(iterator.next())
+    }
+    RpcFunctionSuccess(None)
+  }
+
   override def deleteCell(params: RpcParams): RpcFunctionResult = {
     val key: String = params.namedParams("key").asInstanceOf[String]
     val column: String = params.namedParams("column").asInstanceOf[String]
@@ -73,6 +85,16 @@ class EditTableTestService()(using tableContainer: TableContainer) extends EditT
   override def closeForm(params: RpcParams): RpcFunctionResult = {
     val vp: ViewPort = params.viewPort
     val session: ClientSessionId = params.ctx.session
+    RpcFunctionSuccess(None)
+  }
+
+  override def undoRowChange(params: RpcParams): RpcFunctionResult = {
+    val key: String = params.namedParams("key").asInstanceOf[String]
+    val vp: ViewPort = params.viewPort
+    val session: ClientSessionId = params.ctx.session
+    val originalData: Map[String, Any] = Map()
+
+    vp.table.asTable.processUpdate(key, RowWithData(key, originalData))
     RpcFunctionSuccess(None)
   }
 }

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
@@ -101,7 +101,7 @@ class EditTableTestService(val originalData: Map[String, Any])(using tableContai
 object EditTableTestModule {
 
   final val NAME = "EDIT_TABLE_TEST"
-  final val originalData: Map[Any, Any] = Map("A" -> null, "B" -> null, "C" -> null, "D" -> null)
+  final val originalData: Map[Any, Any] = Map("rowId" -> "key1", "A" -> null, "B" -> null, "C" -> null, "D" -> null)
 
   def apply()(implicit clock: Clock, lifecycle: LifecycleContainer, tableDefContainer: TableDefContainer): ViewServerModule = {
 

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
@@ -92,7 +92,7 @@ class EditTableTestService()(using tableContainer: TableContainer) extends EditT
     val key: String = params.namedParams("key").asInstanceOf[String]
     val vp: ViewPort = params.viewPort
     val session: ClientSessionId = params.ctx.session
-    val originalData: Map[String, Any] = Map()
+    val originalData: Map[String, Any] = Map("A" -> null, "B" -> null, "C" -> null, "D" -> null)
 
     vp.table.asTable.processUpdate(key, RowWithData(key, originalData))
     RpcFunctionSuccess(None)

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
@@ -11,9 +11,7 @@ import org.finos.vuu.net.ClientSessionId
 import org.finos.vuu.net.rpc.{EditTableRpcHandler, RpcFunctionResult, RpcFunctionSuccess, RpcParams}
 import org.finos.vuu.viewport.ViewPort
 
-class EditTableTestService()(using tableContainer: TableContainer) extends EditTableRpcHandler with StrictLogging {
-
-  val originalData: Map[String, Any] = Map("A" -> null, "B" -> null, "C" -> null, "D" -> null)
+class EditTableTestService(val originalData: Map[String, Any])(using tableContainer: TableContainer) extends EditTableRpcHandler with StrictLogging {
   
   override def deleteRow(params: RpcParams): RpcFunctionResult = {
     val key: String = params.namedParams("key").asInstanceOf[String]
@@ -103,7 +101,8 @@ class EditTableTestService()(using tableContainer: TableContainer) extends EditT
 object EditTableTestModule {
 
   final val NAME = "EDIT_TABLE_TEST"
-
+  final val originalData: Map[String, Any] = Map("A" -> null, "B" -> null, "C" -> null, "D" -> null)
+  
   def apply()(implicit clock: Clock, lifecycle: LifecycleContainer, tableDefContainer: TableDefContainer): ViewServerModule = {
 
     ModuleFactory.withNamespace(NAME)
@@ -118,7 +117,7 @@ object EditTableTestModule {
         (table, _) => new NullProvider(),
         (table, _, _, tableContainer) => ViewPortDef(
           columns = table.getTableDef.getColumns,
-          service = new EditTableTestService()(using tableContainer)
+          service = new EditTableTestService(originalData)(using tableContainer)
         )
       ).asModule()
 

--- a/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
+++ b/example/editable/src/test/scala/org/finos/vuu/core/module/editable/EditableTestModule.scala
@@ -12,7 +12,7 @@ import org.finos.vuu.net.rpc.{EditTableRpcHandler, RpcFunctionResult, RpcFunctio
 import org.finos.vuu.viewport.ViewPort
 
 class EditTableTestService(val originalData: Map[String, Any])(using tableContainer: TableContainer) extends EditTableRpcHandler with StrictLogging {
-  
+
   override def deleteRow(params: RpcParams): RpcFunctionResult = {
     val key: String = params.namedParams("key").asInstanceOf[String]
     val vp: ViewPort = params.viewPort
@@ -101,8 +101,8 @@ class EditTableTestService(val originalData: Map[String, Any])(using tableContai
 object EditTableTestModule {
 
   final val NAME = "EDIT_TABLE_TEST"
-  final val originalData: Map[String, Any] = Map("A" -> null, "B" -> null, "C" -> null, "D" -> null)
-  
+  final val originalData: Map[Any, Any] = Map("A" -> null, "B" -> null, "C" -> null, "D" -> null)
+
   def apply()(implicit clock: Clock, lifecycle: LifecycleContainer, tableDefContainer: TableDefContainer): ViewServerModule = {
 
     ModuleFactory.withNamespace(NAME)
@@ -117,7 +117,7 @@ object EditTableTestModule {
         (table, _) => new NullProvider(),
         (table, _, _, tableContainer) => ViewPortDef(
           columns = table.getTableDef.getColumns,
-          service = new EditTableTestService(originalData)(using tableContainer)
+          service = new EditTableTestService(originalData.asInstanceOf[Map[String, Any]])(using tableContainer)
         )
       ).asModule()
 

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -11,14 +11,16 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
     val session: ClientSessionId = params.ctx.session
     val sourceTable = params.viewPort.table
     val copyOption = SessionTableCopyOption.fromString(params.namedParams("copyOption").asInstanceOf[String])
-    val columnsToCopyStr = params.namedParams.get("columnsToCopy") match {
-      case Some(value) => value.asInstanceOf[String]
-      case None => null
-    }
-    val columnsToCopy = if (columnsToCopyStr == null || columnsToCopyStr.isBlank || columnsToCopyStr.equals("*")) {
-      sourceTable.asTable.getTableDef.customColumns.map(_.name).toList // exclude default columns
-    } else {
-      columnsToCopyStr.split(",").toList
+    val columnsToCopy = params.namedParams.get("columnsToCopy") match {
+      case Some(value) =>
+        val columnsToCopyStr = value.asInstanceOf[String]
+        if (columnsToCopyStr == null || columnsToCopyStr.isBlank || columnsToCopyStr.equals("*")) {
+          sourceTable.asTable.getTableDef.customColumns.map(_.name).toList // exclude default columns
+        } else {
+          columnsToCopyStr.split(",").toList
+        }
+      case None =>
+        sourceTable.asTable.getTableDef.customColumns.map(_.name).toList // exclude default columns
     }
     val sessionTableName = params.namedParams.get("sessionTableName") match {
       case Some(value) => value.asInstanceOf[String]

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -4,7 +4,7 @@ import org.finos.vuu.core.table.{TableContainer, ViewPortColumnCreator}
 import org.finos.vuu.net.ClientSessionId
 import org.finos.vuu.net.rpc.SessionTableCopyOption.{All, Empty, Selected}
 
-class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) extends DefaultRpcHandler {
+class CreateSessionTableRpcHandler(using tableContainer: TableContainer) extends DefaultRpcHandler {
   registerRpc(RpcNames.CreateSessionTableRpc, this.createSessionTable)
 
   def createSessionTable(params: RpcParams): RpcFunctionResult = {
@@ -24,7 +24,7 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
     }
     val sessionTableName = params.namedParams.get("sessionTableName") match {
       case Some(value) => value.asInstanceOf[String]
-      case None => s"Edit-${sourceTable.name}"
+      case None => s"edit-${sourceTable.name}"
     }
 
     if (!sourceTable.asTable.getTableDef.isEditable) {

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -13,7 +13,7 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
     val sourceTable = params.viewPort.table
     val copyOption = SessionTableCopyOption.fromString(params.namedParams("copyOption").asInstanceOf[String])
     val columnsToCopyStr = params.namedParams("columnsToCopy").asInstanceOf[String]
-    val columnsToCopy = if (columnsToCopyStr.equals("*")) List.empty[String] else columnsToCopyStr.split(",").toList
+    val columnsToCopy = if (columnsToCopyStr == null || columnsToCopyStr.isBlank || columnsToCopyStr.equals("*")) List.empty[String] else columnsToCopyStr.split(",").toList
     val sessionTableName = params.namedParams("sessionTableName").asInstanceOf[String]
 
     if (!sourceTable.asTable.getTableDef.isEditable) {
@@ -29,7 +29,7 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
 
     val sessionTableSource = tableContainer.getTable(sessionTableName)
     val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
-
+    // if columsntocopy not there, copy editable columns
     copyOption match {
       case All =>
         val vp = params.viewPort

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -11,13 +11,19 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
     val session: ClientSessionId = params.ctx.session
     val sourceTable = params.viewPort.table
     val copyOption = SessionTableCopyOption.fromString(params.namedParams("copyOption").asInstanceOf[String])
-    val columnsToCopyStr = params.namedParams("columnsToCopy").asInstanceOf[String]
+    val columnsToCopyStr = params.namedParams.get("columnsToCopy") match {
+      case Some(value) => value.asInstanceOf[String]
+      case None => null
+    }
     val columnsToCopy = if (columnsToCopyStr == null || columnsToCopyStr.isBlank || columnsToCopyStr.equals("*")) {
       sourceTable.asTable.getTableDef.customColumns.map(_.name).toList // exclude default columns
     } else {
       columnsToCopyStr.split(",").toList
     }
-    val sessionTableName = params.namedParams("sessionTableName").asInstanceOf[String]
+    val sessionTableName = params.namedParams.get("sessionTableName") match {
+      case Some(value) => value.asInstanceOf[String]
+      case None => s"Edit-${sourceTable.name}"
+    }
 
     if (!sourceTable.asTable.getTableDef.isEditable) {
       return new RpcFunctionFailure(s"Table ${sourceTable.name} is not editable")

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -1,9 +1,8 @@
 package org.finos.vuu.net.rpc
 
-import org.finos.vuu.core.table.{InMemSessionDataTable, TableContainer, ViewPortColumnCreator}
+import org.finos.vuu.core.table.{TableContainer, ViewPortColumnCreator}
 import org.finos.vuu.net.ClientSessionId
 import org.finos.vuu.net.rpc.SessionTableCopyOption.{All, Empty, Selected}
-import org.finos.vuu.viewport.{RowSource, ViewPort, ViewPortColumns}
 
 class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) extends DefaultRpcHandler {
   registerRpc(RpcNames.CreateSessionTableRpc, this.createSessionTable)
@@ -13,7 +12,11 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
     val sourceTable = params.viewPort.table
     val copyOption = SessionTableCopyOption.fromString(params.namedParams("copyOption").asInstanceOf[String])
     val columnsToCopyStr = params.namedParams("columnsToCopy").asInstanceOf[String]
-    val columnsToCopy = if (columnsToCopyStr == null || columnsToCopyStr.isBlank || columnsToCopyStr.equals("*")) List.empty[String] else columnsToCopyStr.split(",").toList
+    val columnsToCopy = if (columnsToCopyStr == null || columnsToCopyStr.isBlank || columnsToCopyStr.equals("*")) {
+      sourceTable.asTable.getTableDef.customColumns.map(_.name).toList // exclude default columns
+    } else {
+      columnsToCopyStr.split(",").toList
+    }
     val sessionTableName = params.namedParams("sessionTableName").asInstanceOf[String]
 
     if (!sourceTable.asTable.getTableDef.isEditable) {
@@ -29,30 +32,23 @@ class CreateSessionTableRpcHandler(using val tableContainer: TableContainer) ext
 
     val sessionTableSource = tableContainer.getTable(sessionTableName)
     val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
-    // if columsntocopy not there, copy editable columns
     copyOption match {
       case All =>
         val vp = params.viewPort
         val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy)
         val iterator = vp.getKeys.iterator.take(tableContainer.rpcOptions.maxCopySize)
-        copyRows(iterator, sessionTable, vp.table, vpColumns, columnsToCopy)
+        while (iterator.hasNext) {
+          sessionTable.processUpdate(vp.table.pullRow(iterator.next(), vpColumns))
+        }
       case Selected =>
         val vp = params.viewPort
         val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy)
         val iterator = vp.getSelection.iterator.take(tableContainer.rpcOptions.maxCopySize)
-        copyRows(iterator, sessionTable, vp.table, vpColumns, columnsToCopy)
+        while (iterator.hasNext) {
+          sessionTable.processUpdate(vp.table.pullRow(iterator.next(), vpColumns))
+        }
       case Empty =>
     }
     RpcFunctionSuccess(Some(Map("sessionTable" -> sessionTable.name, "module" -> sessionTable.tableDef.getModule().name)))
-  }
-
-  private def copyRows(iterator: Iterator[String], sessionTable: InMemSessionDataTable, sourceTable: RowSource, vpColumns: ViewPortColumns, columnsToCopy: List[String]): Unit = {
-    while (iterator.hasNext) {
-      if (columnsToCopy.isEmpty) {
-        sessionTable.processUpdate(sourceTable.pullRow(iterator.next()))
-      } else {
-        sessionTable.processUpdate(sourceTable.pullRow(iterator.next(), vpColumns))
-      }
-    }
   }
 }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/EditTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/EditTableRpcHandler.scala
@@ -4,14 +4,18 @@ import org.finos.vuu.core.table.TableContainer
 
 abstract class EditTableRpcHandler(using val tableContainer: TableContainer) extends DefaultRpcHandler {
   registerRpc(RpcNames.DeleteRowRpc, this.deleteRow)
+  registerRpc(RpcNames.DeleteSelectedRowsRpc, this.deleteSelectedRows)
   registerRpc(RpcNames.DeleteCellRpc, this.deleteCell)
   registerRpc(RpcNames.AddRowRpc, this.addRow)
   registerRpc(RpcNames.EditRowRpc, this.editRow)
   registerRpc(RpcNames.EditCellRpc, this.editCell)
   registerRpc(RpcNames.SubmitFormRpc, this.submitForm)
   registerRpc(RpcNames.CloseFormRpc, this.closeForm)
+  registerRpc(RpcNames.UndoRowChangeRpc, this.undoRowChange)
 
   def deleteRow(params: RpcParams): RpcFunctionResult
+
+  def deleteSelectedRows(params: RpcParams): RpcFunctionResult
 
   def deleteCell(params: RpcParams): RpcFunctionResult
 
@@ -24,4 +28,6 @@ abstract class EditTableRpcHandler(using val tableContainer: TableContainer) ext
   def submitForm(params: RpcParams): RpcFunctionResult
 
   def closeForm(params: RpcParams): RpcFunctionResult
+
+  def undoRowChange(params: RpcParams): RpcFunctionResult
 }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/RpcNames.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/RpcNames.scala
@@ -6,13 +6,17 @@ object RpcNames {
   val UniqueFieldValuesRpc: Rpc.FunctionName = "getUniqueFieldValues"
   val UniqueFieldValuesStartWithRpc: Rpc.FunctionName = "getUniqueFieldValuesStartingWith"
 
+  // in EditTableRpcHandler
   val DeleteRowRpc: Rpc.FunctionName = "deleteRow"
+  val DeleteSelectedRowsRpc: Rpc.FunctionName = "deleteSelectedRows"
   val DeleteCellRpc: Rpc.FunctionName = "deleteCell"
   val AddRowRpc: Rpc.FunctionName = "addRow"
   val EditRowRpc: Rpc.FunctionName = "editRow"
   val EditCellRpc: Rpc.FunctionName = "editCell"
   val SubmitFormRpc: Rpc.FunctionName = "submitForm"
   val CloseFormRpc: Rpc.FunctionName = "closeForm"
+  val UndoRowChangeRpc: Rpc.FunctionName = "undoRowChange"
+
   val CreateSessionTableRpc: Rpc.FunctionName = "createSessionTable"
   val EndEditSessionRpc: Rpc.FunctionName = "endEditSession"
 }

--- a/vuu/src/test/scala/org/finos/vuu/viewport/editable/EditableViewportWithRpcTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/editable/EditableViewportWithRpcTest.scala
@@ -61,11 +61,15 @@ class ConstituentInstrumentPricesRpcService()(using tableContainer: TableContain
 
   override def deleteRow(params: RpcParams): RpcFunctionResult = ???
 
+  override def deleteSelectedRows(params: RpcParams): RpcFunctionResult = ???
+
   override def deleteCell(params: RpcParams): RpcFunctionResult = ???
 
   override def addRow(params: RpcParams): RpcFunctionResult = ???
 
   override def closeForm(params: RpcParams): RpcFunctionResult = ???
+
+  override def undoRowChange(params: RpcParams): RpcFunctionResult = ???
 }
 
 class EditableViewportWithRpcTest extends EditableViewPortTest {

--- a/vuu/src/test/scala/org/finos/vuu/viewport/sessiontable/EditSessionTableTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/viewport/sessiontable/EditSessionTableTest.scala
@@ -85,11 +85,15 @@ class EditSessionTableTest extends AbstractViewPortTestCase with Matchers with G
 
     override def deleteRow(params: RpcParams): RpcFunctionResult = ???
 
+    override def deleteSelectedRows(params: RpcParams): RpcFunctionResult = ???
+
     override def deleteCell(params: RpcParams): RpcFunctionResult = ???
 
     override def addRow(params: RpcParams): RpcFunctionResult = ???
 
     override def closeForm(params: RpcParams): RpcFunctionResult = ???
+
+    override def undoRowChange(params: RpcParams): RpcFunctionResult = ???
   }
 
   /**
@@ -136,6 +140,9 @@ class EditSessionTableTest extends AbstractViewPortTestCase with Matchers with G
       RpcFunctionSuccess(None)
     }
 
+
+    override def deleteSelectedRows(params: RpcParams): RpcFunctionResult = ???
+
     override def deleteCell(params: RpcParams): RpcFunctionResult = ???
 
     override def addRow(params: RpcParams): RpcFunctionResult = ???
@@ -145,6 +152,8 @@ class EditSessionTableTest extends AbstractViewPortTestCase with Matchers with G
     override def editCell(params: RpcParams): RpcFunctionResult = ???
 
     override def closeForm(params: RpcParams): RpcFunctionResult = ???
+
+    override def undoRowChange(params: RpcParams): RpcFunctionResult = ???
   }
 
   Feature("Test full flow through editable session table") {

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -20,11 +20,12 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
     .addString("Name")
     .addInt("Account")
     .build();
-  private val tableName1 = "testTable1"
   private val nonEditableTableName = "nonEditableTable"
-  private val largeTableName = "largeTable"
+  private val tableName1 = "testTable1"
   private val defaultSessionTableDefName = "edit-" + tableName1
   private val sessionTableDefName = "testSessionTable1"
+  private val largeTableName = "largeTable"
+  private val largeSessionTableDefName = "edit-" + largeTableName
   private val moduleName = "EditInSessionTableRpcTest"
   private val testProviderFactory = new TestProviderFactory
   private val maxCopySize = 10 // configured in CoreServerApiTest
@@ -322,6 +323,11 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       ), viewPortDefFactoryForSessionTable)
       .addSessionTable(SessionTableDef(
         name = sessionTableDefName,
+        keyField = "Id",
+        columns = allColumns
+      ), viewPortDefFactoryForSessionTable)
+      .addSessionTable(SessionTableDef(
+        name = largeSessionTableDefName,
         keyField = "Id",
         columns = allColumns
       ), viewPortDefFactoryForSessionTable)

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -5,7 +5,7 @@ import org.finos.vuu.api.{ColumnBuilder, SessionTableDef, TableDef, ViewPortDef}
 import org.finos.vuu.core.AbstractVuuServer
 import org.finos.vuu.core.module.{ModuleFactory, ViewServerModule}
 import org.finos.vuu.core.table.{DataTable, TableContainer}
-import org.finos.vuu.net.{CreateViewPortRequest, CreateViewPortSuccess, GetTableMetaRequest, GetTableMetaResponse, RpcRequest, RpcResponseNew, SelectRowRangeRequest, SelectRowRangeSuccess, SelectRowRequest, SelectRowSuccess}
+import org.finos.vuu.net.{CreateViewPortRequest, CreateViewPortSuccess, RpcRequest, RpcResponseNew, SelectRowRangeRequest, SelectRowRangeSuccess, SelectRowRequest, SelectRowSuccess}
 import org.finos.vuu.net.rpc.{CreateSessionTableRpcHandler, EndEditSessionRpcHandler, RpcErrorResult, RpcNames, RpcSuccessResult, ViewPortContext}
 import org.finos.vuu.provider.{Provider, ProviderContainer}
 import org.finos.vuu.viewport.{ViewPortRange, ViewPortTable}
@@ -23,8 +23,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   private val tableName1 = "testTable1"
   private val nonEditableTableName = "nonEditableTable"
   private val largeTableName = "largeTable"
-  private val sessionTableDefName = "testSessionTable1"
   private val defaultSessionTableDefName = "edit-" + tableName1
+  private val sessionTableDefName = "testSessionTable1"
   private val moduleName = "EditInSessionTableRpcTest"
   private val testProviderFactory = new TestProviderFactory
   private val maxCopySize = 10 // configured in CoreServerApiTest
@@ -41,9 +41,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val createSessionTableRequest = RpcRequest(
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
-        params = Map(
-          "copyOption" -> "Empty"
-        ))
+        params = Map("copyOption" -> "Empty"))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
       Then("session table is created using default session table def")
@@ -87,7 +85,6 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "Empty",
           "columnsToCopy" -> "Id,Name"
         ))
@@ -111,7 +108,6 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "All",
           "columnsToCopy" -> "*"
         ))
@@ -135,7 +131,6 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "All",
           "columnsToCopy" -> "Id,Name"
         ))
@@ -159,7 +154,6 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "All",
           "columnsToCopy" -> "*"
         ))
@@ -190,9 +184,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableDefName,
-          "copyOption" -> "Selected",
-          "columnsToCopy" -> "*"
+          "copyOption" -> "Selected"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -218,9 +210,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableDefName,
-          "copyOption" -> "Selected",
-          "columnsToCopy" -> "*"
+          "copyOption" -> "Selected"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -242,9 +232,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableDefName,
-          "copyOption" -> "Empty",
-          "columnsToCopy" -> ""
+          "copyOption" -> "Empty"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -264,7 +252,6 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableDefName,
           "copyOption" -> "Empty",
           "columnsToCopy" -> "DUMMY"
         ))
@@ -329,12 +316,12 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       .addTableForTest(createTableDef(nonEditableTableName, false), viewPortDefFactory, providerFactory)
       .addTableForTest(createTableDef(largeTableName, true), viewPortDefFactory, largeProviderFactory)
       .addSessionTable(SessionTableDef(
-        name = sessionTableDefName,
+        name = defaultSessionTableDefName,
         keyField = "Id",
         columns = allColumns
       ), viewPortDefFactoryForSessionTable)
       .addSessionTable(SessionTableDef(
-        name = defaultSessionTableDefName,
+        name = sessionTableDefName,
         keyField = "Id",
         columns = allColumns
       ), viewPortDefFactoryForSessionTable)

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -20,10 +20,11 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
     .addString("Name")
     .addInt("Account")
     .build();
-  private val tableName1 = "EditInSessionTest1"
-  private val nonEditableTableName = "NonEditableTable"
-  private val largeTableName = "LargeTable"
-  private val sessionTableDefName = "EditInSessionTest1Session"
+  private val tableName1 = "testTable1"
+  private val nonEditableTableName = "nonEditableTable"
+  private val largeTableName = "largeTable"
+  private val sessionTableDefName = "testSessionTable1"
+  private val defaultSessionTableDefName = "edit-" + tableName1
   private val moduleName = "EditInSessionTableRpcTest"
   private val testProviderFactory = new TestProviderFactory
   private val maxCopySize = 10 // configured in CoreServerApiTest
@@ -32,6 +33,51 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   // Test when vp is filtered and sorted, the data copied to session table is also filtered and sorted
   // Test when copying from a given list of columns, only data from those columns are copied
   Feature("[Web Socket API] create a session table and copy data from source table") {
+    Scenario("create a session table from source table using default session table def") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(tableName1)
+
+      When("request creating a session table using default session table def")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "copyOption" -> "Empty"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is created using default session table def")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      sessionTableName.contains("simple-edit-testTable1") shouldBe true
+    }
+
+    Scenario("create a session table from source table using a specific session table def") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(tableName1)
+
+      When("request creating a session table using given session table def")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionTableName" -> sessionTableDefName,
+          "copyOption" -> "Empty"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is created using given session table def")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      sessionTableName.contains("simple-testSessionTable1") shouldBe true
+    }
+
     Scenario("create an empty session table from source table") {
       Given("a view port exist")
       val viewPortId = createViewPort(tableName1)
@@ -284,6 +330,11 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       .addTableForTest(createTableDef(largeTableName, true), viewPortDefFactory, largeProviderFactory)
       .addSessionTable(SessionTableDef(
         name = sessionTableDefName,
+        keyField = "Id",
+        columns = allColumns
+      ), viewPortDefFactoryForSessionTable)
+      .addSessionTable(SessionTableDef(
+        name = defaultSessionTableDefName,
         keyField = "Id",
         columns = allColumns
       ), viewPortDefFactoryForSessionTable)


### PR DESCRIPTION
#2214 
- add deleteSelectedRows rpc
- add undoRowChange rpc
- make columnsToCopy optional in createSessionTable rpc handler and if it's not defined, copy all columns from source table except default columns
- make sessionTableName optional in createSessionTable rpc handler and if it's not defined, use default name "edit-TABLENAME"