### PR TITLE
Add VUU data editing package

### DIFF
--- a/vuu-ui/package-lock.json
+++ b/vuu-ui/package-lock.json
@@ -4736,6 +4736,10 @@
       "resolved": "packages/vuu-context-menu",
       "link": true
     },
+    "node_modules/@vuu-ui/vuu-data-editing": {
+      "resolved": "packages/vuu-data-editing",
+      "link": true
+    },
     "node_modules/@vuu-ui/vuu-data-local": {
       "resolved": "packages/vuu-data-local",
       "link": true
@@ -15089,6 +15093,24 @@
         "clsx": "^2.0.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3"
+      }
+    },
+    "packages/vuu-data-editing": {
+      "name": "@vuu-ui/vuu-data-editing",
+      "version": "2.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@salt-ds/core": "1.67.0",
+        "@vuu-ui/vuu-utils": "2.2.1",
+        "@vuu-ui/vuu-utils2": "2.2.1"
+      },
+      "devDependencies": {
+        "@vuu-ui/vuu-data-types": "2.2.1",
+        "@vuu-ui/vuu-protocol-types": "2.2.1",
+        "@vuu-ui/vuu-table-types": "2.2.1"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
       }
     },
     "packages/vuu-data-local": {

--- a/vuu-ui/packages/vuu-data-editing/DESIGN.md
+++ b/vuu-ui/packages/vuu-data-editing/DESIGN.md
@@ -1,0 +1,38 @@
+# VUU data editing design
+
+## Purpose
+
+`@vuu-ui/vuu-data-editing` is the home for VUU's reusable data editing
+features. It coordinates edit-session state with editable data sources and
+provides React integrations for edit-mode controls.
+
+The initial implementation is copied from `@vuu-ui/vuu-utils`. The originals
+remain in place so existing consumers continue to work while applications
+migrate to this package.
+
+## Architecture
+
+`useEditableTable` creates or accepts a data source and owns an `EditSession`.
+The session opens an editable session data source, tracks cell edits and row
+changes, and commits or discards those changes. `DataEditingProvider` makes
+the session available to nested controls, while `EditButtons` reflects session
+state in the available editing actions.
+
+## Files
+
+| File                          | Responsibility                                                                                                                     |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `src/EditSession.tsx`         | Implements the edit-session lifecycle, change tracking, row operations, validation state, save, cancel, and stale-update handling. |
+| `src/useEditableTable.ts`     | Connects an `EditSession` to React and a VUU data source, exposing handlers and state for editable tables.                         |
+| `src/DataEditingProvider.tsx` | Provides the active `EditSession` through React context.                                                                           |
+| `src/EditModeProvider.tsx`    | Provides shared view/edit mode state for editing controls.                                                                         |
+| `src/EditButtons.tsx`         | Renders save, cancel, delete, and add-row controls based on edit-session state.                                                    |
+| `src/edit-utils.tsx`          | Supplies edit-mode detection and user-facing stale-update messages.                                                                |
+| `src/index.ts`                | Defines the package's public API.                                                                                                  |
+
+## Dependencies
+
+Data-source and protocol contracts come from the VUU type packages. Shared
+formatting, event, RPC, and React utilities remain in `@vuu-ui/vuu-utils` and
+`@vuu-ui/vuu-utils2`; this package depends on them rather than duplicating
+unrelated utilities.

--- a/vuu-ui/packages/vuu-data-editing/README.md
+++ b/vuu-ui/packages/vuu-data-editing/README.md
@@ -1,0 +1,5 @@
+# @vuu-ui/vuu-data-editing
+
+Shared data editing APIs, state management, and React components for VUU UI.
+
+See [DESIGN.md](./DESIGN.md) for the package design and file responsibilities.

--- a/vuu-ui/packages/vuu-data-editing/package.json
+++ b/vuu-ui/packages/vuu-data-editing/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@vuu-ui/vuu-data-editing",
+  "version": "2.2.1",
+  "description": "Shared data editing APIs and React components for VUU UI",
+  "main": "src/index.ts",
+  "author": "heswell",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "node ../../scripts/run-build-rslib.ts",
+    "test": "vitest run",
+    "type-defs": "node ../../scripts/build-type-defs.mjs"
+  },
+  "dependencies": {
+    "@salt-ds/core": "1.67.0",
+    "@vuu-ui/vuu-utils": "2.2.1",
+    "@vuu-ui/vuu-utils2": "2.2.1"
+  },
+  "devDependencies": {
+    "@vuu-ui/vuu-data-types": "2.2.1",
+    "@vuu-ui/vuu-protocol-types": "2.2.1",
+    "@vuu-ui/vuu-table-types": "2.2.1"
+  },
+  "peerDependencies": {
+    "react": "^19.2.3"
+  },
+  "sideEffects": false
+}

--- a/vuu-ui/packages/vuu-data-editing/src/DataEditingProvider.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/DataEditingProvider.tsx
@@ -1,0 +1,35 @@
+import { createContext, ReactNode, useContext } from "react";
+import { EditSession } from "./EditSession";
+
+const DataEditingContext = createContext<EditSession | undefined>(undefined);
+
+export const DataEditingProvider = ({
+  children,
+  editSession,
+}: {
+  children: ReactNode;
+  editSession: EditSession;
+}) => {
+  return (
+    <DataEditingContext.Provider value={editSession}>
+      {children}
+    </DataEditingContext.Provider>
+  );
+};
+
+export function useEditSession(
+  throwIfUnavailable?: false,
+): EditSession | undefined;
+export function useEditSession(throwIfUnavailable: true): EditSession;
+export function useEditSession(throwIfUnavailable = false) {
+  const editSession = useContext(DataEditingContext);
+  if (editSession === undefined) {
+    if (throwIfUnavailable) {
+      throw Error(
+        "[useEditSession] no DataEditingContext in scope. You need to enclose editable component(s) with DataEditingProvider",
+      );
+    }
+  } else {
+    return editSession;
+  }
+}

--- a/vuu-ui/packages/vuu-data-editing/src/EditButtons.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditButtons.tsx
@@ -1,0 +1,79 @@
+import { Button } from "@salt-ds/core";
+import type { EditState, EditSession } from "./EditSession";
+import { useCallback, useEffect, useState } from "react";
+
+export interface EditButtonProps {
+  editSession?: EditSession;
+  hasSelection?: boolean;
+  onCancel?: () => void;
+  onDelete?: () => void;
+  onAddRows?: () => void;
+  onSave: (force?: boolean) => void;
+  saveLabel?: string;
+  confirmSave?: () => boolean | Promise<boolean>;
+  confirmCancel?: () => boolean | Promise<boolean>;
+}
+
+export const EditButtons = ({
+  confirmCancel,
+  confirmSave,
+  editSession,
+  hasSelection = false,
+  onAddRows,
+  onCancel,
+  onDelete,
+  onSave,
+  saveLabel = "Save",
+}: EditButtonProps) => {
+  const [editState, setEditState] = useState<EditState>("clean");
+
+  const handleSave = useCallback(async () => {
+    if (confirmSave) {
+      const confirmed = await confirmSave();
+      if (!confirmed) return;
+    }
+    onSave(editState === "stale");
+  }, [confirmSave, editState, onSave]);
+
+  const handleCancel = useCallback(async () => {
+    if (confirmCancel) {
+      const confirmed = await confirmCancel();
+      if (!confirmed) return;
+    }
+    onCancel?.();
+  }, [confirmCancel, onCancel]);
+
+  useEffect(() => {
+    if (editSession) {
+      editSession.on("editState", setEditState);
+      return () => editSession.removeListener("editState", setEditState);
+    }
+  }, [editSession]);
+
+  return (
+    <>
+      {onDelete && (
+        <Button
+          disabled={!hasSelection}
+          onClick={onDelete}
+          sentiment="negative"
+        >
+          Delete
+        </Button>
+      )}
+      {onAddRows && (
+        <Button onClick={onAddRows} sentiment="neutral">
+          Add Rows
+        </Button>
+      )}
+      <Button
+        disabled={editState === "clean" || editState === "invalid"}
+        onClick={handleSave}
+        sentiment="accented"
+      >
+        {editState === "stale" ? `${saveLabel} (force)` : saveLabel}
+      </Button>
+      {onCancel && <Button onClick={handleCancel}>Cancel</Button>}
+    </>
+  );
+};

--- a/vuu-ui/packages/vuu-data-editing/src/EditModeProvider.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditModeProvider.tsx
@@ -1,0 +1,26 @@
+import { createContext, ReactNode, useContext, useState } from "react";
+
+export interface EditModeContextProps {
+  isEditMode: boolean;
+  setEditMode: (inEditMode: boolean) => void;
+}
+
+const EditModeContext = createContext<EditModeContextProps>({
+  isEditMode: false,
+  setEditMode: () => "EditModeProvider in place",
+});
+
+/**
+ * Implemented as a standalone Provider so that EditMode cna be implemented
+ * at higher level than individual edit controls.
+ */
+export const EditModeProvider = ({ children }: { children: ReactNode }) => {
+  const [isEditMode, setEditMode] = useState(false);
+  return (
+    <EditModeContext.Provider value={{ isEditMode, setEditMode }}>
+      {children}
+    </EditModeContext.Provider>
+  );
+};
+
+export const useEditMode = () => useContext(EditModeContext);

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -1,0 +1,398 @@
+import {
+  CopyOption,
+  DataSource,
+  DeleteRowMode,
+  DeleteSelectedRowsResult,
+  EditApi,
+  EditSessionMode,
+  UndoRowChangeResult,
+} from "@vuu-ui/vuu-data-types";
+import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
+import { EventEmitter, isRpcError } from "@vuu-ui/vuu-utils";
+
+export const isCopyOption = (
+  mode?: EditSessionMode | CopyOption,
+): mode is CopyOption =>
+  mode === "All" || mode === "Empty" || mode === "Selected";
+
+export type EditState = "clean" | "dirty" | "invalid" | "stale";
+
+export class EditError extends Error {}
+
+type CellEdit = {
+  originalValue: VuuRowDataItemType;
+  editedValue: VuuRowDataItemType;
+  isValid?: boolean;
+  isDeleted?: boolean;
+};
+
+// TODO can add more when when we know what the server implementation of error columns will look like
+export class StaleUpdateError extends Error {}
+
+type RowEditDetails = {
+  /**
+   * Column name => cell edit details
+   */
+  cellEdits: Map<string, CellEdit>;
+};
+
+type EditSessionEvents = {
+  editState: (editState: EditState) => void;
+};
+
+export class EditSession extends EventEmitter<EditSessionEvents> {
+  /**
+   *  Row key => row edits
+   */
+  #rowEdits = new Map<string, RowEditDetails>();
+  #deletedRows = new Set<string>();
+  #editCount = 0;
+  #deleteCount = 0;
+  #addCount = 0;
+  #invalidCount = 0;
+  #deleteMode: DeleteRowMode;
+  #sourceTableDataSource?: EditApi;
+  #sessionDataSource?: EditApi;
+  #inEditMode = false;
+  #endEditModePending = false;
+
+  constructor(dataSource: EditApi, deleteMode: DeleteRowMode = "soft") {
+    super();
+    this.#sourceTableDataSource = dataSource;
+    this.#deleteMode = deleteMode;
+  }
+
+  get editCount() {
+    return this.#editCount;
+  }
+
+  set editCount(val: number) {
+    if (val !== this.#editCount) {
+      const oldCount = this.#editCount;
+      this.#editCount = val;
+      if (val === 0 && this.#deleteCount === 0 && this.#addCount === 0) {
+        this.emit("editState", "clean");
+      } else if (oldCount === 0) {
+        this.emit("editState", "dirty");
+      }
+    }
+  }
+
+  get invalidCount() {
+    return this.#invalidCount;
+  }
+
+  set invalidCount(val: number) {
+    if (val !== this.#invalidCount) {
+      const oldCount = this.#invalidCount;
+      this.#invalidCount = val;
+      if (val === 0) {
+        this.emit("editState", this.#editCount === 0 ? "clean" : "dirty");
+      } else if (oldCount === 0) {
+        this.emit("editState", "invalid");
+      }
+    }
+  }
+
+  get deleteCount() {
+    return this.#deleteCount;
+  }
+
+  set deleteCount(val: number) {
+    if (val !== this.#deleteCount) {
+      const oldCount = this.#deleteCount;
+      this.#deleteCount = val;
+      if (val === 0 && this.#editCount === 0 && this.#addCount === 0) {
+        this.emit("editState", "clean");
+      } else if (oldCount === 0) {
+        this.emit("editState", "dirty");
+      }
+    }
+  }
+
+  get addCount() {
+    return this.#addCount;
+  }
+
+  set addCount(val: number) {
+    if (val !== this.#addCount) {
+      const oldCount = this.#addCount;
+      this.#addCount = val;
+      if (val === 0 && this.#editCount === 0 && this.#deleteCount === 0) {
+        this.emit("editState", "clean");
+      } else if (oldCount === 0) {
+        this.emit("editState", "dirty");
+      }
+    }
+  }
+
+  async deleteSelectedRows(): Promise<void> {
+    const response = await this.dataSource?.deleteSelectedRows?.(
+      this.#deleteMode,
+    );
+    if (isRpcError(response)) return;
+    const deletedKeys = (response?.data as DeleteSelectedRowsResult | undefined)
+      ?.deletedKeys;
+    if (deletedKeys && deletedKeys.length > 0) {
+      let newCount = 0;
+      for (const key of deletedKeys) {
+        if (!this.#deletedRows.has(key)) {
+          this.#deletedRows.add(key);
+          newCount++;
+        }
+      }
+      if (newCount > 0) {
+        this.deleteCount = this.#deleteCount + newCount;
+      }
+    }
+  }
+
+  addRows(count = 15, rowData: Record<string, VuuRowDataItemType> = {}) {
+    for (let i = 0; i < count; i++) {
+      this.#sourceTableDataSource?.addRow?.(rowData);
+    }
+    this.addCount = this.#addCount + count;
+  }
+
+  restoreRows(keys: string[]) {
+    for (const key of keys) {
+      if (this.#deletedRows.has(key)) {
+        this.#deletedRows.delete(key);
+        this.deleteCount = this.#deleteCount - 1;
+      }
+    }
+  }
+
+  hasRowChanges(key: string): boolean {
+    return this.#rowEdits.has(key) || this.#deletedRows.has(key);
+  }
+
+  async undoRowChange(key: string): Promise<void> {
+    if (!this.#inEditMode) return;
+
+    const rowEdits = this.#rowEdits.get(key);
+    const wasDeleted = this.#deletedRows.has(key);
+
+    if (!rowEdits?.cellEdits.size && !wasDeleted) return;
+
+    this.#rowEdits.delete(key);
+    if (wasDeleted) this.#deletedRows.delete(key);
+
+    const response = await this.dataSource?.undoRowChange?.(key);
+
+    if (isRpcError(response)) {
+      // Restore on failure
+      if (rowEdits) this.#rowEdits.set(key, rowEdits);
+      if (wasDeleted) this.#deletedRows.add(key);
+      return;
+    }
+
+    // Update counters after confirmed success
+    if (rowEdits) {
+      let validCount = 0;
+      let invalidCount = 0;
+      for (const [, cellEdit] of rowEdits.cellEdits) {
+        if (cellEdit.isValid === false) {
+          invalidCount++;
+        } else {
+          validCount++;
+        }
+      }
+      this.editCount = this.#editCount - validCount;
+      this.invalidCount = this.#invalidCount - invalidCount;
+    }
+    if (wasDeleted) {
+      this.deleteCount = this.#deleteCount - 1;
+    }
+
+    // If the server deleted a newly inserted row, decrement addCount
+    const wasInsertedRow =
+      (response?.data as UndoRowChangeResult | undefined)?.wasInsertedRow ===
+      true;
+    if (wasInsertedRow) {
+      this.addCount = this.#addCount - 1;
+    }
+  }
+
+  clear() {
+    this.#rowEdits.clear();
+    this.#deletedRows.clear();
+    this.#editCount = 0;
+    this.#deleteCount = 0;
+    this.#addCount = 0;
+    this.#invalidCount = 0;
+    this.#inEditMode = false;
+    this.#endEditModePending = false;
+  }
+
+  /** @deprecated Pass a `CopyOption` ("All" | "Empty" | "Selected") to use `createSessionDataSource` instead. Long-form `EditSessionMode` values will be removed in a future release. */
+  async begin(mode: EditSessionMode): Promise<DataSource | undefined>;
+  async begin(mode?: CopyOption): Promise<DataSource | undefined>;
+  async begin(
+    mode?: EditSessionMode | CopyOption,
+  ): Promise<DataSource | undefined> {
+    try {
+      this.#inEditMode = true;
+      const sessionDataSource = isCopyOption(mode)
+        ? await this.#sourceTableDataSource?.createSessionDataSource?.(mode)
+        : await this.#sourceTableDataSource?.beginEditSession?.(mode);
+
+      this.#sessionDataSource = sessionDataSource;
+      return sessionDataSource;
+    } catch (e) {
+      this.#inEditMode = false;
+    }
+  }
+
+  get dataSource() {
+    return this.#sessionDataSource ?? this.#sourceTableDataSource;
+  }
+
+  async end(saveChanges = false, force = false) {
+    try {
+      if (this.#inEditMode) {
+        this.#endEditModePending = true;
+        await this.dataSource?.endEditSession?.(saveChanges, force);
+        this.clear();
+      }
+    } catch (e) {
+      this.#endEditModePending = false;
+      if (e instanceof StaleUpdateError) {
+        this.emit("editState", "stale");
+      } else {
+        console.error(`[EditSession] ${(e as Error).message}`);
+      }
+    }
+  }
+
+  get inEditMode() {
+    return this.#inEditMode === true && this.#endEditModePending === false;
+  }
+
+  get editState(): EditState {
+    return this.editCount === 0 &&
+      this.#deleteCount === 0 &&
+      this.#addCount === 0
+      ? "clean"
+      : "dirty";
+  }
+
+  getOrCreateRowEdits(key: string): RowEditDetails {
+    const rowEditDetails = this.#rowEdits.get(key);
+    if (rowEditDetails) {
+      return rowEditDetails;
+    } else {
+      const rowEditDetails = {
+        cellEdits: new Map<string, CellEdit>(),
+      };
+      this.#rowEdits.set(key, rowEditDetails);
+      return rowEditDetails;
+    }
+  }
+
+  storeCellEdit(
+    cellEdits: Map<string, CellEdit>,
+    column: string,
+    originalValue: VuuRowDataItemType,
+    editedValue: VuuRowDataItemType,
+    isValid: boolean,
+  ) {
+    const cellEdit = cellEdits.get(column);
+    if (cellEdit) {
+      if (cellEdit.originalValue === editedValue) {
+        cellEdits.delete(column);
+        cellEdit.isDeleted = true;
+        if (cellEdit.isValid) {
+          this.editCount -= 1;
+        } else {
+          this.invalidCount -= 1;
+        }
+      } else {
+        if (isValid && cellEdit.isValid === false) {
+          cellEdit.isValid = true;
+          cellEdit.editedValue = editedValue;
+          // do not trigger the event, save it for the editCount
+          this.#invalidCount -= 1;
+          this.editCount += 1;
+        }
+      }
+      return cellEdit;
+    } else {
+      const cellEdit: CellEdit = {
+        originalValue,
+        editedValue,
+        isValid,
+      };
+      cellEdits.set(column, cellEdit);
+      if (isValid) {
+        this.editCount += 1;
+      }
+      return cellEdit;
+    }
+  }
+
+  async commit(
+    key: string,
+    columnName: string,
+    originalValue: VuuRowDataItemType,
+    typedValue: string | number | boolean,
+    isValid: boolean,
+  ) {
+    if (!this.#inEditMode) {
+      throw new Error("No edit session in progress");
+    }
+    const rowEditDetails = this.getOrCreateRowEdits(key);
+
+    if (isValid) {
+      const { cellEdits } = rowEditDetails;
+
+      const cellEdit = this.storeCellEdit(
+        cellEdits,
+        columnName,
+        originalValue,
+        typedValue,
+        isValid,
+      );
+
+      if (cellEdit.isDeleted) {
+        if (rowEditDetails.cellEdits.size === 0) {
+          this.#rowEdits.delete(key);
+        }
+      }
+
+      if (this.dataSource?.editCell) {
+        const response = await this.dataSource.editCell(
+          key,
+          columnName,
+          typedValue,
+        );
+        if (isRpcError(response)) {
+          cellEdit.isValid = false;
+          this.invalidCount += 1;
+        }
+
+        return {
+          editedDuringCurrentSession: cellEdit.originalValue !== typedValue,
+          ...response,
+        };
+      }
+    } else {
+      const { cellEdits } = rowEditDetails;
+      let cellEdit = cellEdits.get(columnName);
+      if (cellEdit && cellEdit.isValid !== false) {
+        cellEdit.isValid = false;
+        this.invalidCount += 1;
+      } else if (cellEdit === undefined) {
+        cellEdit = this.storeCellEdit(
+          cellEdits,
+          columnName,
+          originalValue,
+          typedValue,
+          isValid,
+        );
+        this.invalidCount += 1;
+      }
+      return { editedDuringCurrentSession: false };
+    }
+  }
+}

--- a/vuu-ui/packages/vuu-data-editing/src/edit-utils.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/edit-utils.tsx
@@ -1,0 +1,41 @@
+import { EditSessionMode, InlineEditSessionMode } from "@vuu-ui/vuu-data-types";
+import { DataRow, RuntimeColumnDescriptor } from "@vuu-ui/vuu-table-types";
+import { formatDate } from "@vuu-ui/vuu-utils";
+
+export const isInlineEditingSession = (
+  editSessionMode: EditSessionMode,
+): editSessionMode is InlineEditSessionMode =>
+  editSessionMode.startsWith("inline");
+
+const timeFormatter = formatDate({ time: "hh:mm:ss" });
+
+export const getVuuEditMessage = (
+  dataRow: DataRow,
+  column: RuntimeColumnDescriptor,
+  originalValue: string,
+) => {
+  const vuuMsg = dataRow.vuuMsg as string;
+  if (typeof vuuMsg === "string" && vuuMsg !== "") {
+    const columnMessages = vuuMsg.split(",");
+    const msgForCol = columnMessages.find((msg) =>
+      msg.startsWith(`${column.name}:`),
+    );
+    if (msgForCol) {
+      const [, value, updatedValue, ts] = msgForCol.split(":");
+      const updateTime = timeFormatter(new Date(parseInt(ts as string)));
+      return (
+        <span>
+          {"Update rejected. Original value "}
+          <b>{originalValue}</b>
+          {" could not be updated to "}
+          <b>{value}</b>
+          {". It was updated to "}
+          <b>{updatedValue}</b>
+          {" at "}
+          {updateTime}
+          {"."}
+        </span>
+      );
+    }
+  }
+};

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -1,0 +1,20 @@
+export { DataEditingProvider, useEditSession } from "./DataEditingProvider";
+export { getVuuEditMessage, isInlineEditingSession } from "./edit-utils";
+export { EditButtons, type EditButtonProps } from "./EditButtons";
+export {
+  EditModeProvider,
+  useEditMode,
+  type EditModeContextProps,
+} from "./EditModeProvider";
+export {
+  EditError,
+  EditSession,
+  isCopyOption,
+  StaleUpdateError,
+  type EditState,
+} from "./EditSession";
+export {
+  useEditableTable,
+  type EditableTableHookProps,
+  type EditMode,
+} from "./useEditableTable";

--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -1,0 +1,168 @@
+import {
+  CopyOption,
+  DataSource,
+  DeleteRowMode,
+  EditApi,
+  EditSessionMode,
+} from "@vuu-ui/vuu-data-types";
+import type { VuuTable } from "@vuu-ui/vuu-protocol-types";
+import { useLayoutEffectSkipFirst } from "@vuu-ui/vuu-utils";
+import { useData } from "@vuu-ui/vuu-utils2";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { EditSession, isCopyOption } from "./EditSession";
+
+export type EditMode = "edit" | "view";
+
+export interface EditableTableHookProps {
+  /**
+   * columns to be included in subscription. If not provided,
+   * default will be '*'. Ignored if dataSource prop present.
+   */
+  columns?: string[];
+  dataSource?: DataSource;
+  addRowsCount?: number;
+  deleteMode?: DeleteRowMode;
+  editSessionMode?: EditSessionMode | CopyOption;
+  isEditMode: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+  /**
+   * If dataSource not provided, new DataSource
+   * will be created using table and columns
+   */
+  table?: VuuTable;
+}
+
+export const useEditableTable = ({
+  addRowsCount = 15,
+  columns,
+  dataSource: dataSourceProp,
+  deleteMode = "soft",
+  editSessionMode = "inline-all-rows" as EditSessionMode | CopyOption,
+  isEditMode,
+  onCancel,
+  onSave,
+  table,
+}: EditableTableHookProps) => {
+  const { VuuDataSource } = useData();
+  const [sessionDataSource, setSessionDataSource] = useState<
+    DataSource | undefined
+  >(undefined);
+  const [selectionCount, setSelectionCount] = useState(0);
+  const [deleteCount, setDeleteCount] = useState(0);
+  useLayoutEffectSkipFirst(() => {
+    console.warn(`[useEditableTable] columns and or table changed`);
+  }, [columns, table]);
+
+  const dataSource = useMemo(() => {
+    if (dataSourceProp) {
+      return dataSourceProp;
+    } else if (table) {
+      return new VuuDataSource({ columns, table });
+    } else {
+      throw Error(
+        `useEditableTable unable to provide DataSource, neither dataSource nor table available as props`,
+      );
+    }
+  }, [VuuDataSource, columns, dataSourceProp, table]);
+
+  // The editSession will be made available to all the edit controls in scope
+  // by wrapping the edit component with a DataEditingProvider.
+  const editSession = useMemo(
+    () => new EditSession(dataSource as EditApi, deleteMode),
+    // deleteMode is intentionally excluded — changing it mid-session is not supported
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dataSource],
+  );
+
+  const handleCancel = useCallback(async () => {
+    try {
+      await editSession.end();
+      setSessionDataSource(undefined);
+      setSelectionCount(0);
+      onCancel();
+    } catch (e) {
+      //
+    }
+  }, [editSession, onCancel]);
+
+  const handleSave = useCallback(
+    async (force = false) => {
+      dataSource.resume?.();
+      try {
+        await editSession.end(true, force);
+        if (editSession.inEditMode === false) {
+          setSessionDataSource(undefined);
+          setSelectionCount(0);
+          onSave();
+        }
+      } catch (e) {
+        console.log(`[useEditableTable] handleSave ${(e as Error).message}`);
+      }
+    },
+    [dataSource, editSession, onSave],
+  );
+
+  const handleDelete = useCallback(async () => {
+    await editSession.deleteSelectedRows();
+    setSelectionCount(0);
+  }, [editSession]);
+
+  const handleAddRows = useCallback(() => {
+    editSession.addRows(addRowsCount);
+  }, [addRowsCount, editSession]);
+
+  const handleUndoRowChange = useCallback(
+    (key: string) => void editSession.undoRowChange(key),
+    [editSession],
+  );
+
+  useEffect(() => {
+    const activeDataSource = sessionDataSource ?? dataSource;
+    activeDataSource.on("row-selection", setSelectionCount);
+    return () =>
+      activeDataSource.removeListener("row-selection", setSelectionCount);
+  }, [dataSource, sessionDataSource]);
+
+  useEffect(() => {
+    const syncDeleteCount = () => setDeleteCount(editSession.deleteCount);
+    editSession.on("editState", syncDeleteCount);
+    return () => editSession.removeListener("editState", syncDeleteCount);
+  }, [editSession]);
+
+  useMemo(async () => {
+    if (isEditMode) {
+      try {
+        const sessionDs = isCopyOption(editSessionMode)
+          ? await editSession.begin(editSessionMode)
+          : await editSession.begin(editSessionMode);
+        if (sessionDs) {
+          setSessionDataSource(sessionDs);
+        } else {
+          console.warn(
+            `[useEditableTable] editSession.begin(${editSessionMode}) did not return a session DataSource`,
+          );
+        }
+      } catch (e) {
+        console.error(`[useEditableTable] begin edit session failed`, e);
+        onCancel();
+      }
+    } else if (editSession.inEditMode) {
+      await editSession.end();
+      setSessionDataSource(undefined);
+      setSelectionCount(0);
+    }
+  }, [editSession, editSessionMode, isEditMode, onCancel]);
+
+  return {
+    dataSource,
+    editSession,
+    hasSelection: selectionCount > 0 || deleteCount > 0,
+    onAddRows: handleAddRows,
+    onCancel: handleCancel,
+    onDelete: handleDelete,
+    onSave: handleSave,
+    onUndoRowChange: handleUndoRowChange,
+    sessionDataSource,
+  };
+};

--- a/vuu-ui/packages/vuu-data-editing/tsconfig.json
+++ b/vuu-ui/packages/vuu-data-editing/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/vuu-ui/scripts/build-all-rslib.ts
+++ b/vuu-ui/scripts/build-all-rslib.ts
@@ -25,6 +25,7 @@ export const buildAll = async () => {
   ];
   const wave2 = [
     "grid-layout",
+    "vuu-data-editing",
     "vuu-data-remote",
     "vuu-data-local",
     "vuu-notifications",

--- a/vuu-ui/scripts/build-all-type-defs.mjs
+++ b/vuu-ui/scripts/build-all-type-defs.mjs
@@ -17,6 +17,7 @@ const packages = [
   "vuu-chart",
   "vuu-auth",
   "vuu-portal",
+  "vuu-data-editing",
   "vuu-data-local",
   "vuu-data-react",
   "vuu-data-remote",

--- a/vuu-ui/scripts/publish.mjs
+++ b/vuu-ui/scripts/publish.mjs
@@ -7,6 +7,7 @@ const packages = [
   "vuu-chart",
   "vuu-codemirror",
   "vuu-context-menu",
+  "vuu-data-editing",
   "vuu-data-local",
   "vuu-data-remote",
   "vuu-data-react",


### PR DESCRIPTION
## Summary
- add `@vuu-ui/vuu-data-editing` with copies of the existing `vuu-utils/data-editing` features
- document the package architecture and file responsibilities
- include the package in rslib builds, type-definition builds, and publishing
- retain the original `vuu-utils` implementations during migration

## Validation
- `npm run build` succeeds for `@vuu-ui/vuu-data-editing`
- package-level type generation reaches existing unrelated repository TypeScript errors