### PR TITLE
Remediate CVEs in third party libraries

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -13,9 +13,9 @@
     <name>${project.artifactId}</name>
 
     <properties>
-        <sttp.client4.version>4.0.25</sttp.client4.version>
-        <typesafe.conf.version>1.4.8</typesafe.conf.version>
-        <vertx.version>5.0.12</vertx.version>
+        <sttp.client4.version>4.0.26</sttp.client4.version>
+        <typesafe.conf.version>1.4.9</typesafe.conf.version>
+        <vertx.version>5.1.6</vertx.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -46,16 +46,16 @@
         <assertj.version>3.27.7</assertj.version>
         <jackson.version>3.1.5</jackson.version>
         <junit.jupiter.version>6.1.2</junit.jupiter.version>
-        <logback.version>1.5.38</logback.version>
-        <metrics.version>4.2.38</metrics.version>
-        <netty.version>4.2.16.Final</netty.version>
+        <logback.version>1.6.1</logback.version>
+        <metrics.version>4.2.39</metrics.version>
+        <netty.version>4.2.17.Final</netty.version>
         <roaring.bitmap.version>1.6.14</roaring.bitmap.version>
         <scala.version>3.3.8</scala.version> <!-- Scala LTS -->
         <scala.logging.version>3.9.6</scala.logging.version>
         <scalamock.version>7.5.5</scalamock.version>
         <scalatest.version>3.2.20</scalatest.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <testcontainers.version>2.0.3</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <testcontainers.scalatest.version>0.44.1</testcontainers.scalatest.version>
     </properties>
 

--- a/vuu/pom.xml
+++ b/vuu/pom.xml
@@ -129,12 +129,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4</artifactId>
-            <version>${antlr.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>


### PR DESCRIPTION
As we use the maven plugin, we only need to declare the antlr4-runtime dependency.

We can remove the other Antlr dependency, which negates our exposure to the following CVEs

https://github.com/advisories/GHSA-m64j-m5c8-f58p
https://github.com/advisories/GHSA-w346-wxvq-p3xr

Also upgraded the following to new major versions:

https://vertx.io/blog/eclipse-vert-x-5-1-6/
https://github.com/qos-ch/logback/releases/tag/v_1.6.1

Minor version updates of the following:

Netty
sttp.client4
typesafe.conf
metrics
testcontainers


