### PR TITLE
Replace dropwizard-metrics with micrometer 1.15.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <jackson.version>3.1.5</jackson.version>
         <junit.jupiter.version>6.1.2</junit.jupiter.version>
         <logback.version>1.5.38</logback.version>
-        <metrics.version>4.2.38</metrics.version>
+        <micrometer.version>1.15.4</micrometer.version>
         <netty.version>4.2.16.Final</netty.version>
         <roaring.bitmap.version>1.6.14</roaring.bitmap.version>
         <scala.version>3.3.8</scala.version> <!-- Scala LTS -->

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -33,15 +33,15 @@
         </dependency>
 
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>${metrics.version}</version>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${micrometer.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-jmx</artifactId>
-            <version>${metrics.version}</version>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-jmx</artifactId>
+            <version>${micrometer.version}</version>
         </dependency>
 
         <dependency>

--- a/toolbox/src/main/scala/org/finos/toolbox/jmx/MetricsProvider.scala
+++ b/toolbox/src/main/scala/org/finos/toolbox/jmx/MetricsProvider.scala
@@ -1,28 +1,29 @@
 package org.finos.toolbox.jmx
 
-import com.codahale.metrics._
-import com.codahale.metrics.jmx._
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.micrometer.core.instrument.{Clock, Counter, DistributionSummary, MeterRegistry}
+import io.micrometer.jmx.{JmxConfig, JmxMeterRegistry}
 
 
 trait MetricsProvider{
-  def meter(name: String): Meter
+  def meter(name: String): Counter
   def counter(name: String): Counter
-  def histogram(name: String): Histogram
+  def histogram(name: String): DistributionSummary
 }
 
 class MetricsProviderImpl() extends MetricsProvider{
-  final val metrics = new MetricRegistry()
 
-  @volatile var reporter: JmxReporter = null
+  final val metrics: MeterRegistry =
+    if (JmxInfra.isJmxEnabled) new JmxMeterRegistry(JmxConfig.DEFAULT, Clock.SYSTEM)
+    else new SimpleMeterRegistry()
 
-  override def histogram(name: String): Histogram = metrics.histogram(name)
-  override def meter(name: String): Meter = metrics.meter(name)
+  override def histogram(name: String): DistributionSummary =
+    DistributionSummary.builder(name)
+      .publishPercentiles(0.5, 0.75, 0.99, 0.999)
+      .register(metrics)
+
+  override def meter(name: String): Counter = metrics.counter(name)
+
   override def counter(name: String): Counter = metrics.counter(name)
 
-  if(JmxInfra.isJmxEnabled){
-    reporter = JmxReporter.forRegistry(metrics).build()
-    reporter.start()
-  }
-
 }
-

--- a/toolbox/src/test/scala/org/finos/toolbox/metrics/MetricsProviderTest.scala
+++ b/toolbox/src/test/scala/org/finos/toolbox/metrics/MetricsProviderTest.scala
@@ -14,16 +14,17 @@ class MetricsProviderTest extends AnyFeatureSpec with Matchers {
 
       val histogram = metrics.histogram("foo.bar")
 
-      histogram.update(1L)
+      histogram.record(1.0)
 
-      histogram.update(2L)
+      histogram.record(2.0)
 
-      histogram.update(3L)
+      histogram.record(3.0)
 
-      val snapshot = histogram.getSnapshot
+      val snapshot = histogram.takeSnapshot()
 
-      snapshot.getMax should equal(3L)
-      snapshot.getMin should equal(1L)
+      snapshot.max() should equal(3.0)
+      snapshot.count() should equal(3L)
+      snapshot.mean() should equal(2.0)
 
     }
 

--- a/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsGroupByProvider.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsGroupByProvider.scala
@@ -1,7 +1,8 @@
 package org.finos.vuu.core.module.metrics
 
-import com.codahale.metrics.Histogram
 import com.typesafe.scalalogging.StrictLogging
+import io.micrometer.core.instrument.DistributionSummary
+import org.finos.vuu.core.module.metrics.MicrometerMetrics.percentileValue
 import org.finos.vuu.core.table.{DataTable, RowWithData}
 import org.finos.vuu.provider.Provider
 import org.finos.vuu.viewport.ViewPortContainer
@@ -32,7 +33,7 @@ class MetricsGroupByProvider(table: DataTable, viewPortContainer: ViewPortContai
 
   override val lifecycleId: String = "metricsGroupByProvider"
 
-  def buildColumnsForHistogram(prefix: String, hist: Histogram): Map[String, Any] = {
+  def buildColumnsForHistogram(prefix: String, hist: DistributionSummary): Map[String, Any] = {
     /*
     val settree_mean = "settree_mean"
     val settree_samples = "settree_samples"
@@ -45,11 +46,11 @@ class MetricsGroupByProvider(table: DataTable, viewPortContainer: ViewPortContai
       Map()
     } else {
 
-      val snapshot = hist.getSnapshot
+      val snapshot = hist.takeSnapshot()
 
-      Map(prefix + "_mean" -> snapshot.getMean, prefix + "_samples" -> snapshot.getValues.length,
-        prefix + "_50_perc" -> snapshot.getMedian, prefix + "_75_perc" -> snapshot.get75thPercentile(),
-        prefix + "_99_perc" -> snapshot.get99thPercentile(), prefix + "_99_9_perc" -> snapshot.get999thPercentile()
+      Map(prefix + "_mean" -> snapshot.mean(), prefix + "_samples" -> snapshot.count(),
+        prefix + "_50_perc" -> percentileValue(snapshot, 0.5), prefix + "_75_perc" -> percentileValue(snapshot, 0.75),
+        prefix + "_99_perc" -> percentileValue(snapshot, 0.99), prefix + "_99_9_perc" -> percentileValue(snapshot, 0.999)
       )
     }
   }

--- a/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsTableProvider.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsTableProvider.scala
@@ -9,6 +9,8 @@ import org.finos.vuu.core.table.{DataTable, RowWithData, TableContainer}
 import org.finos.vuu.provider.Provider
 import org.finos.vuu.viewport.ViewPortTable
 
+import java.util.concurrent.ConcurrentHashMap
+
 class MetricsTableProvider(table: DataTable, tableContainer: TableContainer)(implicit clock: Clock, lifecycleContainer: LifecycleContainer,
                                                                              metrics: MetricsProvider) extends Provider with StrictLogging {
 
@@ -38,16 +40,19 @@ class MetricsTableProvider(table: DataTable, tableContainer: TableContainer)(imp
     }
   }
 
+  private val updateRates = new ConcurrentHashMap[String, CounterRatePerSecond]()
+
   private def getMetricsData(vpTable: ViewPortTable): Map[String, Any] = {
     val counter = metrics.counter(vpTable.table + ".processUpdates.Counter")
     val size = tableContainer.getTable(vpTable.table).size()
-    val meter = metrics.meter(vpTable.table + ".processUpdates.Meter")
+    val updateRate = updateRates.computeIfAbsent(vpTable.table,
+      t => new CounterRatePerSecond(metrics.meter(t + ".processUpdates.Meter")))
 
     Map(
       "table" -> (vpTable.module + "-" + vpTable.table),
-      "updateCount" -> counter.getCount,
+      "updateCount" -> counter.count().toLong,
       "size" -> size,
-      "updatesPerSecond" -> meter.getOneMinuteRate
+      "updatesPerSecond" -> updateRate.perSecond()
     )
   }
 }

--- a/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsViewPortParallelismProvider.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsViewPortParallelismProvider.scala
@@ -18,15 +18,15 @@ class MetricsViewPortParallelismProvider(table: DataTable, viewPortContainer: Vi
 
   lifecycleContainer(this).dependsOn(runner)
 
+  private val treeWorkRate = new CounterRatePerSecond(viewPortContainer.totalTreeWorkHistogram)
+  private val flatWorkRate = new CounterRatePerSecond(viewPortContainer.totalFlatWorkHistogram)
+
   private def runOnce(): Unit = {
-    val flatWorkMeter = viewPortContainer.totalFlatWorkHistogram
-    val treeWorkMeter = viewPortContainer.totalTreeWorkHistogram
+    val treeRate = treeWorkRate.perSecond() // this is ms of work done per second
+    val flatRate = flatWorkRate.perSecond()
 
-    val treeFiveMinRate = treeWorkMeter.getOneMinuteRate // this is events/sec over x minutes
-    val flatFiveMinRate = flatWorkMeter.getOneMinuteRate
-
-    val tree = Map("type" -> "tree", ViewPortParallelism.work_ms_in_1m -> treeFiveMinRate, ViewPortParallelism.work_par_ratio -> (treeFiveMinRate / 1000))
-    val flat = Map("type" -> "flat", ViewPortParallelism.work_ms_in_1m -> flatFiveMinRate, ViewPortParallelism.work_par_ratio -> (flatFiveMinRate / 1000))
+    val tree = Map("type" -> "tree", ViewPortParallelism.work_ms_in_1m -> treeRate, ViewPortParallelism.work_par_ratio -> (treeRate / 1000))
+    val flat = Map("type" -> "flat", ViewPortParallelism.work_ms_in_1m -> flatRate, ViewPortParallelism.work_par_ratio -> (flatRate / 1000))
 
     table.processUpdate("tree", RowWithData("tree", tree))
     table.processUpdate("flat", RowWithData("flat", flat))

--- a/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsViewPortProvider.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MetricsViewPortProvider.scala
@@ -5,6 +5,7 @@ import org.finos.toolbox.jmx.MetricsProvider
 import org.finos.toolbox.lifecycle.LifecycleContainer
 import org.finos.toolbox.thread.LifeCycleRunner
 import org.finos.toolbox.time.Clock
+import org.finos.vuu.core.module.metrics.MicrometerMetrics.percentileValue
 import org.finos.vuu.core.table.datatype.{Scale, ScaledDecimal}
 import org.finos.vuu.core.table.{DataTable, RowWithData}
 import org.finos.vuu.provider.Provider
@@ -44,20 +45,20 @@ class MetricsViewPortProvider(table: DataTable, viewPortContainer: ViewPortConta
       val toDelete = viewportIds.filterNot(kv => mapOfHistograms.contains(kv._1)).toMap
 
       mapOfHistograms.foreach({ case (key, histogram) => {
-        val snapshot = histogram.getSnapshot
+        val snapshot = histogram.takeSnapshot()
         val vp = viewPortContainer.getViewPorts.find(f => f.id == key).orNull
         if (vp != null) {
           val upMap = Map(
             "id" -> key,
             "table" -> vp.table.name,
-            "mean" -> ScaledDecimal(snapshot.getMean, Scale.Two),
-            "max" -> snapshot.getMax,
+            "mean" -> ScaledDecimal(snapshot.mean(), Scale.Two),
+            "max" -> snapshot.max(),
             "structureHash" -> vp.getStructuralHashCode(),
             "updateCount" -> vp.getTableUpdateCount(),
             "keyBuildCount" -> vp.keyBuildCount,
-            "75Perc" -> ScaledDecimal(snapshot.get75thPercentile(), Scale.Four),
-            "99Perc" -> ScaledDecimal(snapshot.get99thPercentile(), Scale.Six),
-            "99_9Perc" -> ScaledDecimal(snapshot.get999thPercentile(), Scale.Eight)
+            "75Perc" -> ScaledDecimal(percentileValue(snapshot, 0.75), Scale.Four),
+            "99Perc" -> ScaledDecimal(percentileValue(snapshot, 0.99), Scale.Six),
+            "99_9Perc" -> ScaledDecimal(percentileValue(snapshot, 0.999), Scale.Eight)
           )
           table.processUpdate(key, RowWithData(key, upMap))
         } else {

--- a/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MicrometerMetrics.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/module/metrics/MicrometerMetrics.scala
@@ -1,0 +1,41 @@
+package org.finos.vuu.core.module.metrics
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.distribution.HistogramSnapshot
+import org.finos.toolbox.time.Clock
+
+/**
+ * Computes a per-second rate from a monotonically increasing counter by sampling
+ * it on each call. Dropwizard meters exposed a one-minute exponentially weighted
+ * rate; Micrometer counters leave rate computation to the consumer, so the
+ * providers that used to read getOneMinuteRate sample the counter on their run
+ * cycle instead.
+ */
+class CounterRatePerSecond(counter: Counter)(implicit clock: Clock) {
+
+  private var lastTimeMillis: Long = clock.now()
+  private var lastCount: Double = counter.count()
+
+  def perSecond(): Double = {
+    val nowMillis = clock.now()
+    val count = counter.count()
+    val elapsedMillis = nowMillis - lastTimeMillis
+    val rate = if (elapsedMillis <= 0) 0.0 else (count - lastCount) * 1000.0 / elapsedMillis
+    lastTimeMillis = nowMillis
+    lastCount = count
+    rate
+  }
+}
+
+object MicrometerMetrics {
+
+  /**
+   * Returns the value recorded for a percentile the summary was configured to
+   * publish (see MetricsProviderImpl), or 0.0 when nothing has been recorded.
+   */
+  def percentileValue(snapshot: HistogramSnapshot, percentile: Double): Double =
+    snapshot.percentileValues()
+      .find(pv => math.abs(pv.percentile() - percentile) < 1e-6)
+      .map(_.value())
+      .getOrElse(0.0)
+}

--- a/vuu/src/main/scala/org/finos/vuu/core/table/AutoSubscribeTable.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/AutoSubscribeTable.scala
@@ -16,10 +16,10 @@ class AutoSubscribeTable(tableDef: TableDef, joinProvider: JoinTableProvider)(im
 
   def tryAndSubscribe(key: String): Unit = {
 
-    totalSubscribe.inc()
+    totalSubscribe.increment()
 
     if (!subscriptionKeys.contains(key)) {
-      onTrySubscribe.inc()
+      onTrySubscribe.increment()
 
       subscriptionKeys.add(key)
       getProvider.subscribe(key)

--- a/vuu/src/main/scala/org/finos/vuu/core/table/InMemDataTable.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/InMemDataTable.scala
@@ -386,7 +386,7 @@ class InMemDataTable(val tableDef: TableDef, val joinProvider: JoinTableProvider
   }
 
   def sendToJoinSink(rowKey: String, rowData: RowData): Unit = {
-    eventIntoJoiner.inc()
+    eventIntoJoiner.increment()
     if (joinProvider.hasJoins(this.tableDef.name)) {
       val event = toEvent(rowKey, rowData)
       joinProvider.sendEvent(this.tableDef.name, event)
@@ -394,7 +394,7 @@ class InMemDataTable(val tableDef: TableDef, val joinProvider: JoinTableProvider
   }
 
   def sendDeleteToJoinSink(rowKey: String, rowData: RowData): Unit = {
-    eventIntoJoiner.inc()
+    eventIntoJoiner.increment()
     if (joinProvider.hasJoins(this.tableDef.name)) {
       val event = toDeleteEvent(rowKey, rowData)
       joinProvider.sendEvent(this.tableDef.name, event)
@@ -403,9 +403,9 @@ class InMemDataTable(val tableDef: TableDef, val joinProvider: JoinTableProvider
 
   def processUpdate(rowKey: String, rowData: RowData): Unit = {
 
-    onUpdateMeter.mark()
+    onUpdateMeter.increment()
 
-    onUpdateCounter.inc()
+    onUpdateCounter.increment()
 
     val updatedRowData = update(rowKey, rowData)
 
@@ -418,9 +418,9 @@ class InMemDataTable(val tableDef: TableDef, val joinProvider: JoinTableProvider
 
   def processDelete(rowKey: String): Unit = {
 
-    onDeleteMeter.mark()
+    onDeleteMeter.increment()
 
-    onUpdateCounter.inc()
+    onUpdateCounter.increment()
 
     val rowData = delete(rowKey)
 

--- a/vuu/src/main/scala/org/finos/vuu/core/table/JoinTable.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/table/JoinTable.scala
@@ -79,7 +79,7 @@ class JoinTable(val tableDef: JoinTableDef,
 
   override def processUpdate(rowKey: String, rowUpdate: RowData): Unit = {
 
-    onUpdateMeter.mark()
+    onUpdateMeter.increment()
 
     logger.trace(s"$name processing row update: $rowKey $rowUpdate")
 

--- a/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortContainer.scala
+++ b/vuu/src/main/scala/org/finos/vuu/viewport/ViewPortContainer.scala
@@ -1,6 +1,6 @@
 package org.finos.vuu.viewport
 
-import com.codahale.metrics.{Histogram, Meter}
+import io.micrometer.core.instrument.{Counter, DistributionSummary}
 import com.typesafe.scalalogging.StrictLogging
 import org.finos.toolbox.collection.array.ImmutableArray
 import org.finos.toolbox.jmx.{JmxAble, MetricsProvider}
@@ -54,20 +54,20 @@ class ViewPortContainer(val tableContainer: TableContainer, val providerContaine
 
   private val viewPortHistogram = metrics.histogram(toJmxName("thread.viewport.cycleTime"))
 
-  val viewPortHistograms = new ConcurrentHashMap[String, Histogram]()
-  val treeToKeysHistograms = new ConcurrentHashMap[String, Histogram]()
-  val treeSetKeysHistograms = new ConcurrentHashMap[String, Histogram]()
-  val treeSetTreeHistograms = new ConcurrentHashMap[String, Histogram]()
-  val treeDiffBranchesHistograms = new ConcurrentHashMap[String, Histogram]()
-  val treeBuildHistograms = new ConcurrentHashMap[String, Histogram]()
-  val filterSortHistograms = new ConcurrentHashMap[String, Histogram]()
+  val viewPortHistograms = new ConcurrentHashMap[String, DistributionSummary]()
+  val treeToKeysHistograms = new ConcurrentHashMap[String, DistributionSummary]()
+  val treeSetKeysHistograms = new ConcurrentHashMap[String, DistributionSummary]()
+  val treeSetTreeHistograms = new ConcurrentHashMap[String, DistributionSummary]()
+  val treeDiffBranchesHistograms = new ConcurrentHashMap[String, DistributionSummary]()
+  val treeBuildHistograms = new ConcurrentHashMap[String, DistributionSummary]()
+  val filterSortHistograms = new ConcurrentHashMap[String, DistributionSummary]()
 
   private val viewPortDefinitions = new ConcurrentHashMap[String, (DataTable, Provider, ProviderContainer, TableContainer) => ViewPortDef]()
   private val viewPorts = new ConcurrentHashMap[SessionViewPortId, ViewPort]()
   private val treeNodeStatesByVp = new ConcurrentHashMap[String, TreeNodeStateStore]()
 
-  val totalTreeWorkHistogram: Meter = metrics.meter(toJmxName("viewport.work.tree"))
-  val totalFlatWorkHistogram: Meter = metrics.meter(toJmxName("viewport.work.flat"))
+  val totalTreeWorkHistogram: Counter = metrics.meter(toJmxName("viewport.work.tree"))
+  val totalFlatWorkHistogram: Counter = metrics.meter(toJmxName("viewport.work.flat"))
 
   def getViewPorts: List[ViewPort] = CollectionHasAsScala(viewPorts.values()).asScala.toList
 
@@ -647,7 +647,7 @@ class ViewPortContainer(val tableContainer: TableContainer, val providerContaine
       })
     }
 
-    viewPortHistogram.update(millis)
+    viewPortHistogram.record(millis.toDouble)
   }
 
   /**
@@ -716,11 +716,11 @@ class ViewPortContainer(val tableContainer: TableContainer, val providerContaine
     val (millis, _) = timeIt{
       refreshOneTreeViewPortInternal(viewPort)
     }
-    totalTreeWorkHistogram.mark(millis)
+    totalTreeWorkHistogram.increment(millis.toDouble)
   }
 
-  private def updateHistogram(vp: ViewPort, histograms: ConcurrentHashMap[String, Histogram], suffix: String, millis: Long): Unit = {
-    histograms.computeIfAbsent(vp.id, s => metrics.histogram(toJmxName(suffix + s))).update(millis)
+  private def updateHistogram(vp: ViewPort, histograms: ConcurrentHashMap[String, DistributionSummary], suffix: String, millis: Long): Unit = {
+    histograms.computeIfAbsent(vp.id, s => metrics.histogram(toJmxName(suffix + s))).record(millis.toDouble)
   }
 
   private def refreshOneTreeViewPortInternal(viewPort: ViewPort): Unit = {
@@ -841,7 +841,7 @@ class ViewPortContainer(val tableContainer: TableContainer, val providerContaine
     val (millis, _) = timeIt{
       refreshOneViewPortInternal(viewPort)
     }
-    totalFlatWorkHistogram.mark(millis)
+    totalFlatWorkHistogram.increment(millis.toDouble)
   }
 
   private def refreshOneViewPortInternal(viewPort: ViewPort): Unit = {
@@ -863,7 +863,7 @@ class ViewPortContainer(val tableContainer: TableContainer, val providerContaine
           viewPort.setKeys(viewPort.getKeys.create(sorted))
         }
 
-        viewPortHistograms.computeIfAbsent(viewPort.id, s => metrics.histogram(toJmxName("vp.flat.cycle." + s))).update(millis)
+        viewPortHistograms.computeIfAbsent(viewPort.id, s => metrics.histogram(toJmxName("vp.flat.cycle." + s))).record(millis.toDouble)
         viewPort.setLastHashAndUpdateCount(currentStructureHash, currentUpdateCount)
       }
 

--- a/vuu/src/test/scala/org/finos/vuu/core/table/InMemSessionDataTableTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/table/InMemSessionDataTableTest.scala
@@ -33,8 +33,8 @@ class InMemSessionDataTableTest extends AnyFeatureSpec with Matchers {
       val counter = metricsProvider.counter(inMemSessionDataTable.name + ".processUpdates.Counter")
       val meter = metricsProvider.meter(inMemSessionDataTable.name + ".processUpdates.Meter")
 
-      counter.getCount shouldEqual 2
-      meter.getCount shouldEqual 2
+      counter.count() shouldEqual 2.0
+      meter.count() shouldEqual 2.0
     }
   }
 


### PR DESCRIPTION
Fixes #1785

## What changed

- `toolbox` now depends on `micrometer-core` and `micrometer-registry-jmx` 1.15.4 (aligned with the Spring Boot BOM) instead of `io.dropwizard.metrics`.
- `MetricsProvider` keeps its `meter`/`counter`/`histogram` API shape, but hands out Micrometer `Counter`s and `DistributionSummary`s. Summaries publish the percentiles the metrics tables display (50/75/99/99.9). When JMX is enabled the registry is a `JmxMeterRegistry`, otherwise a `SimpleMeterRegistry` — matching the old conditional `JmxReporter`.
- Call sites: `inc()`/`mark()` → `increment()`, `update(millis)` → `record(millis)`, snapshot reads (`getMean`/`getMax`/`getMedian`/`getNNthPercentile`) → `takeSnapshot()` + `mean()`/`max()`/percentile lookup.

## One semantic decision to review

Dropwizard `Meter` exposed `getOneMinuteRate` (1-minute EWMA), read by `MetricsTableProvider` (`updatesPerSecond`) and `MetricsViewPortParallelismProvider`. Micrometer counters deliberately leave rate computation to the backend/consumer, so those providers now sample the counter on their 1-second run cycle via a small `CounterRatePerSecond` helper — a windowed instantaneous rate rather than a 1-minute EWMA. The displayed values will be less smoothed than before; happy to add EWMA smoothing to the helper if you'd rather preserve the old feel.

Two smaller notes:
- `snapshot.count()` (total recorded events) replaces `getValues.length` (reservoir sample size) for the `_samples` columns.
- JMX bean naming follows Micrometer's `HierarchicalNameMapper`, so bean names may differ slightly from the Dropwizard reporter's.

## Testing

- `mvn -pl toolbox test`: 55/55 pass (including the migrated `MetricsProviderTest`).
- `mvn -pl vuu test -Dsuites=org.finos.vuu.core.table.InMemSessionDataTableTest`: passes (counter/meter counts still recorded through `InMemDataTable`).
- `mvn -pl toolbox,vuu -am compile`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)