### PR TITLE
feat: add createSessionTable RPC with CopyOption API

### DIFF
--- a/vuu-ui/packages/vuu-data-react/src/hooks/useVuuMenuActions.tsx
+++ b/vuu-ui/packages/vuu-data-react/src/hooks/useVuuMenuActions.tsx
@@ -371,7 +371,8 @@ export const useVuuMenuActions = ({
         );
       }
 
-      const sessionDs = await ds.createSessionDataSource?.(action.table);
+      //will the tableSchema be different to ds?
+      const sessionDs = await ds.createSessionDataSource?.('All');
       const handleSubmit = () => {
         sessionDs?.rpcRequest?.({
           params: {

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -680,18 +680,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     return Promise.reject<T>();
   }
 
-  createSessionDataSource(sessionTable: VuuTable) {
-    //TODO filters, sort etc
-    const columns = this.#sessionTableMessageColumn
-      ? this.columns.concat(this.#sessionTableMessageColumn)
-      : this.columns;
-    return new VuuDataSource({
-      columns: columns,
-      table: sessionTable,
-    });
-  }
-
-  async createSessionTable(
+  async createSessionDataSource(
     copyOption: CopyOption,
   ): Promise<VuuDataSource | undefined> {
     const rpcResponse = await this?.rpcRequest?.({
@@ -708,7 +697,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
       });
     } else {
       throw Error(
-        `[VuuDataSource] createSessionTable ${rpcResponse?.errorMessage}`,
+        `[VuuDataSource] createSessionDataSource ${rpcResponse?.errorMessage}`,
       );
     }
   }

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -9,6 +9,7 @@ import type {
   DataSourceVisualLinkCreatedMessage,
   DeleteRowMode,
   EditSessionMode,
+  CopyOption,
   OptimizeStrategy,
   ServerAPI,
   TableSchema,
@@ -44,7 +45,6 @@ import {
   itemsOrOrderChanged,
   logger,
   Range,
-  toRpcEditSessionMode,
   StaleUpdateError,
   throttle,
   uuid,
@@ -691,12 +691,34 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     });
   }
 
+  async createSessionTable(
+    copyOption: CopyOption,
+  ): Promise<VuuDataSource | undefined> {
+    const rpcResponse = await this?.rpcRequest?.({
+      type: "RPC_REQUEST",
+      rpcName: "createSessionTable",
+      params: { copyOption },
+    });
+    if (isRpcSuccess(rpcResponse)) {
+      const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
+      return new VuuDataSource({
+        ...this.config,
+        table: sessionTable,
+        viewport: sessionTable.table,
+      });
+    } else {
+      throw Error(
+        `[VuuDataSource] createSessionTable ${rpcResponse?.errorMessage}`,
+      );
+    }
+  }
+
   async beginEditSession(editSessionMode: EditSessionMode = "all-rows") {
     const rpcResponse = await this?.rpcRequest?.({
       type: "RPC_REQUEST",
       rpcName: "beginEditSession",
       params: {
-        editSessionMode: toRpcEditSessionMode(editSessionMode),
+        editSessionMode,
       },
     });
 

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -11,6 +11,7 @@ import type {
   DataSourceVisualLinkCreatedMessage,
   DeleteRowMode,
   EditSessionMode,
+  CopyOption,
 } from "@vuu-ui/vuu-data-types";
 import type {
   LinkDescriptorWithLabel,
@@ -31,7 +32,6 @@ import {
   isRpcSuccess,
   isTypeaheadRequest,
   Range,
-  toRpcEditSessionMode,
   uuid,
 } from "@vuu-ui/vuu-utils";
 import {
@@ -246,12 +246,34 @@ export class TickingArrayDataSource extends ArrayDataSource {
     }
   }
 
+  async createSessionTable(
+    copyOption: CopyOption,
+  ): Promise<DataSourceBase<DataSourceRowWithBigint> | undefined> {
+    const rpcResponse = await this?.rpcRequest?.({
+      type: "RPC_REQUEST",
+      rpcName: "createSessionTable",
+      params: { copyOption },
+    });
+    if (isRpcSuccess(rpcResponse)) {
+      const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
+      return this.#vuuModule?.createDataSource(
+        sessionTable.table,
+        sessionTable.table,
+        this.config,
+      );
+    } else {
+      throw Error(
+        `[TickingArrayDataSource] createSessionTable ${rpcResponse?.errorMessage}`,
+      );
+    }
+  }
+
   async beginEditSession(editSessionMode: EditSessionMode = "inline-all-rows") {
     const rpcResponse = await this?.rpcRequest?.({
       type: "RPC_REQUEST",
       rpcName: "beginEditSession",
       params: {
-        editSessionMode: toRpcEditSessionMode(editSessionMode),
+        editSessionMode,
       },
     });
 

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -233,20 +233,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
     }
   };
 
-  createSessionDataSource(sessionTable: VuuTable) {
-    if (this.#vuuModule) {
-      return this.#vuuModule?.createDataSource(
-        sessionTable.table,
-        sessionTable.table,
-      );
-    } else {
-      throw Error(
-        `[TickingArrayDataSource] unable to createSessionDataSource, not constructed with VuuModule`,
-      );
-    }
-  }
-
-  async createSessionTable(
+  async createSessionDataSource(
     copyOption: CopyOption,
   ): Promise<DataSourceBase<DataSourceRowWithBigint> | undefined> {
     const rpcResponse = await this?.rpcRequest?.({
@@ -263,7 +250,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
       );
     } else {
       throw Error(
-        `[TickingArrayDataSource] createSessionTable ${rpcResponse?.errorMessage}`,
+        `[TickingArrayDataSource] createSessionDataSource ${rpcResponse?.errorMessage}`,
       );
     }
   }

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -6,7 +6,7 @@ import {
   DataSourceVisualLinkCreatedMessage,
   DeleteRowMode,
   EditSessionMode,
-  EditSessionModeAlias,
+  CopyOption,
   TableSchema,
 } from "@vuu-ui/vuu-data-types";
 import {
@@ -27,10 +27,10 @@ import {
 import {
   isAddRowRpcRequest,
   isBeginEditSessionRpcRequest,
+  isCreateSessionTableRpcRequest,
   isDeleteSelectedRowsRpcRequest,
   isEditCellRpcRequest,
   isEndEditSessionRpcRequest,
-  fromRpcEditSessionMode,
   isRpcSuccess,
   isUndoRowChangeRpcRequest,
   uuid,
@@ -642,13 +642,15 @@ export abstract class VuuModule<T extends string = string>
     }
   };
 
-  private beginEditSession: ServiceHandler = async (rpcRequest) => {
-    if (isBeginEditSessionRpcRequest(rpcRequest)) {
+  /**
+   * Creates a standalone session table without starting an inline edit session.
+   * The `copyOption` determines which rows are copied into the session table.
+   * Returns the session table reference so the caller can subscribe to it.
+   */
+  private createSessionTableService: ServiceHandler = async (rpcRequest) => {
+    if (isCreateSessionTableRpcRequest(rpcRequest)) {
       const { viewPortId } = rpcRequest.context;
-      const { editSessionMode = "inline-all-rows" } = rpcRequest.params;
-      const longFormMode = fromRpcEditSessionMode(
-        editSessionMode as EditSessionModeAlias,
-      );
+      const { copyOption } = rpcRequest.params;
       const subscription = this.getSubscriptionByViewport(viewPortId);
       const { dataSource } = subscription;
       const { table: vuuTable } = dataSource;
@@ -660,7 +662,50 @@ export abstract class VuuModule<T extends string = string>
             const sessionTable = this.createSessionTable(
               sourceTable,
               sessionTableName,
-              longFormMode,
+              copyOption,
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              dataSource as TickingArrayDataSource,
+            );
+            this.#sessionTableMap[sessionTableName] = sessionTable;
+            subscription.sessionTableName = sessionTableName;
+            return {
+              data: {
+                table: { module: vuuTable.module, table: sessionTableName },
+              },
+              type: "SUCCESS_RESULT",
+            };
+          } catch (e) {
+            return {
+              type: "ERROR_RESULT",
+              errorMessage: (e as Error).message,
+            };
+          }
+        }
+      }
+    }
+    return {
+      type: "ERROR_RESULT",
+      errorMessage: "createSessionTable: invalid rpc request",
+    };
+  };
+
+  private beginEditSession: ServiceHandler = async (rpcRequest) => {
+    if (isBeginEditSessionRpcRequest(rpcRequest)) {
+      const { viewPortId } = rpcRequest.context;
+      const { editSessionMode = "inline-all-rows" } = rpcRequest.params;
+      const subscription = this.getSubscriptionByViewport(viewPortId);
+      const { dataSource } = subscription;
+      const { table: vuuTable } = dataSource;
+      if (vuuTable) {
+        const sourceTable = this.tables[vuuTable.table as T];
+        if (sourceTable) {
+          const sessionTableName = `session-${uuid()}`;
+          try {
+            const sessionTable = this.createSessionTable(
+              sourceTable,
+              sessionTableName,
+              editSessionMode as EditSessionMode,
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore
               dataSource as TickingArrayDataSource,
@@ -846,18 +891,24 @@ export abstract class VuuModule<T extends string = string>
   protected createSessionTable(
     sourceTable: Table,
     sessionTableName: string,
-    editSessionMode: EditSessionMode = "inline-all-rows",
+    editSessionMode: EditSessionMode | CopyOption = "inline-all-rows",
     dataSource: TickingArrayDataSource,
   ) {
-    if (editSessionMode.endsWith("all-rows")) {
+    if (editSessionMode === "All" || editSessionMode.endsWith("all-rows")) {
       return this.createSessionTableWithAllRows(sourceTable, sessionTableName);
-    } else if (editSessionMode === "selected-rows") {
+    } else if (
+      editSessionMode === "Selected" ||
+      editSessionMode === "selected-rows"
+    ) {
       return this.createSessionTableFromSelectedRows(
         sourceTable,
         sessionTableName,
         dataSource,
       );
-    } else if (editSessionMode === "empty-session-table") {
+    } else if (
+      editSessionMode === "Empty" ||
+      editSessionMode === "empty-session-table"
+    ) {
       return this.createEmptySessionTable(sourceTable, sessionTableName);
     } else {
       throw Error(
@@ -929,6 +980,10 @@ export abstract class VuuModule<T extends string = string>
     {
       rpcName: "VP_BULK_EDIT_COLUMN_CELLS_RPC",
       service: this.applyBulkEdits,
+    },
+    {
+      rpcName: "createSessionTable",
+      service: this.createSessionTableService,
     },
     {
       rpcName: "beginEditSession",

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -643,7 +643,7 @@ export abstract class VuuModule<T extends string = string>
   };
 
   /**
-   * Creates a standalone session table without starting an inline edit session.
+   * Creates a standalone session table.
    * The `copyOption` determines which rows are copied into the session table.
    * Returns the session table reference so the caller can subscribe to it.
    */

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -377,7 +377,7 @@ describe("endEditSession", () => {
   });
 });
 
-describe("createSessionTable", () => {
+describe("createSessionDataSource", () => {
   const sessionSuccess: RpcResultSuccess = {
     type: "SUCCESS_RESULT",
     data: { table: { module: "TEST", table: "session-xyz" } },
@@ -386,7 +386,7 @@ describe("createSessionTable", () => {
   it("dispatches createSessionTable RPC with copyOption 'All'", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
-    await ds.createSessionTable?.("All");
+    await ds.createSessionDataSource?.("All");
     expect(ds.rpcRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "RPC_REQUEST",
@@ -399,7 +399,7 @@ describe("createSessionTable", () => {
   it("dispatches createSessionTable RPC with copyOption 'Selected'", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
-    await ds.createSessionTable?.("Selected");
+    await ds.createSessionDataSource?.("Selected");
     expect(ds.rpcRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "RPC_REQUEST",
@@ -412,7 +412,7 @@ describe("createSessionTable", () => {
   it("dispatches createSessionTable RPC with copyOption 'Empty'", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
-    await ds.createSessionTable?.("Empty");
+    await ds.createSessionDataSource?.("Empty");
     expect(ds.rpcRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "RPC_REQUEST",
@@ -425,7 +425,7 @@ describe("createSessionTable", () => {
   it("throws with the server error message on failure", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(ERROR("session table creation failed"));
-    await expect(ds.createSessionTable?.("All")).rejects.toThrow(
+    await expect(ds.createSessionDataSource?.("All")).rejects.toThrow(
       "session table creation failed",
     );
   });

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -279,7 +279,7 @@ describe("beginEditSession", () => {
     );
   });
 
-  it("converts 'all-rows' to alias 'All' in the RPC params", async () => {
+  it("sends 'all-rows' unchanged in the RPC params", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
 
@@ -288,12 +288,12 @@ describe("beginEditSession", () => {
     expect(ds.rpcRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         rpcName: "beginEditSession",
-        params: { editSessionMode: "All" },
+        params: { editSessionMode: "all-rows" },
       }),
     );
   });
 
-  it("converts 'selected-rows' to alias 'Selected' in the RPC params", async () => {
+  it("sends 'selected-rows' unchanged in the RPC params", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
 
@@ -302,12 +302,12 @@ describe("beginEditSession", () => {
     expect(ds.rpcRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         rpcName: "beginEditSession",
-        params: { editSessionMode: "Selected" },
+        params: { editSessionMode: "selected-rows" },
       }),
     );
   });
 
-  it("converts 'empty-session-table' to alias 'Empty' in the RPC params", async () => {
+  it("sends 'empty-session-table' unchanged in the RPC params", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
 
@@ -316,21 +316,7 @@ describe("beginEditSession", () => {
     expect(ds.rpcRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         rpcName: "beginEditSession",
-        params: { editSessionMode: "Empty" },
-      }),
-    );
-  });
-
-  it("passes short-form alias 'All' through unchanged", async () => {
-    const ds = createDataSource();
-    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
-
-    await ds.beginEditSession("All");
-
-    expect(ds.rpcRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rpcName: "beginEditSession",
-        params: { editSessionMode: "All" },
+        params: { editSessionMode: "empty-session-table" },
       }),
     );
   });
@@ -388,5 +374,59 @@ describe("endEditSession", () => {
     vi.mocked(ds.rpcRequest).mockResolvedValue(ERROR("stale update"));
 
     await expect(ds.endEditSession(true)).resolves.toBeUndefined();
+  });
+});
+
+describe("createSessionTable", () => {
+  const sessionSuccess: RpcResultSuccess = {
+    type: "SUCCESS_RESULT",
+    data: { table: { module: "TEST", table: "session-xyz" } },
+  };
+
+  it("dispatches createSessionTable RPC with copyOption 'All'", async () => {
+    const ds = createDataSource();
+    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
+    await ds.createSessionTable?.("All");
+    expect(ds.rpcRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RPC_REQUEST",
+        rpcName: "createSessionTable",
+        params: { copyOption: "All" },
+      }),
+    );
+  });
+
+  it("dispatches createSessionTable RPC with copyOption 'Selected'", async () => {
+    const ds = createDataSource();
+    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
+    await ds.createSessionTable?.("Selected");
+    expect(ds.rpcRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RPC_REQUEST",
+        rpcName: "createSessionTable",
+        params: { copyOption: "Selected" },
+      }),
+    );
+  });
+
+  it("dispatches createSessionTable RPC with copyOption 'Empty'", async () => {
+    const ds = createDataSource();
+    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
+    await ds.createSessionTable?.("Empty");
+    expect(ds.rpcRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RPC_REQUEST",
+        rpcName: "createSessionTable",
+        params: { copyOption: "Empty" },
+      }),
+    );
+  });
+
+  it("throws with the server error message on failure", async () => {
+    const ds = createDataSource();
+    vi.mocked(ds.rpcRequest).mockResolvedValue(ERROR("session table creation failed"));
+    await expect(ds.createSessionTable?.("All")).rejects.toThrow(
+      "session table creation failed",
+    );
   });
 });

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -594,11 +594,15 @@ export declare type StandaloneEditSessionMode =
  * `"inline-all-rows"` is a client-only concept and is NOT mapped — it passes
  * through to the RPC unchanged so the server can create an all-rows session table.
  */
-export declare type EditSessionModeAlias = "All" | "Empty" | "Selected";
+export declare type CopyOption = "All" | "Empty" | "Selected";
+/**
+ * @deprecated Prefer `CopyOption` ("All" | "Empty" | "Selected") for standalone
+ * edit sessions supported by vuu server. Long-form values (e.g. `"all-rows"`) are used 
+ * by `beginEditSession`; new code should use `CopyOption` with `createSessionTable`.
+ */
 export declare type EditSessionMode =
   | InlineEditSessionMode
-  | StandaloneEditSessionMode
-  | EditSessionModeAlias;
+  | StandaloneEditSessionMode;
 
 export interface EditApi<
   T extends DataSourceRow | DataSourceRowWithBigint = DataSourceRow,
@@ -620,6 +624,9 @@ export interface EditApi<
     value: VuuRowDataItemType,
   ) => Promise<RpcResult> | undefined;
   undoRowChange?: (key: string) => Promise<RpcResult> | undefined;
+  createSessionTable?: (
+    copyOption: CopyOption,
+  ) => Promise<DataSourceBase<T> | undefined>;
   endEditSession?: (
     saveChanges?: boolean,
     force?: boolean,

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -598,7 +598,7 @@ export declare type CopyOption = "All" | "Empty" | "Selected";
 /**
  * @deprecated Prefer `CopyOption` ("All" | "Empty" | "Selected") for standalone
  * edit sessions supported by vuu server. Long-form values (e.g. `"all-rows"`) are used 
- * by `beginEditSession`; new code should use `CopyOption` with `createSessionTable`.
+ * by `beginEditSession`; new code should use `CopyOption` with `createSessionDataSource`.
  */
 export declare type EditSessionMode =
   | InlineEditSessionMode
@@ -624,9 +624,13 @@ export interface EditApi<
     value: VuuRowDataItemType,
   ) => Promise<RpcResult> | undefined;
   undoRowChange?: (key: string) => Promise<RpcResult> | undefined;
-  createSessionTable?: (
+  /**
+   * Create a session datasource by requesting the server to create a session table
+   * via the `createSessionTable` RPC and wrapping the returned table.
+   */
+  createSessionDataSource?: (
     copyOption: CopyOption,
-  ) => Promise<DataSourceBase<T> | undefined>;
+  ) => Promise<DataSource<T> | undefined>;
   endEditSession?: (
     saveChanges?: boolean,
     force?: boolean,
@@ -697,13 +701,6 @@ export interface DataSourceBase<
   resume?: (callback?: DataSourceSubscribeCallback) => void;
 
   deleteRow?: DataSourceDeleteHandler;
-  /**
-   * create a DataSource on a session table. The concrete DataSource implementation that
-   * implements this method will always return a session table datasource of the same concrete type.
-   * @param table the sessionTable  (module and table name)
-   * @returns
-   */
-  createSessionDataSource?: (table: VuuTable) => DataSource<T>;
   /**
    * For a dataSource that has been previously disabled and is currently in disabled state , this will restore
    * the subscription to active status. Fresh data will be dispatched to client. The enable call optionally

--- a/vuu-ui/packages/vuu-protocol-types/index.d.ts
+++ b/vuu-ui/packages/vuu-protocol-types/index.d.ts
@@ -576,7 +576,7 @@ export declare type EditCellRpcServiceRequest = {
 };
 
 export declare type BeginEditSessionParams = {
-  editSessionMode?: "all-rows" | "selected-rows";
+  editSessionMode?: "inline-all-rows" | "all-rows" | "selected-rows" | "empty-session-table";
 };
 export declare type BeginEditSessionRpcServiceRequest = {
   context: ViewportRpcContext;
@@ -612,6 +612,19 @@ export declare type DeleteSelectedRowsRpcServiceRequest = {
   type: "RPC_REQUEST";
   params: DeleteSelectedRowsParams;
   rpcName: "deleteSelectedRows";
+};
+/**
+ * copyOption mirrors EditSessionModeAlias from vuu-data-types.
+ * Using string literals here to avoid a cross-package circular import.
+ */
+export declare type CreateSessionTableParams = {
+  copyOption: "All" | "Empty" | "Selected";
+};
+export declare type CreateSessionTableRpcServiceRequest = {
+  context: ViewportRpcContext;
+  type: "RPC_REQUEST";
+  params: CreateSessionTableParams;
+  rpcName: "createSessionTable";
 };
 
 export declare type AddRowRpcRequest = {

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/CsvUpload.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/CsvUpload.tsx
@@ -61,8 +61,8 @@ export type CsvUploadPhase =
 export interface CsvUploadProps {
   children?: ReactNode;
   dataSource: DataSource;
-  onEditSessionStarted?: (dataSource: DataSource) => void;
-  onEditSessionEnded?: (result: CsvUploadSessionEndResult) => void;
+  onImportSessionStarted?: (dataSource: DataSource) => void;
+  onImportSessionEnded?: (result: CsvUploadSessionEndResult) => void;
   onError?: (result: CsvUploadErrorResult | undefined) => void;
   onImported?: (result: CsvUploadImportedResult) => void;
   onProcessingStarted?: () => void;

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
@@ -16,8 +16,8 @@ import { CsvUpload } from "@vuu-ui/vuu-table-extras";
   onCancel={handleCancel}
   onClose={handleClose}
   onProcessingStarted={handleProcessingStarted}
-  onEditSessionStarted={handleEditSessionStarted}
-  onEditSessionEnded={handleEditSessionEnded}
+  onImportSessionStarted={handleImportSessionStarted}
+  onImportSessionEnded={handleImportSessionEnded}
   onImported={handleImported}
   onError={handleError}
 />
@@ -29,14 +29,14 @@ import { CsvUpload } from "@vuu-ui/vuu-table-extras";
 
 | Prop | Type | Description |
 |---|---|---|
-| `dataSource` | `DataSource` | **Required.** The Vuu data source for the target table. Must support `beginEditSession`, `endEditSession`, `createSessionDataSource`, and `rpcRequest`. |
+| `dataSource` | `DataSource` | **Required.** The Vuu data source for the target table. Must support `createSessionDataSource`, `endEditSession`, and `rpcRequest`. |
 | `maxRows` | `number` | Maximum number of data rows permitted in the CSV. Defaults to `25000`. |
 | `open` | `boolean` | Controls dialog open state. When provided the component is fully controlled; when omitted it manages open state internally. |
 | `dialogTitle` | `string` | Dialog header text. Defaults to `"Import CSV"`. |
 | `parseOptions` | `CsvParseOptions` | Options passed to the CSV parser (see [Parse Options](#parse-options)). |
 | `onProcessingStarted` | `() => void` | Fired when a file starts being parsed and validated. |
-| `onEditSessionStarted` | `(dataSource: DataSource) => void` | Fired when the server-side edit session is open and a session `DataSource` is available for preview. |
-| `onEditSessionEnded` | `(result: CsvUploadSessionEndResult) => void` | Fired when the edit session closes, whether by import, cancel, or failure. |
+| `onImportSessionStarted` | `(dataSource: DataSource) => void` | Fired when the server-side session is open and a session `DataSource` is available for preview. |
+| `onImportSessionEnded` | `(result: CsvUploadSessionEndResult) => void` | Fired when the import session closes, whether by import, cancel, or failure. |
 | `onImported` | `(result: CsvUploadImportedResult) => void` | Fired after a successful import. |
 | `onError` | `(result: CsvUploadErrorResult \| undefined) => void` | Fired when any error occurs. Called with `undefined` to clear a previous error. |
 | `onCancel` | `() => void` | Fired when the Cancel button is clicked. |
@@ -71,7 +71,7 @@ processing          ← onProcessingStarted()
  ├─ parse / schema / validation errors ──► failed   ← onError({ errors })
  │
  ▼
-preview-ready       ← onEditSessionStarted(sessionDataSource)
+preview-ready       ← onImportSessionStarted(sessionDataSource)
  │
  │  user clicks Import
  ▼
@@ -81,12 +81,12 @@ importing           ← onClose()
  │
  ▼
 imported            ← onImported(result)
-                    ← onEditSessionEnded({ reason: "saved" })
+                    ← onImportSessionEnded({ reason: "saved" })
 ```
 
 If the user cancels at any point:
 - `onCancel()` is called.
-- `onEditSessionEnded({ reason: "discarded" })` fires if a session was open.
+- `onImportSessionEnded({ reason: "discarded" })` fires if a session was open.
 - Phase returns to `idle`.
 
 ### Callbacks reference
@@ -94,8 +94,8 @@ If the user cancels at any point:
 | Callback | Phase transition | Notes |
 |---|---|---|
 | `onProcessingStarted` | `→ processing` | Fires before parsing begins. No data available yet. |
-| `onEditSessionStarted` | `→ preview-ready` | Provides a session `DataSource`. Extract `dataSource.table` (`CsvUploadSessionTable`) and pass it to `useCsvUploadSessionPreview` to build a preview UI without mutating the shared session datasource. |
-| `onEditSessionEnded` | `→ imported` or `→ idle` | `reason` is `"saved"` on successful import, `"discarded"` on cancel, `"failed"` on error. `sessionTable` contains the Vuu session table reference. |
+| `onImportSessionStarted` | `→ preview-ready` | Provides a session `DataSource`. Extract `dataSource.table` (`CsvUploadSessionTable`) and pass it to `useCsvUploadSessionPreview` to build a preview UI without mutating the shared session datasource. |
+| `onImportSessionEnded` | `→ imported` or `→ idle` | `reason` is `"saved"` on successful import, `"discarded"` on cancel, `"failed"` on error. `sessionTable` contains the Vuu session table reference. |
 | `onImported` | `→ imported` | Provides `rpcResult` and normalised `tableData`. |
 | `onError` | `→ failed` | See [Error Types](#error-types) below. |
 | `onClose` | `→ importing` | Dialog is closing because import was triggered. |
@@ -163,7 +163,7 @@ type CsvErrorMap<TError extends string> = {
 
 ### Session preview
 
-When `onEditSessionStarted` fires, the edit session table is populated with one row per uploaded CSV row. Each row has the source table's columns plus a `vuuMsg` column. For rows with validation errors, `vuuMsg` contains a human-readable summary including the CSV row number:
+When `onImportSessionStarted` fires, the edit session table is populated with one row per uploaded CSV row. Each row has the source table's columns plus a `vuuMsg` column. For rows with validation errors, `vuuMsg` contains a human-readable summary including the CSV row number:
 
 ```
 "Row 3: price: Value 'abc' is not a valid double; ric: Empty value is not allowed for non-string columns."
@@ -202,8 +202,8 @@ const MyApp = () => {
   return (
     <CsvUpload
       dataSource={dataSource}
-      onEditSessionStarted={(sessionDs) => setSessionTable(sessionDs.table as CsvUploadSessionTable)}
-      onEditSessionEnded={() => setSessionTable(undefined)}
+      onImportSessionStarted={(sessionDs) => setSessionTable(sessionDs.table as CsvUploadSessionTable)}
+      onImportSessionEnded={() => setSessionTable(undefined)}
     >
       <ErrorsTable sessionTable={sessionTable} />
     </CsvUpload>
@@ -217,7 +217,7 @@ The `useCsvUploadSessionPreview` hook:
 - Creates a dedicated `VuuDataSource` for the session table
 - Cleans up when `sessionTable` becomes `undefined`
 
-To show only rows with errors, apply the filter `'vuuMsg > ""'` on the `previewDataSource` (not on the datasource from `onEditSessionStarted`).
+To show only rows with errors, apply the filter `'vuuMsg > ""'` on the `previewDataSource` (not on the datasource from `onImportSessionStarted`).
 
 ## Parse Options
 

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
@@ -30,8 +30,8 @@ import type {
 export interface CsvUploadHookProps {
   dataSource: DataSource;
   maxRows?: number;
-  onEditSessionEnded?: (result: CsvUploadSessionEndResult) => void;
-  onEditSessionStarted?: (dataSource: DataSource) => void;
+  onImportSessionEnded?: (result: CsvUploadSessionEndResult) => void;
+  onImportSessionStarted?: (dataSource: DataSource) => void;
   onError?: (result: CsvUploadErrorResult | undefined) => void;
   onImported?: (result: CsvUploadImportedResult) => void;
   onProcessingStarted?: () => void;
@@ -55,8 +55,8 @@ export type UseCsvUploadReturn = {
 
 export const useCsvUpload = ({
   dataSource,
-  onEditSessionEnded,
-  onEditSessionStarted,
+  onImportSessionEnded,
+  onImportSessionStarted,
   onError,
   onImported,
   onProcessingStarted,
@@ -76,15 +76,9 @@ export const useCsvUpload = ({
   const setActiveSessionTable = useCallback(
     (table?: CsvUploadSessionTable) => {
       sessionTableRef.current = table;
-      if (table) {
-        const sessionDs = dataSource.createSessionDataSource?.(table);
-        if (sessionDs) {
-          onEditSessionStarted?.(sessionDs);
-        }
-      }
       setSessionTable(table);
     },
-    [dataSource, onEditSessionStarted],
+    [],
   );
 
   const endEditSessionAndNotify = useCallback(
@@ -96,13 +90,13 @@ export const useCsvUpload = ({
       const result = await dataSource.endEditSession(save);
 
       setActiveSessionTable(undefined);
-      onEditSessionEnded?.({
+      onImportSessionEnded?.({
         reason,
         sessionTable: currentSessionTable,
       });
       return result;
     },
-    [dataSource, onEditSessionEnded, setActiveSessionTable],
+    [dataSource, onImportSessionEnded, setActiveSessionTable],
   );
 
   const table = dataSource.table;
@@ -179,17 +173,20 @@ export const useCsvUpload = ({
   );
 
   const beginEditSession = useCallback(async () => {
-    if (!dataSource.beginEditSession) {
-      throw Error("CsvUpload requires datasource beginEditSession support.");
+    if (!dataSource.createSessionDataSource) {
+      throw Error("CsvUpload requires datasource createSessionDataSource support.");
     }
 
-    const sessionDataSource = await dataSource.beginEditSession("empty-session-table");
+    const sessionDataSource = await dataSource.createSessionDataSource("Empty");
 
     const sessionVuuTable = sessionDataSource?.table;
     if (sessionVuuTable && isSessionTable(sessionVuuTable)) {
       setActiveSessionTable(sessionVuuTable as CsvUploadSessionTable);
+      if (sessionDataSource) {
+        onImportSessionStarted?.(sessionDataSource);
+      }
     }
-  }, [dataSource, setActiveSessionTable]);
+  }, [dataSource, onImportSessionStarted, setActiveSessionTable]);
 
   const closePendingEditSession = useCallback(
     async (save: boolean) => {

--- a/vuu-ui/packages/vuu-table-extras/test/csv-upload/useCsvUpload.test.tsx
+++ b/vuu-ui/packages/vuu-table-extras/test/csv-upload/useCsvUpload.test.tsx
@@ -46,7 +46,7 @@ const makeDataSource = (overrides: Partial<DataSource> = {}): DataSource =>
     table: vuuTable,
     tableSchema: schema,
     columns: ["id", "label", "count"],
-    beginEditSession: vi.fn().mockResolvedValue({ table: sessionTable }),
+    createSessionDataSource: vi.fn().mockResolvedValue({ table: sessionTable }),
     endEditSession: vi.fn().mockResolvedValue({ type: "SUCCESS_RESULT" }),
     rpcRequest: vi.fn().mockResolvedValue({ type: "SUCCESS_RESULT" }),
     ...overrides,
@@ -151,7 +151,7 @@ describe("useCsvUpload", () => {
 
     expect(latestResult?.canImport).toBe(true);
     expect(latestResult?.validation?.errors).toHaveLength(0);
-    expect(dataSource.beginEditSession).toHaveBeenCalledWith("empty-session-table");
+    expect(dataSource.createSessionDataSource).toHaveBeenCalledWith("Empty");
   });
 
   it("sets canImport=false and emits an error for a file-level parse error", async () => {
@@ -197,7 +197,7 @@ describe("useCsvUpload", () => {
     await dropFile(latestResult, '"label","count"\n"foo","10"');
 
     expect(latestResult?.canImport).toBe(false);
-    expect(dataSource.beginEditSession).not.toHaveBeenCalled();
+    expect(dataSource.createSessionDataSource).not.toHaveBeenCalled();
     const schemaErrorCall = onError.mock.calls
       .map((c) => c[0])
       .filter(Boolean)
@@ -205,18 +205,18 @@ describe("useCsvUpload", () => {
     expect(schemaErrorCall?.errors.schemaError).toBeDefined();
   });
 
-  it("fires onEditSessionStarted with the session datasource when a valid CSV is processed", async () => {
+  it("fires onImportSessionStarted with the session datasource when a valid CSV is processed", async () => {
     let latestResult: UseCsvUploadReturn | undefined;
-    const onEditSessionStarted = vi.fn();
-    const mockSessionDs = {} as DataSource;
+    const onImportSessionStarted = vi.fn();
+    const mockSessionDs = { table: sessionTable } as unknown as DataSource;
     const dataSource = makeDataSource({
-      createSessionDataSource: vi.fn().mockReturnValue(mockSessionDs),
+      createSessionDataSource: vi.fn().mockResolvedValue(mockSessionDs),
     });
 
     await act(async () => {
       root.render(
         <Probe
-          props={{ dataSource, onEditSessionStarted }}
+          props={{ dataSource, onImportSessionStarted }}
           onResult={(r) => {
             latestResult = r;
           }}
@@ -227,19 +227,19 @@ describe("useCsvUpload", () => {
 
     await dropFile(latestResult, '"id","label","count"\n"a1","foo","10"');
 
-    expect(onEditSessionStarted).toHaveBeenCalledWith(mockSessionDs);
+    expect(onImportSessionStarted).toHaveBeenCalledWith(mockSessionDs);
   });
 
   it("calls endEditSession(true) and fires onImported when importData succeeds", async () => {
     let latestResult: UseCsvUploadReturn | undefined;
     const onImported = vi.fn();
-    const onEditSessionEnded = vi.fn();
+    const onImportSessionEnded = vi.fn();
     const dataSource = makeDataSource();
 
     await act(async () => {
       root.render(
         <Probe
-          props={{ dataSource, onImported, onEditSessionEnded }}
+          props={{ dataSource, onImported, onImportSessionEnded }}
           onResult={(r) => {
             latestResult = r;
           }}
@@ -260,7 +260,7 @@ describe("useCsvUpload", () => {
     expect(dataSource.endEditSession).toHaveBeenCalledWith(true);
     expect(onImported).toHaveBeenCalled();
     const endedResult: CsvUploadSessionEndResult =
-      onEditSessionEnded.mock.calls[0][0];
+      onImportSessionEnded.mock.calls[0][0];
     expect(endedResult.reason).toBe("saved");
   });
 
@@ -332,10 +332,10 @@ describe("useCsvUpload", () => {
     expect(dataSource.endEditSession).toHaveBeenCalledWith(false);
   });
 
-  it("emits an error when dataSource.beginEditSession is not defined", async () => {
+  it("emits an error when dataSource.createSessionDataSource is not defined", async () => {
     let latestResult: UseCsvUploadReturn | undefined;
     const onError = vi.fn();
-    const dataSource = makeDataSource({ beginEditSession: undefined });
+    const dataSource = makeDataSource({ createSessionDataSource: undefined });
 
     await act(async () => {
       root.render(
@@ -405,7 +405,7 @@ describe("useCsvUpload", () => {
 
     await dropFile(latestResult, '"id","label","count"\n"a1","foo","NOT_A_NUMBER"');
 
-    expect(dataSource.beginEditSession).toHaveBeenCalledWith("empty-session-table");
+    expect(dataSource.createSessionDataSource).toHaveBeenCalledWith("Empty");
     expect(latestResult?.canImport).toBe(false);
     expect(latestResult?.validation?.errors.length).toBeGreaterThan(0);
 
@@ -453,15 +453,15 @@ describe("useCsvUpload", () => {
     expect(errorPayload?.vuuMsg as string).toMatch(/^Row \d+:.*count/);
   });
 
-  it("fires onEditSessionEnded with reason 'discarded' when a second file replaces the first", async () => {
+  it("fires onImportSessionEnded with reason 'discarded' when a second file replaces the first", async () => {
     let latestResult: UseCsvUploadReturn | undefined;
-    const onEditSessionEnded = vi.fn();
+    const onImportSessionEnded = vi.fn();
     const dataSource = makeDataSource();
 
     await act(async () => {
       root.render(
         <Probe
-          props={{ dataSource, onEditSessionEnded }}
+          props={{ dataSource, onImportSessionEnded }}
           onResult={(r) => {
             latestResult = r;
           }}
@@ -474,7 +474,7 @@ describe("useCsvUpload", () => {
 
     await dropFile(latestResult, '"id","label","count"\n"a2","bar","20"');
 
-    const discardedCall = onEditSessionEnded.mock.calls
+    const discardedCall = onImportSessionEnded.mock.calls
       .map((c: unknown[]) => c[0] as CsvUploadSessionEndResult)
       .find((r) => r.reason === "discarded");
     expect(discardedCall).toBeDefined();
@@ -522,7 +522,7 @@ describe("useCsvUpload", () => {
     await dropFile(latestResult, '"id","label","count"\n"a1","foo","10"\n"a2","bar","20"');
 
     expect(latestResult?.canImport).toBe(false);
-    expect(dataSource.beginEditSession).not.toHaveBeenCalled();
+    expect(dataSource.createSessionDataSource).not.toHaveBeenCalled();
     expect(onError.mock.calls.at(-1)?.[0]?.errors.schemaError).toBeDefined();
   });
 
@@ -630,7 +630,7 @@ describe("useCsvUpload", () => {
     await dropFile(latestResult, 'id,label,count\n"a1","foo","10"');
 
     expect(latestResult?.canImport).toBe(false);
-    expect(dataSource.beginEditSession).not.toHaveBeenCalled();
+    expect(dataSource.createSessionDataSource).not.toHaveBeenCalled();
     expect(onError.mock.calls.at(-1)?.[0]?.errors.validationError).toBeDefined();
   });
 });

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -1,6 +1,7 @@
 import { test } from "@playwright/experimental-ct-react";
 import { LocalDataSourceProvider } from "@vuu-ui/vuu-data-test";
 import {
+  CreateSessionTableInstruments,
   EditableInstruments,
   EditableInstrumentsInlineEdit,
   TwoEditableInstruments,
@@ -637,5 +638,98 @@ test.describe("Inline row editing (session)", () => {
     // Returns to view mode — action buttons gone
     await expect(page.getByRole("button", { name: "Submit" })).not.toBeVisible();
     await expect(page.getByRole("radio", { name: "View" })).toBeVisible();
+  });
+});
+
+test.describe("Session table editing (createSessionTable)", () => {
+  test("entering edit mode shows the session table data", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<CreateSessionTableInstruments />);
+    const table = new TableOM(page.getByRole("table"));
+
+    await page.getByRole("radio", { name: "Edit" }).click();
+    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+
+    // Column 2 = bbg (column 1 is the checkbox selector)
+    const cell = table.locateCell(2, 2);
+    await cell.dblclick();
+    await expect(cell.getByRole("textbox")).toBeVisible();
+  });
+
+  test("editing a cell marks the row with an Undo button", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<CreateSessionTableInstruments />);
+    await page.getByRole("radio", { name: "Edit" }).click();
+    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+
+    const table = new TableOM(page.getByRole("table"));
+    // Column 2 = bbg
+    const cell = table.locateCell(2, 2);
+    await cell.dblclick();
+    await cell.pressSequentially("EDITED");
+    await cell.press("Enter");
+
+    const undoButton = table.row(2).getByRole("button", { name: "Undo" });
+    await expect(undoButton).toBeVisible();
+    await expect(page.getByRole("button", { name: "Submit" })).toBeEnabled();
+  });
+
+  test("selecting a row enables the Delete button", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<CreateSessionTableInstruments />);
+    await page.getByRole("radio", { name: "Edit" }).click();
+    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+
+    const table = new TableOM(page.getByRole("table"));
+    const deleteButton = page.getByRole("button", { name: "Delete" });
+    await expect(deleteButton).toBeDisabled();
+
+    // Column 1 = checkbox selector
+    const checkboxCell = table.locateCell(2, 1);
+    await checkboxCell.click();
+    await expect(deleteButton).toBeEnabled();
+  });
+
+  test("deleting a selected row marks it SOFT_DELETED with an Undo button", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<CreateSessionTableInstruments />);
+    await page.getByRole("radio", { name: "Edit" }).click();
+    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+
+    const table = new TableOM(page.getByRole("table"));
+    const checkboxCell = table.locateCell(2, 1);
+    await checkboxCell.click();
+    await page.getByRole("button", { name: "Delete" }).click();
+
+    // Column 11 = vuuMsg
+    const vuuMsgCell = table.locateCell(2, 11);
+    await expect(vuuMsgCell).toContainText("SOFT_DELETED");
+
+    const undoButton = table.row(2).getByRole("button", { name: "Undo" });
+    await expect(undoButton).toBeVisible();
+    await expect(page.getByRole("button", { name: "Submit" })).toBeEnabled();
+  });
+
+  test("Add Rows appends blank rows to the session table", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<CreateSessionTableInstruments />);
+    await page.getByRole("radio", { name: "Edit" }).click();
+    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+
+    const submitButton = page.getByRole("button", { name: "Submit" });
+    await expect(submitButton).toBeDisabled();
+
+    await page.getByRole("button", { name: "Add Rows" }).click();
+    await expect(submitButton).toBeEnabled();
   });
 });

--- a/vuu-ui/packages/vuu-utils/src/data-editing/EditSession.tsx
+++ b/vuu-ui/packages/vuu-utils/src/data-editing/EditSession.tsx
@@ -210,14 +210,14 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     this.#endEditModePending = false;
   }
 
-  /** @deprecated Pass a `CopyOption` ("All" | "Empty" | "Selected") to use `createSessionTable` instead. Long-form `EditSessionMode` values will be removed in a future release. */
+  /** @deprecated Pass a `CopyOption` ("All" | "Empty" | "Selected") to use `createSessionDataSource` instead. Long-form `EditSessionMode` values will be removed in a future release. */
   async begin(mode: EditSessionMode): Promise<DataSource | undefined>;
   async begin(mode?: CopyOption): Promise<DataSource | undefined>;
   async begin(mode?: EditSessionMode | CopyOption): Promise<DataSource | undefined> {
     try {
       this.#inEditMode = true;
       const sessionDataSource = isCopyOption(mode)
-        ? await this.#sourceTableDataSource?.createSessionTable?.(mode)
+        ? await this.#sourceTableDataSource?.createSessionDataSource?.(mode)
         : await this.#sourceTableDataSource?.beginEditSession?.(mode);
 
       this.#sessionDataSource = sessionDataSource;

--- a/vuu-ui/packages/vuu-utils/src/data-editing/EditSession.tsx
+++ b/vuu-ui/packages/vuu-utils/src/data-editing/EditSession.tsx
@@ -1,7 +1,10 @@
-import { DeleteRowMode, DeleteSelectedRowsResult, EditApi, EditSessionMode, UndoRowChangeResult } from "@vuu-ui/vuu-data-types";
+import { CopyOption, DataSource, DeleteRowMode, DeleteSelectedRowsResult, EditApi, EditSessionMode, UndoRowChangeResult } from "@vuu-ui/vuu-data-types";
 import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
 import { EventEmitter } from "../event-emitter";
 import { isRpcError } from "../protocol-message-utils";
+
+export const isCopyOption = (mode?: EditSessionMode | CopyOption): mode is CopyOption =>
+  mode === "All" || mode === "Empty" || mode === "Selected";
 
 export type EditState = "clean" | "dirty" | "invalid" | "stale";
 
@@ -207,14 +210,17 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     this.#endEditModePending = false;
   }
 
-  async begin(editSessionMode?: EditSessionMode) {
+  /** @deprecated Pass a `CopyOption` ("All" | "Empty" | "Selected") to use `createSessionTable` instead. Long-form `EditSessionMode` values will be removed in a future release. */
+  async begin(mode: EditSessionMode): Promise<DataSource | undefined>;
+  async begin(mode?: CopyOption): Promise<DataSource | undefined>;
+  async begin(mode?: EditSessionMode | CopyOption): Promise<DataSource | undefined> {
     try {
       this.#inEditMode = true;
-      const sessionDataSource =
-        await this.#sourceTableDataSource?.beginEditSession?.(editSessionMode);
+      const sessionDataSource = isCopyOption(mode)
+        ? await this.#sourceTableDataSource?.createSessionTable?.(mode)
+        : await this.#sourceTableDataSource?.beginEditSession?.(mode);
 
       this.#sessionDataSource = sessionDataSource;
-
       return sessionDataSource;
     } catch (e) {
       this.#inEditMode = false;

--- a/vuu-ui/packages/vuu-utils/src/data-editing/README.md
+++ b/vuu-ui/packages/vuu-utils/src/data-editing/README.md
@@ -25,7 +25,7 @@ Two independent RPCs can initiate a session:
 | Method | RPC | Parameter | Purpose |
 |---|---|---|---|
 | `beginEditSession` | `"beginEditSession"` | `EditSessionMode` (long-form, see below) | Inline or standalone edit session tied to the source viewport |
-| `createSessionTable` | `"createSessionTable"` | `CopyOption` (`"All"` \| `"Empty"` \| `"Selected"`) | Standalone session table returned directly to the caller; no internal session state on the source datasource |
+| `createSessionDataSource` | `"createSessionTable"` | `CopyOption` (`"All"` \| `"Empty"` \| `"Selected"`) | Requests server to create a session table, then returns a session datasource; no internal session state on the source datasource |
 
 ### EditSessionMode (long-form, deprecated for new code)
 
@@ -39,7 +39,7 @@ type StandaloneEditSessionMode = "all-rows"                 // copy all rows
 type EditSessionMode = InlineEditSessionMode | StandaloneEditSessionMode;
 ```
 
-`EditSessionMode` long-form strings are sent directly to the `beginEditSession` RPC without conversion. Callers should now prefer `CopyOption` when requesting standalone sessions via `createSessionTable`.
+`EditSessionMode` long-form strings are sent directly to the `beginEditSession` RPC without conversion. Callers should now prefer `CopyOption` when requesting standalone sessions via `createSessionDataSource`.
 
 ### CopyOption (preferred for standalone sessions)
 
@@ -47,7 +47,7 @@ type EditSessionMode = InlineEditSessionMode | StandaloneEditSessionMode;
 type CopyOption = "All" | "Empty" | "Selected";
 ```
 
-Used with `createSessionTable` and accepted by `EditSession.begin()` and `useEditableTable.editSessionMode`. When a `CopyOption` is passed to `begin()`, it routes to `createSessionTable` instead of `beginEditSession`.
+Used with `createSessionDataSource` and accepted by `EditSession.begin()` and `useEditableTable.editSessionMode`. When a `CopyOption` is passed to `begin()`, it routes to `createSessionDataSource` instead of `beginEditSession`.
 
 ---
 
@@ -82,7 +82,7 @@ begin(mode: EditSessionMode): Promise<DataSource | undefined>;
 begin(mode?: CopyOption): Promise<DataSource | undefined>;
 ```
 
-Passing a `CopyOption` value routes to `createSessionTable`; anything else routes to `beginEditSession`. The returned session datasource is stored internally and returned to the caller.
+Passing a `CopyOption` value routes to `createSessionDataSource`; anything else routes to `beginEditSession`. The returned session datasource is stored internally and returned to the caller.
 
 The `isCopyOption(mode)` type guard is exported from `@vuu-ui/vuu-utils` for use at call sites that hold a `EditSessionMode | CopyOption` union:
 
@@ -133,7 +133,7 @@ Wraps `EditSession` for use in React components. Manages session lifecycle in re
 | `dataSource` | — | Pre-existing DataSource; takes precedence over `table` |
 | `table` | — | Creates a new DataSource if `dataSource` not provided |
 | `columns` | `undefined` | Column list for the subscription |
-| `editSessionMode` | `"inline-all-rows"` | Passed to `editSession.begin()`. Accepts `CopyOption` (preferred, routes to `createSessionTable`) or `EditSessionMode` long-form values (deprecated, routes to `beginEditSession`). Narrowed internally with `isCopyOption` before the call. |
+| `editSessionMode` | `"inline-all-rows"` | Passed to `editSession.begin()`. Accepts `CopyOption` (preferred, routes to `createSessionDataSource`) or `EditSessionMode` long-form values (deprecated, routes to `beginEditSession`). Narrowed internally with `isCopyOption` before the call. |
 | `deleteMode` | `"soft"` | `"soft"` marks the row; `"hard"` deletes immediately |
 | `addRowsCount` | `15` | Number of rows added per `onAddRows` call |
 | `isEditMode` | required | Toggling to `true` calls `editSession.begin()`; to `false` calls `editSession.end()` |
@@ -218,19 +218,19 @@ editSession.begin("all-rows")           // or "selected-rows" / "empty-session-t
   EditSession stores #sessionDataSource, returns it to consumer
 ```
 
-### Create Session Table (standalone via createSessionTable)
+### Create Session Datasource (standalone via createSessionDataSource)
 
 ```
 editSession.begin("All")               // or "Empty" / "Selected"
-  editSession detects CopyOption → routes to createSessionTable
-  dataSource.createSessionTable("All")
+  editSession detects CopyOption → routes to createSessionDataSource
+  dataSource.createSessionDataSource("All")
     → "createSessionTable" RPC → VuuModule.createSessionTableService
         determines mode from CopyOption directly:
           "All"      → createSessionTableWithAllRows
           "Selected" → createSessionTableFromSelectedRows
           "Empty"    → createEmptySessionTable
         returns { table: { module, table: sessionTableName } }
-    → datasource creates and returns session DataSource
+    → datasource wraps returned VuuTable in a new session DataSource
   EditSession stores #sessionDataSource, returns it to consumer
 ```
 
@@ -359,7 +359,7 @@ All datasources used with `EditSession` must implement `EditApi` from `@vuu-ui/v
 ```ts
 interface EditApi<T extends DataSourceRow | DataSourceRowWithBigint = DataSourceRow> {
   beginEditSession?(mode?: EditSessionMode): Promise<DataSourceBase<T> | undefined>;
-  createSessionTable?(copyOption: CopyOption): Promise<DataSourceBase<T> | undefined>;
+  createSessionDataSource?(copyOption: CopyOption): Promise<DataSource<T> | undefined>;
   addRow?(rowData?: Record<string, VuuRowDataItemType>): Promise<RpcResult> | undefined;
   deleteRow?(key: string, mode?: DeleteRowMode): Promise<RpcResult> | undefined;
   deleteSelectedRows?(mode?: DeleteRowMode): Promise<RpcResult> | undefined;
@@ -376,7 +376,7 @@ Each `EditApi` method returns `RpcResultSuccess` on success. The table below sho
 | Method | `data` on success | Typed as |
 |---|---|---|
 | `beginEditSession` | `{ table: VuuTable }` — the server-assigned session table | `BeginEditSessionResult` |
-| `createSessionTable` | `{ table: VuuTable }` — same shape as `beginEditSession` | `BeginEditSessionResult` |
+| `createSessionDataSource` | `{ table: VuuTable }` — same shape as `beginEditSession` | `BeginEditSessionResult` |
 | `addRow` | `undefined` | — |
 | `deleteRow` | `undefined` | — |
 | `deleteSelectedRows` | `{ deletedKeys: string[] }` | `DeleteSelectedRowsResult` |
@@ -387,7 +387,7 @@ Each `EditApi` method returns `RpcResultSuccess` on success. The table below sho
 The structured payloads are declared in `@vuu-ui/vuu-data-types`:
 
 ```ts
-// beginEditSession / createSessionTable — session table to subscribe to
+// beginEditSession / createSessionDataSource (CopyOption path) — session table to subscribe to
 type BeginEditSessionResult = { table: VuuTable };
 // Example: { table: { module: "SIMUL", table: "session-a1b2c3" } }
 
@@ -440,7 +440,7 @@ The `params` object sent with each RPC request (types from `@vuu-ui/vuu-protocol
 | EditApi method | RPC name | Routes via | VuuModule handler |
 |---|---|---|---|
 | `beginEditSession` | `"beginEditSession"` | source datasource | creates `SessionTable` proxy, stores in `#sessionTableMap`; `editSessionMode` passed through unchanged |
-| `createSessionTable` | `"createSessionTable"` | source datasource | `createSessionTableService` — resolves `CopyOption` directly in `VuuModule.createSessionTable()`, no alias conversion |
+| `createSessionDataSource` | `"createSessionTable"` | source datasource | `createSessionTableService` — resolves `CopyOption` directly in `VuuModule.createSessionTable()`, no alias conversion |
 | `addRow` | `"addRow"` | **source** datasource | `addRow` — inserts into session table |
 | `deleteRow` | `"deleteRow"` | session datasource | `deleteRow` — direct key-based delete (for programmatic use) |
 | `deleteSelectedRows` | `"deleteSelectedRows"` | session datasource | reads `selectedRows` from session subscription; soft/hard deletes each; returns `DeleteSelectedRowsResult` |

--- a/vuu-ui/packages/vuu-utils/src/data-editing/README.md
+++ b/vuu-ui/packages/vuu-utils/src/data-editing/README.md
@@ -7,7 +7,454 @@ This document describes how client-side inline row editing works in Vuu UI, cove
 ## Layers at a Glance
 
 ```
-Consumer component (e.g. InlineEditTableTemplate)
+Consumer component (e.g. EditableInstrumentsTemplate)
+  └─ useEditableTable (React hook)
+       └─ EditSession (session state + orchestration)
+            └─ DataSource (EditApi)
+                 ├─ TickingArrayDataSource  (local / test)
+                 └─ VuuDataSource           (remote)
+                      └─ VuuModule / server RPC handlers
+```
+
+---
+
+## Session Modes
+
+Two independent RPCs can initiate a session:
+
+| Method | RPC | Parameter | Purpose |
+|---|---|---|---|
+| `beginEditSession` | `"beginEditSession"` | `EditSessionMode` (long-form, see below) | Inline or standalone edit session tied to the source viewport |
+| `createSessionTable` | `"createSessionTable"` | `CopyOption` (`"All"` \| `"Empty"` \| `"Selected"`) | Standalone session table returned directly to the caller; no internal session state on the source datasource |
+
+### EditSessionMode (long-form, deprecated for new code)
+
+```typescript
+type InlineEditSessionMode    = "inline-all-rows";          // edits in-place in the table
+type StandaloneEditSessionMode = "all-rows"                 // copy all rows
+                               | "selected-rows"            // copy currently selected rows
+                               | "empty-session-table";     // empty table (add-rows workflow)
+
+// @deprecated — prefer CopyOption for standalone sessions in new code
+type EditSessionMode = InlineEditSessionMode | StandaloneEditSessionMode;
+```
+
+`EditSessionMode` long-form strings are sent directly to the `beginEditSession` RPC without conversion. Callers should now prefer `CopyOption` when requesting standalone sessions via `createSessionTable`.
+
+### CopyOption (preferred for standalone sessions)
+
+```typescript
+type CopyOption = "All" | "Empty" | "Selected";
+```
+
+Used with `createSessionTable` and accepted by `EditSession.begin()` and `useEditableTable.editSessionMode`. When a `CopyOption` is passed to `begin()`, it routes to `createSessionTable` instead of `beginEditSession`.
+
+---
+
+## EditSession — Core API
+
+`EditSession` is a plain class (not a React component) that tracks all pending changes for one edit session and orchestrates RPC calls to the underlying datasource.
+
+### State
+
+| Property | Type | Description |
+|---|---|---|
+| `editCount` | `number` | Number of valid cell edits pending |
+| `deleteCount` | `number` | Number of rows marked for soft-deletion |
+| `addCount` | `number` | Number of rows added in this session |
+| `invalidCount` | `number` | Number of invalid cell edits |
+| `inEditMode` | `boolean` | `true` once `begin()` has resolved and before `end()` completes |
+| `editState` | `"clean" \| "dirty" \| "invalid" \| "stale"` | Derived summary; emitted via `"editState"` event |
+
+### Lifecycle
+
+```typescript
+editSession.begin(mode?)   // EditSessionMode (deprecated) | CopyOption — opens session datasource
+  → editSession.end(save?, force?)   // commits or discards, clears all state
+```
+
+`begin()` is overloaded with a deprecation marker on the `EditSessionMode` signature:
+
+```typescript
+// ① deprecated — IDE shows strikethrough for long-form values like "all-rows"
+begin(mode: EditSessionMode): Promise<DataSource | undefined>;
+// ② preferred — "All", "Empty", "Selected", or no argument (defaults to inline)
+begin(mode?: CopyOption): Promise<DataSource | undefined>;
+```
+
+Passing a `CopyOption` value routes to `createSessionTable`; anything else routes to `beginEditSession`. The returned session datasource is stored internally and returned to the caller.
+
+The `isCopyOption(mode)` type guard is exported from `@vuu-ui/vuu-utils` for use at call sites that hold a `EditSessionMode | CopyOption` union:
+
+```typescript
+import { isCopyOption } from "@vuu-ui/vuu-utils";
+
+const sessionDs = isCopyOption(mode)
+  ? await editSession.begin(mode)   // CopyOption overload
+  : await editSession.begin(mode);  // EditSessionMode overload (deprecated)
+```
+
+### Row Operations
+
+| Method | Description |
+|---|---|
+| `editSession.addRows(count, rowData?)` | Adds `count` blank rows via the source-table datasource `addRow` RPC |
+| `editSession.deleteSelectedRows()` | Deletes the rows currently selected in the server-side viewport via a single `deleteSelectedRows` RPC; updates `#deletedRows` and `deleteCount` from the returned `deletedKeys` |
+| `editSession.restoreRows(keys[])` | Removes keys from the local deleted-rows set (does not send an RPC — use `undoRowChange` for full reversion) |
+| `editSession.undoRowChange(key)` | Reverts **all** pending changes for one row (cell edits + soft-delete) via a single `undoRowChange` RPC; only updates local counters on confirmed success |
+| `editSession.hasRowChanges(key)` | Returns `true` if the row has pending edits or is marked for deletion |
+
+### Cell Editing
+
+```
+editSession.commit(key, column, originalValue, editedValue, isValid)
+```
+
+Tracks the cell edit locally and forwards it to `dataSource.editCell()`. Handles the case where a user reverts a cell back to its original value (removes the pending edit entry).
+
+### Events
+
+```ts
+editSession.on("editState", (state: EditState) => { ... });
+```
+
+Fired whenever `editCount`, `deleteCount`, `addCount`, or `invalidCount` changes. Consumed by `EditButtons` to enable/disable the Save button.
+
+---
+
+## useEditableTable — React Hook
+
+Wraps `EditSession` for use in React components. Manages session lifecycle in response to `isEditMode` toggling.
+
+### Props
+
+| Prop | Default | Description |
+|---|---|---|
+| `dataSource` | — | Pre-existing DataSource; takes precedence over `table` |
+| `table` | — | Creates a new DataSource if `dataSource` not provided |
+| `columns` | `undefined` | Column list for the subscription |
+| `editSessionMode` | `"inline-all-rows"` | Passed to `editSession.begin()`. Accepts `CopyOption` (preferred, routes to `createSessionTable`) or `EditSessionMode` long-form values (deprecated, routes to `beginEditSession`). Narrowed internally with `isCopyOption` before the call. |
+| `deleteMode` | `"soft"` | `"soft"` marks the row; `"hard"` deletes immediately |
+| `addRowsCount` | `15` | Number of rows added per `onAddRows` call |
+| `isEditMode` | required | Toggling to `true` calls `editSession.begin()`; to `false` calls `editSession.end()` |
+| `onCancel` | required | Called after `editSession.end()` (discard) completes |
+| `onSave` | required | Called after `editSession.end(true)` (save) completes successfully |
+
+### Return Values
+
+| Value | Description |
+|---|---|
+| `dataSource` | The (possibly newly created) DataSource |
+| `editSession` | The `EditSession` instance |
+| `sessionDataSource` | Set for standalone modes; `undefined` for inline |
+| `hasSelection` | `true` when one or more rows are selected |
+| `onCancel` | Async handler: `await editSession.end()` → `onCancel()` |
+| `onSave` | Async handler: `await editSession.end(true, force)` → `onSave()` |
+| `onDelete` | Calls `editSession.deleteSelectedRows()`; resets selection count |
+| `onAddRows` | Adds rows via `editSession.addRows(addRowsCount)` |
+| `onUndoRowChange` | `(key) =>` `editSession.undoRowChange(key)` |
+
+`hasSelection` is kept in sync by a `useEffect` that subscribes to the datasource's
+`"row-selection"` event — no `onSelectionChange` callback needs to be wired into the Table.
+
+---
+
+## EditButtons — UI Component
+
+Renders the action bar for an edit session. Subscribes to `EditSession` directly for button state, and accepts handler callbacks for each action. The handlers are typically provided by `useEditableTable`, but any callbacks that satisfy the props interface can be used — the component has no hard dependency on the hook.
+
+### Props
+
+| Prop | Description |
+|---|---|
+| `editSession` | Subscribes to `"editState"` events to drive Save button state |
+| `hasSelection` | Enables the Delete button |
+| `onSave(force?)` | Called when Save is clicked (after optional `confirmSave` gate) |
+| `onCancel()` | Called when Cancel is clicked (after optional `confirmCancel` gate) |
+| `onDelete()` | Called when Delete is clicked |
+| `onAddRows()` | Called when Add Rows is clicked |
+| `saveLabel` | Label for the Save button (defaults to `"Save"`); appended with `" (force)"` when `editState === "stale"` |
+| `confirmSave?` | `() => boolean \| Promise<boolean>` — async gate; save is aborted if it returns `false` |
+| `confirmCancel?` | `() => boolean \| Promise<boolean>` — async gate; cancel is aborted if it returns `false` |
+
+### Save button states
+
+| `editState` | Button |
+|---|---|
+| `"clean"` | Disabled |
+| `"dirty"` | Enabled, shows `saveLabel` |
+| `"invalid"` | Disabled |
+| `"stale"` | Enabled, shows `"${saveLabel} (force)"` |
+
+---
+
+## Call Flows
+
+### Begin Edit Session (inline)
+
+```
+isEditMode → true
+  useEditableTable (useMemo)
+    editSession.begin("inline-all-rows")
+      dataSource.beginEditSession("inline-all-rows")          ← EditApi RPC
+        → "beginEditSession" RPC → VuuModule.beginEditSession
+          creates SessionTable (Proxy over source Table)
+          stores in #sessionTableMap[sessionTableName]
+          returns { table: { module, table: sessionTableName } }
+      dataSource creates #sessionDataSource for sessionTableName
+      #sessionDataSource.subscribe(range, handleSessionMessage)
+    EditSession stores #sessionDataSource
+    subsequent operations route to #sessionDataSource
+```
+
+### Begin Edit Session (standalone via beginEditSession)
+
+```
+editSession.begin("all-rows")           // or "selected-rows" / "empty-session-table"
+  dataSource.beginEditSession("all-rows")
+    → "beginEditSession" RPC → VuuModule.beginEditSession
+        creates SessionTable, returns { table: ... }
+    → returns session DataSource to caller
+  EditSession stores #sessionDataSource, returns it to consumer
+```
+
+### Create Session Table (standalone via createSessionTable)
+
+```
+editSession.begin("All")               // or "Empty" / "Selected"
+  editSession detects CopyOption → routes to createSessionTable
+  dataSource.createSessionTable("All")
+    → "createSessionTable" RPC → VuuModule.createSessionTableService
+        determines mode from CopyOption directly:
+          "All"      → createSessionTableWithAllRows
+          "Selected" → createSessionTableFromSelectedRows
+          "Empty"    → createEmptySessionTable
+        returns { table: { module, table: sessionTableName } }
+    → datasource creates and returns session DataSource
+  EditSession stores #sessionDataSource, returns it to consumer
+```
+
+No `fromRpcEditSessionMode` conversion is needed — `VuuModule.createSessionTable()` accepts `CopyOption` directly alongside `EditSessionMode`.
+
+### Cell Edit
+
+```
+User edits cell
+  editSession.commit(key, column, originalValue, editedValue, isValid)
+    editSession.storeCellEdit(...)             ← updates #rowEdits, adjusts editCount
+    dataSource.editCell(key, column, value)    ← EditApi RPC (via session datasource)
+      → "editCell" RPC → VuuModule.editCell
+          sessionTable.update(key, column, value)
+            emits "update" event → session datasource updates its cache
+            session datasource sends updated row to client
+```
+
+### Delete Selected Rows (soft)
+
+```
+User selects rows → clicks Delete
+  EditButtons.onDelete → useEditableTable.handleDelete
+    editSession.deleteSelectedRows()
+      dataSource.deleteSelectedRows("soft")      ← EditApi RPC (via session datasource)
+        → "deleteSelectedRows" RPC → VuuModule.deleteSelectedRows
+            reads selectedRows from session datasource subscription
+            for each selected key:
+              sessionTable.update(key, sessionTableMessageColumn, "SOFT_DELETED")
+            returns { deletedKeys: [...] }
+      on RpcSuccess: #deletedRows.add(key) for each, deleteCount += n ← emits "editState" → "dirty"
+      on RpcError:  local state unchanged
+    setSelectionCount(0)                         ← disables Delete button
+```
+
+> **Note:** The client does not send row keys to the server. Selection state is owned by the server-side
+> viewport. The `deletedKeys` in the response are used to populate `#deletedRows` locally so that
+> `hasRowChanges` and `undoRowChange` continue to work correctly.
+
+### Add Row
+
+```
+User clicks Add Rows
+  EditButtons.onAddRows → useEditableTable.handleAddRows
+    editSession.addRows(count)
+      for each new row:
+        #sourceTableDataSource.addRow(rowData)  ← EditApi RPC (via SOURCE datasource, not session)
+          → "addRow" RPC → VuuModule.addRow
+              sessionTable.insert(newRow)
+              emits "insert" event → session datasource adds row to its view
+      addCount += count                         ← emits "editState" → "dirty"
+```
+
+> **Note:** `addRow` always routes through the **source** datasource (not the session datasource) because `VuuModule.addRow` looks up the session table via `subscription.sessionTableName`.
+
+### Undo Row Change
+
+```
+User clicks Undo button on a row
+  UndoCellRenderer.onClick → onUndoRowChange(key)
+    editSession.undoRowChange(key)
+      checks #rowEdits.has(key) || #deletedRows.has(key)
+      deletes key from #rowEdits / #deletedRows BEFORE the RPC       ← undo button hides immediately
+      dataSource.undoRowChange(key)              ← EditApi RPC (via session datasource)
+        → "undoRowChange" RPC → VuuModule.undoRowChange
+            sourceTable = this.tables[dataSource.table.table]         ← real Table (avoids Proxy private-field issue)
+            if sourceTable.findByKey(key) === null:                   ← newly inserted row
+              sessionTable.delete(key)                                ← removes row from session view
+              returns UndoRowChangeResult { wasInsertedRow: true }
+            else:                                                     ← existing source row
+              for each column in sessionUpdates.cellUpdates:
+                originalValue = sourceTable.findByKey(key)[column]
+                sessionTable.update(key, column, originalValue)       ← emits "update" → client sees original values
+              sessionUpdates.delete(key)                              ← excluded from endEditSession commit
+      on RpcSuccess:
+        adjust editCount / invalidCount from reverted cell edits
+        if wasDeleted: deleteCount--
+        if wasInsertedRow: addCount--
+      on RpcError: restore #rowEdits / #deletedRows (undo button reappears)
+```
+
+### Save (End Session)
+
+```
+User clicks Save
+  EditButtons.handleSave
+    confirmSave?.()                              ← optional async gate
+    onSave(isStale)                              ← useEditableTable.handleSave
+      dataSource.resume()
+      editSession.end(save=true, force)
+        dataSource.endEditSession(true, force)   ← EditApi RPC (via session datasource)
+          → "endEditSession" RPC → VuuModule.endEditSession
+              for each key in sessionTable.getSessionUpdates():
+                compare lastUpdateTimestamp with source table
+                if stale: write error to sessionTableMessageColumn, rejectedCount++
+                else: apply cellUpdates to source table row
+              if rejectedCount > 0 → returns ERROR_RESULT "stale update"
+                EditSession.end catches StaleUpdateError → emits "editState" "stale"
+              else → returns SUCCESS_RESULT
+        editSession.clear()                      ← resets all counters and state
+      onSave()                                   ← consumer callback
+```
+
+### Cancel (End Session — Discard)
+
+```
+User clicks Cancel
+  EditButtons.handleCancel
+    confirmCancel?.()                            ← optional async gate
+    onCancel()                                   ← useEditableTable.handleCancel
+      await editSession.end(save=false)
+        dataSource.endEditSession(false)         ← EditApi RPC (via session datasource)
+          → "endEditSession" RPC → VuuModule.endEditSession
+              save=false: skips applying updates to source table
+              sessionDataSource.unsubscribe()
+        editSession.clear()
+      onCancel()                                 ← consumer callback (e.g. toggle view mode)
+```
+
+---
+
+## EditApi — DataSource Contract
+
+All datasources used with `EditSession` must implement `EditApi` from `@vuu-ui/vuu-data-types`:
+
+```ts
+interface EditApi<T extends DataSourceRow | DataSourceRowWithBigint = DataSourceRow> {
+  beginEditSession?(mode?: EditSessionMode): Promise<DataSourceBase<T> | undefined>;
+  createSessionTable?(copyOption: CopyOption): Promise<DataSourceBase<T> | undefined>;
+  addRow?(rowData?: Record<string, VuuRowDataItemType>): Promise<RpcResult> | undefined;
+  deleteRow?(key: string, mode?: DeleteRowMode): Promise<RpcResult> | undefined;
+  deleteSelectedRows?(mode?: DeleteRowMode): Promise<RpcResult> | undefined;
+  editCell?(rowKey: string, column: string, value: VuuRowDataItemType): Promise<RpcResult> | undefined;
+  undoRowChange?(key: string): Promise<RpcResult> | undefined;
+  endEditSession?(saveChanges?: boolean, force?: boolean): Promise<RpcResult> | undefined;
+}
+```
+
+### RPC Success Response Payloads
+
+Each `EditApi` method returns `RpcResultSuccess` on success. The table below shows the `data` field shape for each.
+
+| Method | `data` on success | Typed as |
+|---|---|---|
+| `beginEditSession` | `{ table: VuuTable }` — the server-assigned session table | `BeginEditSessionResult` |
+| `createSessionTable` | `{ table: VuuTable }` — same shape as `beginEditSession` | `BeginEditSessionResult` |
+| `addRow` | `undefined` | — |
+| `deleteRow` | `undefined` | — |
+| `deleteSelectedRows` | `{ deletedKeys: string[] }` | `DeleteSelectedRowsResult` |
+| `editCell` | `undefined` | — |
+| `undoRowChange` | `{ wasInsertedRow?: boolean }` | `UndoRowChangeResult` |
+| `endEditSession` | `undefined` | — |
+
+The structured payloads are declared in `@vuu-ui/vuu-data-types`:
+
+```ts
+// beginEditSession / createSessionTable — session table to subscribe to
+type BeginEditSessionResult = { table: VuuTable };
+// Example: { table: { module: "SIMUL", table: "session-a1b2c3" } }
+
+// deleteSelectedRows — keys of every row deleted server-side
+type DeleteSelectedRowsResult = { deletedKeys: string[] };
+// Example: { deletedKeys: ["VOD.L", "AAPL.O"] }
+
+// undoRowChange — true when a newly added (uncommitted) row was removed entirely
+type UndoRowChangeResult = { wasInsertedRow?: boolean };
+// Example (existing row reverted): undefined
+// Example (newly added row removed): { wasInsertedRow: true }
+```
+
+Both `TickingArrayDataSource` (local/test) and `VuuDataSource` (remote) implement all methods.
+Each method dispatches a named RPC request registered and handled in `VuuModule.#moduleServices`.
+
+> **`addRow` vs `deleteSelectedRows` key ownership:**
+> - `addRow` generates a client-side UUID key (local test only); `VuuDataSource` omits the key and lets the server generate it.
+> - `deleteSelectedRows` sends no row keys at all — the server reads its own viewport selection state.
+
+> **`sessionTableMessageColumn`:** `VuuModule` uses a configurable column name for soft-delete and
+> stale-rejection markers (defaults to `"vuuMsg"`). Subclasses can override it via `VuuModuleOptions`:
+> ```typescript
+> super("MY_MODULE", { sessionTableMessageColumn: "statusCol" });
+> ```
+> Pass the same name as `sessionTableMessageColumn` in the `UndoCellComponentProps` so the undo
+> button correctly reads the soft-delete state from the row data.
+
+---
+
+## RPC Routing Summary
+
+### Request Params
+
+The `params` object sent with each RPC request (types from `@vuu-ui/vuu-protocol-types`):
+
+| RPC name | Params shape | Example |
+|---|---|---|
+| `"beginEditSession"` | `{ editSessionMode?: EditSessionMode }` | `{ editSessionMode: "inline-all-rows" }` |
+| `"createSessionTable"` | `{ copyOption: CopyOption }` | `{ copyOption: "All" }` |
+| `"addRow"` | `{ data: Record<string, VuuRowDataItemType> }` — remote; local also adds `key` | `{ key: "VOD.L-a1b2", data: { ric: "VOD.L-a1b2", lotSize: 100, ... } }` |
+| `"deleteRow"` | `{ key: string, mode: DeleteRowMode }` | `{ key: "VOD.L", mode: "soft" }` |
+| `"deleteSelectedRows"` | `{ mode: DeleteRowMode }` — no keys; server reads its own selection | `{ mode: "soft" }` |
+| `"editCell"` | `{ key: string, column: string, data: VuuRowDataItemType }` | `{ key: "VOD.L", column: "lotSize", data: 500 }` |
+| `"undoRowChange"` | `{ key: string }` | `{ key: "VOD.L" }` |
+| `"endEditSession"` | `{ save?: boolean, force?: boolean }` | `{ save: true }` or `{}` (discard) |
+
+### Routing & Handlers
+
+| EditApi method | RPC name | Routes via | VuuModule handler |
+|---|---|---|---|
+| `beginEditSession` | `"beginEditSession"` | source datasource | creates `SessionTable` proxy, stores in `#sessionTableMap`; `editSessionMode` passed through unchanged |
+| `createSessionTable` | `"createSessionTable"` | source datasource | `createSessionTableService` — resolves `CopyOption` directly in `VuuModule.createSessionTable()`, no alias conversion |
+| `addRow` | `"addRow"` | **source** datasource | `addRow` — inserts into session table |
+| `deleteRow` | `"deleteRow"` | session datasource | `deleteRow` — direct key-based delete (for programmatic use) |
+| `deleteSelectedRows` | `"deleteSelectedRows"` | session datasource | reads `selectedRows` from session subscription; soft/hard deletes each; returns `DeleteSelectedRowsResult` |
+| `editCell` | `"editCell"` | session datasource | `editCell` — `sessionTable.update(key, col, val)` |
+| `undoRowChange` | `"undoRowChange"` | session datasource | if key not in source table: deletes inserted row, returns `{ wasInsertedRow: true }`; otherwise reverts `cellUpdates` to source values |
+| `endEditSession` | `"endEditSession"` | session datasource | applies (or discards) session updates to source table |
+
+
+---
+
+## Layers at a Glance
+
+```
+Consumer component (e.g. EditableInstrumentsTemplate)
   └─ useEditableTable (React hook)
        └─ EditSession (session state + orchestration)
             └─ DataSource (EditApi)

--- a/vuu-ui/packages/vuu-utils/src/data-editing/edit-utils.tsx
+++ b/vuu-ui/packages/vuu-utils/src/data-editing/edit-utils.tsx
@@ -1,38 +1,6 @@
-import { EditSessionMode, EditSessionModeAlias, InlineEditSessionMode, StandaloneEditSessionMode } from "@vuu-ui/vuu-data-types";
+import { EditSessionMode, InlineEditSessionMode } from "@vuu-ui/vuu-data-types";
 import { DataRow, RuntimeColumnDescriptor } from "@vuu-ui/vuu-table-types";
 import { formatDate } from "../date";
-
-/**
- * Converts a StandaloneEditSessionMode long-form value to the short-form alias
- * accepted by the beginEditSession RPC.
- * `"inline-all-rows"` is NOT converted here — it is a client-only flag that
- * passes through to the RPC unchanged.
- */
-const TO_RPC_MODE: Partial<Record<string, EditSessionModeAlias>> = {
-  "all-rows": "All",
-  "empty-session-table": "Empty",
-  "selected-rows": "Selected",
-};
-
-export const toRpcEditSessionMode = (
-  mode: EditSessionMode,
-): EditSessionModeAlias =>
-  TO_RPC_MODE[mode] ?? (mode as EditSessionModeAlias);
-
-/**
- * Converts an RPC alias back to the long-form mode needed by VuuModule
- * internals (e.g. `createSessionTable`). Always returns a long-form value.
- */
-const FROM_RPC_MODE: Record<EditSessionModeAlias, InlineEditSessionMode | StandaloneEditSessionMode> = {
-  All: "all-rows",
-  Empty: "empty-session-table",
-  Selected: "selected-rows",
-};
-
-export const fromRpcEditSessionMode = (
-  alias: EditSessionModeAlias,
-): InlineEditSessionMode | StandaloneEditSessionMode =>
-  FROM_RPC_MODE[alias] ?? (alias as StandaloneEditSessionMode);
 
 export const isInlineEditingSession = (
   editSessionMode: EditSessionMode,

--- a/vuu-ui/packages/vuu-utils/src/data-editing/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-utils/src/data-editing/useEditableTable.ts
@@ -1,9 +1,9 @@
-import { DataSource, DeleteRowMode, EditSessionMode } from "@vuu-ui/vuu-data-types";
+import { CopyOption, DataSource, DeleteRowMode, EditApi, EditSessionMode } from "@vuu-ui/vuu-data-types";
 import type { VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useData } from "../context-definitions/DataProvider";
 import { useLayoutEffectSkipFirst } from "../useLayoutEffectSkipFirst";
-import { EditSession } from "./EditSession";
+import { EditSession, isCopyOption } from "./EditSession";
 
 export type EditMode = "edit" | "view";
 
@@ -16,7 +16,7 @@ export interface EditableTableHookProps {
   dataSource?: DataSource;
   addRowsCount?: number;
   deleteMode?: DeleteRowMode;
-  editSessionMode?: EditSessionMode;
+  editSessionMode?: EditSessionMode | CopyOption;
   isEditMode: boolean;
   onCancel: () => void;
   onSave: () => void;
@@ -32,7 +32,7 @@ export const useEditableTable = ({
   columns,
   dataSource: dataSourceProp,
   deleteMode = "soft",
-  editSessionMode = "inline-all-rows",
+  editSessionMode = "inline-all-rows" as EditSessionMode | CopyOption,
   isEditMode,
   onCancel,
   onSave,
@@ -62,7 +62,7 @@ export const useEditableTable = ({
   // The editSession will be made available to all the edit controls in scope
   // by wrapping the edit component with a DataEditingProvider.
   const editSession = useMemo(
-    () => new EditSession(dataSource, deleteMode),
+    () => new EditSession(dataSource as EditApi, deleteMode),
     // deleteMode is intentionally excluded — changing it mid-session is not supported
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [dataSource],
@@ -71,6 +71,8 @@ export const useEditableTable = ({
   const handleCancel = useCallback(async () => {
     try {
       await editSession.end();
+      setSessionDataSource(undefined);
+      setSelectionCount(0);
       onCancel();
     } catch (e) {
       //
@@ -83,6 +85,8 @@ export const useEditableTable = ({
       try {
         await editSession.end(true, force);
         if (editSession.inEditMode === false) {
+          setSessionDataSource(undefined);
+          setSelectionCount(0);
           onSave();
         }
       } catch (e) {
@@ -107,14 +111,17 @@ export const useEditableTable = ({
   );
 
   useEffect(() => {
-    dataSource.on("row-selection", setSelectionCount);
-    return () => dataSource.removeListener("row-selection", setSelectionCount);
-  }, [dataSource]);
+    const activeDataSource = sessionDataSource ?? dataSource;
+    activeDataSource.on("row-selection", setSelectionCount);
+    return () => activeDataSource.removeListener("row-selection", setSelectionCount);
+  }, [dataSource, sessionDataSource]);
 
   useMemo(async () => {
     if (isEditMode) {
       try {
-        const sessionDataSource = await editSession.begin(editSessionMode);
+        const sessionDataSource = isCopyOption(editSessionMode)
+          ? await editSession.begin(editSessionMode)
+          : await editSession.begin(editSessionMode);
         if (sessionDataSource) {
           setSessionDataSource(sessionDataSource);
         }
@@ -124,6 +131,8 @@ export const useEditableTable = ({
       }
     } else if (editSession.inEditMode) {
       await editSession.end();
+      setSessionDataSource(undefined);
+      setSelectionCount(0);
     }
   }, [editSession, editSessionMode, isEditMode, onCancel]);
 

--- a/vuu-ui/packages/vuu-utils/src/index.ts
+++ b/vuu-ui/packages/vuu-utils/src/index.ts
@@ -20,6 +20,7 @@ export { getVuuEditMessage } from "./data-editing/edit-utils";
 export { EditButtons, type EditButtonProps } from "./data-editing/EditButtons";
 export {
   EditSession,
+  isCopyOption,
   StaleUpdateError,
   type EditState,
 } from "./data-editing/EditSession";
@@ -100,7 +101,7 @@ export {
   useDataSource,
 } from "./context-definitions/DataSourceProvider";
 export * from "./context-definitions/WorkspaceContext";
-export { fromRpcEditSessionMode, isInlineEditingSession, toRpcEditSessionMode } from "./data-editing/edit-utils";
+export { isInlineEditingSession } from "./data-editing/edit-utils";
 export { PageVisibilityObserver } from "./PageVisibilityObserver";
 export * from "./ShellContext";
 export { ThemeLoadChecker } from "./theme-utils";

--- a/vuu-ui/packages/vuu-utils/src/protocol-message-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/protocol-message-utils.ts
@@ -37,6 +37,7 @@ import {
   BeginEditSessionRpcServiceRequest,
   UndoRowChangeRpcServiceRequest,
   DeleteSelectedRowsRpcServiceRequest,
+  CreateSessionTableRpcServiceRequest,
   ServerToClientError,
 } from "@vuu-ui/vuu-protocol-types";
 import { isView as componentInRegistry } from "./component-registry";
@@ -266,3 +267,7 @@ export const isDeleteSelectedRowsRpcRequest = (
   rpcRequest: VuuRpcServiceRequest,
 ): rpcRequest is DeleteSelectedRowsRpcServiceRequest =>
   rpcRequest.rpcName === "deleteSelectedRows";
+export const isCreateSessionTableRpcRequest = (
+  rpcRequest: VuuRpcServiceRequest,
+): rpcRequest is CreateSessionTableRpcServiceRequest =>
+  rpcRequest.rpcName === "createSessionTable";

--- a/vuu-ui/showcase/src/examples/Apps/CsvUploadRpcExample.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Apps/CsvUploadRpcExample.examples.tsx
@@ -141,11 +141,11 @@ const CsvUploadRpcExampleContent = () => {
     setImported(true);
   }, []);
 
-  const handleEditSessionStarted = useCallback((sessionDs: DataSource) => {
+  const handleImportSessionStarted = useCallback((sessionDs: DataSource) => {
     setSessionTable(sessionDs.table as CsvUploadSessionTable);
   }, []);
 
-  const handleEditSessionEnded = useCallback(() => {
+  const handleImportSessionEnded = useCallback(() => {
     setSessionTable(undefined);
   }, []);
 
@@ -165,10 +165,10 @@ const CsvUploadRpcExampleContent = () => {
         maxRows={25000}
         onCancel={handleCancel}
         onClose={handleCancel}
-        onEditSessionEnded={handleEditSessionEnded}
+        onImportSessionEnded={handleImportSessionEnded}
         onError={handleError}
         onImported={handleImported}
-        onEditSessionStarted={handleEditSessionStarted}
+        onImportSessionStarted={handleImportSessionStarted}
         open={dialogOpen}
       >
         {errorMessage ? (
@@ -233,7 +233,7 @@ const CsvUploadRpcLifecycleExampleContent = () => {
     addTransition(phaseLabelById["processing"]);
   }, [addTransition]);
 
-  const handleEditSessionStarted = useCallback(
+  const handleImportSessionStarted = useCallback(
     (dataSource: DataSource) => {
       setSessionTable(dataSource.table as CsvUploadSessionTable);
       setPhase("preview-ready");
@@ -242,7 +242,7 @@ const CsvUploadRpcLifecycleExampleContent = () => {
     [addTransition],
   );
 
-  const handleEditSessionEnded = useCallback(
+  const handleImportSessionEnded = useCallback(
     (result: CsvUploadSessionEndResult) => {
       setSessionTable(undefined);
       const nextPhase = result.reason === "saved" ? "imported" : "idle";
@@ -337,8 +337,8 @@ const CsvUploadRpcLifecycleExampleContent = () => {
         onCancel={handleCancel}
         onClose={handleClose}
         onProcessingStarted={handleProcessingStarted}
-        onEditSessionStarted={handleEditSessionStarted}
-        onEditSessionEnded={handleEditSessionEnded}
+        onImportSessionStarted={handleImportSessionStarted}
+        onImportSessionEnded={handleImportSessionEnded}
         onError={handleError}
         open={dialogOpen}
       />

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -28,6 +28,7 @@ import { ModalProvider, useModal } from "@vuu-ui/vuu-ui-controls";
 import {
   DataEditingProvider,
   DataSourceProvider,
+  isCopyOption,
   registerComponent,
   toColumnName,
   useData,
@@ -289,7 +290,11 @@ export const EditableInstruments = () => {
   );
 };
 
-const InlineEditTableTemplate = () => {
+const EditableInstrumentsTemplate = ({
+  editSessionMode,
+}: {
+  editSessionMode?: Parameters<typeof useEditableTable>[0]["editSessionMode"];
+}) => {
   const [editMode, setEditMode] = useState<EditMode>("view");
   const { VuuDataSource } = useData();
 
@@ -307,10 +312,11 @@ const InlineEditTableTemplate = () => {
 
   const exitEditMode = useCallback(() => setEditMode("view"), []);
 
-  const { dataSource, editSession, hasSelection, onAddRows, onDelete, onSave, onUndoRowChange } =
+  const { dataSource, editSession, hasSelection, onAddRows, onDelete, onSave, onUndoRowChange, sessionDataSource } =
     useEditableTable({
       dataSource: sourceTableDataSource,
       deleteMode: "soft",
+      editSessionMode,
       isEditMode: editMode === "edit",
       onCancel: exitEditMode,
       onSave: exitEditMode,
@@ -380,14 +386,20 @@ const InlineEditTableTemplate = () => {
         </ToggleButtonGroup>
       </div>
       <div style={{ flex: "1 1 auto" }}>
-        <DataEditingProvider editSession={editSession}>
-          <Table
-            config={config}
-            dataSource={dataSource}
-            renderBufferSize={10}
-            selectionModel="checkbox"
-          />
-        </DataEditingProvider>
+        {editMode === "edit" && isCopyOption(editSessionMode) && !sessionDataSource ? (
+          <div role="status" aria-label="Loading session table">
+            Loading session…
+          </div>
+        ) : (
+          <DataEditingProvider editSession={editSession}>
+            <Table
+              config={config}
+              dataSource={sessionDataSource ?? dataSource}
+              renderBufferSize={10}
+              selectionModel="checkbox"
+            />
+          </DataEditingProvider>
+        )}
       </div>
       <TableFooter>
         {editMode === "view" ? (
@@ -411,7 +423,16 @@ const InlineEditTableTemplate = () => {
 export const EditableInstrumentsInlineEdit = () => (
   <LocalDataSourceProvider>
     <NotificationsProvider>
-      <InlineEditTableTemplate />
+      <EditableInstrumentsTemplate />
+    </NotificationsProvider>
+  </LocalDataSourceProvider>
+);
+
+/** tags=data-consumer */
+export const CreateSessionTableInstruments = () => (
+  <LocalDataSourceProvider>
+    <NotificationsProvider>
+      <EditableInstrumentsTemplate editSessionMode="All" />
     </NotificationsProvider>
   </LocalDataSourceProvider>
 );


### PR DESCRIPTION
- Introduce CopyOption = "All" | "Empty" | "Selected" for standalone session tables
- Remove CopyOption from EditSessionMode union; deprecate EditSessionMode for new code
- Fix useEditableTable: subscribe row-selection on active datasource (sessionDataSource ?? dataSource); reset sessionDataSource/selectionCount on session end
- Add editSessionMode prop to EditableInstrumentsTemplate with loading state for async createSessionTable; add CreateSessionTableInstruments showcase example
- Added unit tests (createSessionTable), Playwright CT tests