### PR TITLE
Refactor edit session lifecycle management

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/src/DataEditingProvider.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/DataEditingProvider.tsx
@@ -10,11 +10,6 @@ export const DataEditingProvider = ({
   children: ReactNode;
   editSession: EditSession;
 }) => {
-
-  console.log('@vuu-data-editing [DataEditingProvider], editSession', {
-    editSession
-  })
-
   return (
     <DataEditingContext.Provider value={editSession}>
       {children}

--- a/vuu-ui/packages/vuu-data-editing/src/EditButtons.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditButtons.tsx
@@ -17,6 +17,7 @@ export interface EditButtonProps {
 }
 
 export const EditButtons = ({
+  canCancel,
   canSave,
   confirmCancel,
   confirmSave,
@@ -69,14 +70,14 @@ export const EditButtons = ({
           Add Rows
         </Button>
       )}
-      <Button
-        disabled={!canSave}
-        onClick={handleSave}
-        sentiment="accented"
-      >
+      <Button disabled={!canSave} onClick={handleSave} sentiment="accented">
         {editState === "stale" ? `${saveLabel} (force)` : saveLabel}
       </Button>
-      {onCancel && <Button onClick={handleCancel}>Cancel</Button>}
+      {onCancel && (
+        <Button disabled={!canCancel} onClick={handleCancel}>
+          Cancel
+        </Button>
+      )}
     </>
   );
 };

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -17,7 +17,19 @@ export const isCopyOption = (
 
 export type EditState = "clean" | "dirty" | "invalid" | "stale";
 
-export class EditError extends Error { }
+export type EditLifecycle =
+  | { status: "idle" }
+  | { status: "starting" }
+  | { status: "active"; sessionDataSource?: DataSource }
+  | { status: "ending"; sessionDataSource?: DataSource }
+  | {
+      status: "error";
+      operation: "begin" | "end";
+      error: Error;
+      sessionDataSource?: DataSource;
+    };
+
+export class EditError extends Error {}
 
 type CellEdit = {
   originalValue: VuuRowDataItemType;
@@ -27,7 +39,7 @@ type CellEdit = {
 };
 
 // TODO can add more when when we know what the server implementation of error columns will look like
-export class StaleUpdateError extends Error { }
+export class StaleUpdateError extends Error {}
 
 type RowEditDetails = {
   /**
@@ -38,6 +50,7 @@ type RowEditDetails = {
 
 type EditSessionEvents = {
   editState: (editState: EditState) => void;
+  lifecycle: (lifecycle: EditLifecycle) => void;
 };
 
 export class EditSession extends EventEmitter<EditSessionEvents> {
@@ -52,9 +65,9 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   #invalidCount = 0;
   #deleteMode: DeleteRowMode;
   #sourceTableDataSource?: EditApi;
-  #sessionDataSource?: EditApi;
-  #inEditMode = false;
-  #endEditModePending = false;
+  #sessionDataSource?: DataSource;
+  #lifecycle: EditLifecycle = { status: "idle" };
+  #transitionQueue: Promise<void> = Promise.resolve();
 
   constructor(dataSource: EditApi, deleteMode: DeleteRowMode = "soft") {
     super();
@@ -168,7 +181,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   }
 
   async undoRowChange(key: string): Promise<void> {
-    if (!this.#inEditMode) return;
+    if (!this.inEditMode) return;
 
     const rowEdits = this.#rowEdits.get(key);
     const wasDeleted = this.#deletedRows.has(key);
@@ -214,60 +227,119 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     }
   }
 
-  clear() {
+  #clearEdits() {
     this.#rowEdits.clear();
     this.#deletedRows.clear();
     this.#editCount = 0;
     this.#deleteCount = 0;
     this.#addCount = 0;
     this.#invalidCount = 0;
-    this.#inEditMode = false;
-    this.#endEditModePending = false;
+  }
+
+  #setLifecycle(lifecycle: EditLifecycle) {
+    this.#lifecycle = lifecycle;
+    this.emit("lifecycle", lifecycle);
+  }
+
+  #enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#transitionQueue.then(operation);
+    this.#transitionQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   /** @deprecated Pass a `CopyOption` ("All" | "Empty" | "Selected") to use `createSessionDataSource` instead. Long-form `EditSessionMode` values will be removed in a future release. */
-  async begin(mode: EditSessionMode): Promise<DataSource | undefined>;
-  async begin(mode?: CopyOption): Promise<DataSource | undefined>;
-  async begin(
-    mode?: EditSessionMode | CopyOption,
-  ): Promise<DataSource | undefined> {
-    try {
-      this.#inEditMode = true;
-      const sessionDataSource = isCopyOption(mode)
-        ? await this.#sourceTableDataSource?.createSessionDataSource?.(mode)
-        : await this.#sourceTableDataSource?.beginEditSession?.(mode);
+  begin(mode: EditSessionMode): Promise<DataSource | undefined>;
+  begin(mode?: CopyOption): Promise<DataSource | undefined>;
+  begin(mode?: EditSessionMode | CopyOption): Promise<DataSource | undefined>;
+  begin(mode?: EditSessionMode | CopyOption): Promise<DataSource | undefined> {
+    return this.#enqueue(async () => {
+      if (
+        this.#lifecycle.status === "active" ||
+        (this.#lifecycle.status === "error" &&
+          this.#lifecycle.operation === "end")
+      ) {
+        if (this.#lifecycle.status === "error") {
+          this.#setLifecycle({
+            status: "active",
+            sessionDataSource: this.#sessionDataSource,
+          });
+        }
+        return this.#sessionDataSource;
+      }
 
-      this.#sessionDataSource = sessionDataSource;
-      return sessionDataSource;
-    } catch (e) {
-      this.#inEditMode = false;
-      throw e;
-    }
+      this.#setLifecycle({ status: "starting" });
+
+      try {
+        const sessionDataSource = isCopyOption(mode)
+          ? await this.#sourceTableDataSource?.createSessionDataSource?.(mode)
+          : await this.#sourceTableDataSource?.beginEditSession?.(mode);
+
+        this.#sessionDataSource = sessionDataSource;
+        this.#setLifecycle({ status: "active", sessionDataSource });
+        return sessionDataSource;
+      } catch (cause) {
+        const error = cause instanceof Error ? cause : new Error(String(cause));
+        this.#setLifecycle({ status: "error", operation: "begin", error });
+        throw error;
+      }
+    });
   }
 
   get dataSource() {
     return this.#sessionDataSource ?? this.#sourceTableDataSource;
   }
 
-  async end(saveChanges = false, force = false) {
-    if (!this.#inEditMode) {
-      return;
-    }
-    try {
-      this.#endEditModePending = true;
-      await this.dataSource?.endEditSession?.(saveChanges, force);
-      this.clear();
-    } catch (e) {
-      this.#endEditModePending = false;
-      if (e instanceof StaleUpdateError) {
-        this.emit("editState", "stale");
+  end(saveChanges = false, force = false): Promise<void> {
+    return this.#enqueue(async () => {
+      if (
+        this.#lifecycle.status === "idle" ||
+        (this.#lifecycle.status === "error" &&
+          this.#lifecycle.operation === "begin")
+      ) {
+        if (this.#lifecycle.status !== "idle") {
+          this.#setLifecycle({ status: "idle" });
+        }
+        return;
       }
-      throw e;
-    }
+
+      const sessionDataSource = this.#sessionDataSource;
+      this.#setLifecycle({ status: "ending", sessionDataSource });
+
+      try {
+        await this.dataSource?.endEditSession?.(saveChanges, force);
+        this.#clearEdits();
+        this.#sessionDataSource = undefined;
+        this.#setLifecycle({ status: "idle" });
+      } catch (cause) {
+        const error = cause instanceof Error ? cause : new Error(String(cause));
+        if (error instanceof StaleUpdateError) {
+          this.emit("editState", "stale");
+        }
+        this.#setLifecycle({
+          status: "error",
+          operation: "end",
+          error,
+          sessionDataSource,
+        });
+        throw error;
+      }
+    });
+  }
+
+  get lifecycle() {
+    return this.#lifecycle;
   }
 
   get inEditMode() {
-    return this.#inEditMode === true && this.#endEditModePending === false;
+    return (
+      this.#lifecycle.status === "active" ||
+      this.#lifecycle.status === "ending" ||
+      (this.#lifecycle.status === "error" &&
+        this.#lifecycle.operation === "end")
+    );
   }
 
   get editState(): EditState {
@@ -339,7 +411,13 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     typedValue: string | number | boolean,
     isValid: boolean,
   ) {
-    if (!this.#inEditMode) {
+    if (
+      this.#lifecycle.status !== "active" &&
+      !(
+        this.#lifecycle.status === "error" &&
+        this.#lifecycle.operation === "end"
+      )
+    ) {
       throw new Error("No edit session in progress");
     }
     const rowEditDetails = this.getOrCreateRowEdits(key);

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -11,6 +11,7 @@ export {
   EditSession,
   isCopyOption,
   StaleUpdateError,
+  type EditLifecycle,
   type EditState,
 } from "./EditSession";
 export {

--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -9,16 +9,9 @@ import type { VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { useLayoutEffectSkipFirst } from "@vuu-ui/vuu-utils";
 import { useData } from "@vuu-ui/vuu-utils2";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { EditSession } from "./EditSession";
+import { EditSession, type EditLifecycle, type EditState } from "./EditSession";
 
 export type EditMode = "edit" | "view";
-
-type EditLifecycle =
-  | { status: "idle" }
-  | { status: "starting" }
-  | { status: "active"; sessionDataSource?: DataSource }
-  | { status: "ending" }
-  | { status: "error"; error: Error };
 
 export interface EditableTableHookProps {
   /**
@@ -52,13 +45,10 @@ export const useEditableTable = ({
   table,
 }: EditableTableHookProps) => {
   const { VuuDataSource } = useData();
-  const [sessionDataSource, setSessionDataSource] = useState<
-    DataSource | undefined
-  >(undefined);
   const [selectionCount, setSelectionCount] = useState(0);
   const [deleteCount, setDeleteCount] = useState(0);
   useLayoutEffectSkipFirst(() => {
-    console.warn('[useEditableTable] columns and or table changed');
+    console.warn("[useEditableTable] columns and or table changed");
   }, [columns, table]);
 
   const dataSource = useMemo(() => {
@@ -68,7 +58,7 @@ export const useEditableTable = ({
       return new VuuDataSource({ columns, table });
     } else {
       throw Error(
-        'useEditableTable unable to provide DataSource, neither dataSource nor table available as props',
+        "useEditableTable unable to provide DataSource, neither dataSource nor table available as props",
       );
     }
   }, [VuuDataSource, columns, dataSourceProp, table]);
@@ -77,19 +67,25 @@ export const useEditableTable = ({
   // by wrapping the edit component with a DataEditingProvider.
   const editSession = useMemo(
     () => new EditSession(dataSource as EditApi, deleteMode),
-    // deleteMode is intentionally excluded — changing it mid-session is not supported
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [dataSource, deleteMode],
   );
+  const [lifecycle, setLifecycle] = useState<EditLifecycle>(
+    editSession.lifecycle,
+  );
+  const [editState, setEditState] = useState<EditState>(editSession.editState);
+  const onCancelRef = useRef(onCancel);
+  onCancelRef.current = onCancel;
+
+  const sessionDataSource =
+    "sessionDataSource" in lifecycle ? lifecycle.sessionDataSource : undefined;
 
   const handleCancel = useCallback(async () => {
     try {
       await editSession.end();
-      setSessionDataSource(undefined);
       setSelectionCount(0);
       onCancel();
-    } catch (e) {
-      //
+    } catch (error) {
+      console.error("[useEditableTable] cancel edit session failed", error);
     }
   }, [editSession, onCancel]);
 
@@ -98,13 +94,10 @@ export const useEditableTable = ({
       dataSource.resume?.();
       try {
         await editSession.end(true, force);
-        if (editSession.inEditMode === false) {
-          setSessionDataSource(undefined);
-          setSelectionCount(0);
-          onSave();
-        }
-      } catch (e) {
-        console.log(`[useEditableTable] handleSave ${(e as Error).message}`);
+        setSelectionCount(0);
+        onSave();
+      } catch (error) {
+        console.error("[useEditableTable] save edit session failed", error);
       }
     },
     [dataSource, editSession, onSave],
@@ -132,145 +125,50 @@ export const useEditableTable = ({
   }, [dataSource, sessionDataSource]);
 
   useEffect(() => {
-    const syncDeleteCount = () => setDeleteCount(editSession.deleteCount);
-    editSession.on("editState", syncDeleteCount);
-    return () => editSession.removeListener("editState", syncDeleteCount);
-  }, [editSession]);
-
-  // useMemo(async () => {
-  //   if (isEditMode) {
-  //     try {
-  //       const sessionDs = isCopyOption(editSessionMode)
-  //         ? await editSession.begin(editSessionMode)
-  //         : await editSession.begin(editSessionMode);
-  //       if (sessionDs) {
-  //         setSessionDataSource(sessionDs);
-  //       } else {
-  //         console.warn(
-  //           `[useEditableTable] editSession.begin(${editSessionMode}) did not return a session DataSource`,
-  //         );
-  //       }
-  //     } catch (e) {
-  //       console.error("[useEditableTable] begin edit session failed", e);
-  //       onCancel();
-  //     }
-  //   } else if (editSession.inEditMode) {
-  //     await editSession.end();
-  //     setSessionDataSource(undefined);
-  //     setSelectionCount(0);
-  //   }
-  // }, [editSession, editSessionMode, isEditMode, onCancel]);
-
-
-  const [lifecycle, setLifecycle] = useState<EditLifecycle>({
-    status: "idle",
-  });
-
-  const lifecycleRef = useRef(lifecycle);
-  const desiredRef = useRef({
-    enabled: isEditMode,
-    mode: editSessionMode,
-  });
-
-  // Serializes rapid edit/view changes and React Strict Mode effects.
-  const transitionQueueRef = useRef(Promise.resolve());
-
-  const updateLifecycle = useCallback((next: EditLifecycle) => {
-    lifecycleRef.current = next;
-    setLifecycle(next);
-  }, []);
-
-  useEffect(() => {
-    desiredRef.current = {
-      enabled: isEditMode,
-      mode: editSessionMode,
+    const handleEditState = (nextEditState: EditState) => {
+      setEditState(nextEditState);
+      setDeleteCount(editSession.deleteCount);
+    };
+    const handleLifecycle = (nextLifecycle: EditLifecycle) => {
+      setLifecycle(nextLifecycle);
     };
 
-    transitionQueueRef.current = transitionQueueRef.current
-      .catch(() => undefined)
-      .then(async () => {
-        // Reconcile again when the requested mode changes during an RPC.
-        while (true) {
-          const desired = desiredRef.current;
-          const current = lifecycleRef.current;
+    setEditState(editSession.editState);
+    setLifecycle(editSession.lifecycle);
+    editSession.on("editState", handleEditState);
+    editSession.on("lifecycle", handleLifecycle);
+    return () => {
+      editSession.removeListener("editState", handleEditState);
+      editSession.removeListener("lifecycle", handleLifecycle);
+    };
+  }, [editSession]);
 
-          if (desired.enabled) {
-            if (
-              current.status === "active" ||
-              current.status === "starting"
-            ) {
-              return;
-            }
+  useEffect(() => {
+    const transition = isEditMode
+      ? editSession.begin(editSessionMode)
+      : editSession.end();
 
-            updateLifecycle({ status: "starting" });
+    void transition.catch((error) => {
+      if (isEditMode) {
+        console.error("[useEditableTable] begin edit session failed", error);
+        onCancelRef.current();
+      } else {
+        console.error("[useEditableTable] end edit session failed", error);
+      }
+    });
+  }, [editSession, editSessionMode, isEditMode]);
 
-            try {
-              const sessionDataSource = await editSession.begin(desired.mode);
-
-              // begin() may complete after the user has left edit mode.
-              if (!desiredRef.current.enabled) {
-                updateLifecycle({
-                  status: "active",
-                  sessionDataSource,
-                });
-                continue;
-              }
-
-              setSessionDataSource(sessionDataSource);
-              updateLifecycle({
-                status: "active",
-                sessionDataSource,
-              });
-            } catch (cause) {
-              const error =
-                cause instanceof Error ? cause : new Error(String(cause));
-
-              updateLifecycle({ status: "error", error });
-              onCancel();
-            }
-
-            return;
-          }
-
-          if (current.status === "idle") {
-            return;
-          }
-
-          updateLifecycle({ status: "ending" });
-
-          try {
-            await editSession.end();
-            setSessionDataSource(undefined);
-            setSelectionCount(0);
-            updateLifecycle({ status: "idle" });
-          } catch (cause) {
-            const error =
-              cause instanceof Error ? cause : new Error(String(cause));
-
-            updateLifecycle({ status: "error", error });
-          }
-
-          return;
-        }
-      });
-  }, [
-    editSession,
-    editSessionMode,
-    isEditMode,
-    onCancel,
-    updateLifecycle,
-  ]);
-
-  const isTransitioning =
-    lifecycle.status === "starting" ||
-    lifecycle.status === "ending";
+  const canCancel =
+    lifecycle.status === "active" ||
+    (lifecycle.status === "error" && lifecycle.operation === "end");
 
   const canSave =
-    !isTransitioning &&
-    editSession.editState === "dirty" &&
+    canCancel &&
+    (editState === "dirty" || editState === "stale") &&
     editSession.invalidCount === 0;
 
   return {
+    canCancel,
     canSave,
     dataSource,
     editSession,

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -1,0 +1,152 @@
+import type { EditApi } from "@vuu-ui/vuu-data-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EditSession } from "../src";
+
+type Editable = Required<EditApi>;
+type BeginEdit = Editable["beginEditSession"];
+type CreateSession = Editable["createSessionDataSource"];
+type EndEdit = Editable["endEditSession"];
+
+class MockDataSource implements EditApi {
+  constructor(
+    private beginEdit: BeginEdit,
+    private endEdit: EndEdit,
+    private createSession: CreateSession,
+  ) {}
+
+  beginEditSession(...args: Parameters<BeginEdit>) {
+    return this.beginEdit(...args);
+  }
+
+  endEditSession(...args: Parameters<EndEdit>) {
+    return this.endEdit(...args);
+  }
+
+  createSessionDataSource(...args: Parameters<CreateSession>) {
+    return this.createSession(...args);
+  }
+}
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+};
+
+describe("EditSession lifecycle", () => {
+  let beginEdit: BeginEdit;
+  let createSession: CreateSession;
+  let editSession: EditSession;
+  let endEdit: EndEdit;
+
+  beforeEach(() => {
+    beginEdit = vi.fn();
+    createSession = vi.fn();
+    endEdit = vi.fn();
+    editSession = new EditSession(
+      new MockDataSource(beginEdit, endEdit, createSession),
+    );
+  });
+
+  it("publishes lifecycle transitions", async () => {
+    const lifecycleListener = vi.fn();
+    editSession.on("lifecycle", lifecycleListener);
+
+    await editSession.begin();
+    await editSession.end();
+
+    expect(lifecycleListener.mock.calls.map(([state]) => state.status)).toEqual(
+      ["starting", "active", "ending", "idle"],
+    );
+  });
+
+  it("serializes end behind a pending begin", async () => {
+    const pendingBegin = deferred<undefined>();
+    beginEdit = vi.fn(() => pendingBegin.promise);
+    editSession = new EditSession(
+      new MockDataSource(beginEdit, endEdit, createSession),
+    );
+
+    const beginPromise = editSession.begin();
+    await Promise.resolve();
+    expect(editSession.lifecycle.status).toBe("starting");
+
+    const endPromise = editSession.end();
+    expect(endEdit).not.toHaveBeenCalled();
+
+    pendingBegin.resolve(undefined);
+    await beginPromise;
+    await endPromise;
+
+    expect(beginEdit).toHaveBeenCalledTimes(1);
+    expect(endEdit).toHaveBeenCalledTimes(1);
+    expect(editSession.lifecycle).toEqual({ status: "idle" });
+  });
+
+  it("does not begin a second session when begin is queued twice", async () => {
+    await Promise.all([editSession.begin(), editSession.begin()]);
+
+    expect(beginEdit).toHaveBeenCalledTimes(1);
+    expect(editSession.lifecycle.status).toBe("active");
+  });
+
+  it("routes standalone and inline sessions to the appropriate datasource API", async () => {
+    await editSession.begin("All");
+
+    expect(createSession).toHaveBeenCalledWith("All");
+    expect(beginEdit).not.toHaveBeenCalled();
+
+    await editSession.end();
+    editSession = new EditSession(
+      new MockDataSource(beginEdit, endEdit, createSession),
+    );
+    await editSession.begin("inline-all-rows");
+
+    expect(beginEdit).toHaveBeenCalledWith("inline-all-rows");
+  });
+
+  it("keeps a failed end session active and allows retry", async () => {
+    const endError = new Error("end failed");
+    endEdit = vi
+      .fn()
+      .mockRejectedValueOnce(endError)
+      .mockResolvedValueOnce(undefined);
+    editSession = new EditSession(
+      new MockDataSource(beginEdit, endEdit, createSession),
+    );
+
+    await editSession.begin();
+    await expect(editSession.end()).rejects.toBe(endError);
+
+    expect(editSession.lifecycle).toMatchObject({
+      status: "error",
+      operation: "end",
+      error: endError,
+    });
+    expect(editSession.inEditMode).toBe(true);
+
+    await editSession.end();
+    expect(editSession.lifecycle).toEqual({ status: "idle" });
+  });
+
+  it("reports begin failures without entering edit mode", async () => {
+    const beginError = new Error("begin failed");
+    beginEdit = vi.fn().mockRejectedValueOnce(beginError);
+    editSession = new EditSession(
+      new MockDataSource(beginEdit, endEdit, createSession),
+    );
+
+    await expect(editSession.begin()).rejects.toBe(beginError);
+
+    expect(editSession.lifecycle).toMatchObject({
+      status: "error",
+      operation: "begin",
+      error: beginError,
+    });
+    expect(editSession.inEditMode).toBe(false);
+  });
+});

--- a/vuu-ui/sample-apps/feature-module-admin/src/ModuleAdmin.tsx
+++ b/vuu-ui/sample-apps/feature-module-admin/src/ModuleAdmin.tsx
@@ -1,4 +1,10 @@
-import { ToggleButton, ToggleButtonGroup, Toolbar, ToolbarContent, Tooltray } from "@salt-ds/core";
+import {
+  ToggleButton,
+  ToggleButtonGroup,
+  Toolbar,
+  ToolbarContent,
+  Tooltray,
+} from "@salt-ds/core";
 import { DataEditingProvider, EditButtons } from "@vuu-ui/vuu-data-editing";
 import { Table } from "@vuu-ui/vuu-table";
 import { DataSourceStats, TableFooter } from "@vuu-ui/vuu-table-extras";
@@ -6,10 +12,20 @@ import { useModuleAdmin } from "./useModuleAdmin";
 
 import "./ModuleAdmin.css";
 
-const classBase = 'vuuModuleAdmin';
+const classBase = "vuuModuleAdmin";
 
 const ModuleAdmin = () => {
-  const { canSave, editMode, editSession, onCancel, onSave, onToggleEditMode, config, dataSource, ...moduleAdmin } = useModuleAdmin();
+  const {
+    canCancel,
+    canSave,
+    editMode,
+    editSession,
+    onCancel,
+    onSave,
+    onToggleEditMode,
+    config,
+    dataSource,
+  } = useModuleAdmin();
 
   // if (moduleAdmin.status === "loading") {
   //   return (
@@ -35,23 +51,17 @@ const ModuleAdmin = () => {
             <ToolbarContent position="end">
               <Tooltray align="end">
                 <ToggleButtonGroup onChange={onToggleEditMode} value={editMode}>
-                  <ToggleButton value="view">
-                    View
-                  </ToggleButton>
-                  <ToggleButton value="edit">
-                    Edit
-                  </ToggleButton>
+                  <ToggleButton value="view">View</ToggleButton>
+                  <ToggleButton value="edit">Edit</ToggleButton>
                 </ToggleButtonGroup>
               </Tooltray>
             </ToolbarContent>
-
           </Tooltray>
         </ToolbarContent>
-
       </Toolbar>
       <div className={`${classBase}-tableContainer`}>
         <DataEditingProvider editSession={editSession}>
-          < Table
+          <Table
             config={config}
             dataSource={dataSource}
             height="100%"
@@ -61,12 +71,13 @@ const ModuleAdmin = () => {
             width="100%"
           />
         </DataEditingProvider>
-      </div >
+      </div>
       <TableFooter>
         {editMode === "view" ? (
           <DataSourceStats dataSource={dataSource} />
         ) : (
           <EditButtons
+            canCancel={canCancel}
             canSave={canSave}
             editSession={editSession}
             onCancel={onCancel}
@@ -74,8 +85,7 @@ const ModuleAdmin = () => {
           />
         )}
       </TableFooter>
-
-    </div >
+    </div>
   );
 };
 

--- a/vuu-ui/sample-apps/feature-module-admin/src/useModuleAdmin.ts
+++ b/vuu-ui/sample-apps/feature-module-admin/src/useModuleAdmin.ts
@@ -2,12 +2,11 @@ import type { TableConfig } from "@vuu-ui/vuu-table-types";
 import { useEditableTable, type EditMode } from "@vuu-ui/vuu-data-editing";
 import { type SyntheticEvent, useCallback, useMemo, useState } from "react";
 import { editableColumns, moduleColumnDescriptors } from "./columnDescriptors";
-import { toColumnName } from "@vuu-ui/vuu-utils/dist/index.mjs";
+import { toColumnName } from "@vuu-ui/vuu-utils";
 import { useData } from "@vuu-ui/vuu-utils2";
 
-
 export const useModuleAdmin = () => {
-  const { VuuDataSource } = useData()
+  const { VuuDataSource } = useData();
 
   const [editMode, setEditMode] = useState<EditMode>("view");
 
@@ -24,18 +23,21 @@ export const useModuleAdmin = () => {
     return new VuuDataSource({
       bufferSize: 200,
       columns: moduleColumnDescriptors.map(toColumnName),
-      table: { module: 'MODULE_DISCOVERY', table: 'modules' },
+      table: { module: "MODULE_DISCOVERY", table: "modules" },
+    });
+  }, [VuuDataSource]);
 
-    })
-  }, [VuuDataSource])
-
-  const config = useMemo<TableConfig | undefined>(
-    () =>
-    ({
+  const config = useMemo<TableConfig>(
+    () => ({
       columnLayout: "static",
-      columns: editMode === 'edit'
-        ? moduleColumnDescriptors.map(col => editableColumns.includes(col.name) ? { ...col, editable: true } : col)
-        : moduleColumnDescriptors,
+      columns:
+        editMode === "edit"
+          ? moduleColumnDescriptors.map((col) =>
+              editableColumns.includes(col.name)
+                ? { ...col, editable: true }
+                : col,
+            )
+          : moduleColumnDescriptors,
       rowSeparators: true,
       zebraStripes: true,
     }),
@@ -46,16 +48,20 @@ export const useModuleAdmin = () => {
     setEditMode("view");
   }, []);
 
-  const { canSave, dataSource: ds, editSession, lifecycle, onCancel, onSave } = useEditableTable({
+  const {
+    canCancel,
+    canSave,
+    dataSource: ds,
+    editSession,
+    lifecycle,
+    onCancel,
+    onSave,
+  } = useEditableTable({
     dataSource,
     isEditMode: editMode === "edit",
     onCancel: exitEditMode,
     onSave: exitEditMode,
   });
-
-  console.log('[useModuleAdmion], editSession', {
-    editSession
-  })
 
   // if (error) {
   //   return { error, status: "error" };
@@ -65,5 +71,17 @@ export const useModuleAdmin = () => {
   //   return { status: "loading" };
   // }
 
-  return { canSave, config, dataSource: ds, editMode, editSession, lifecycle, onCancel, onSave, onToggleEditMode, status: "ready" };
+  return {
+    canCancel,
+    canSave,
+    config,
+    dataSource: ds,
+    editMode,
+    editSession,
+    lifecycle,
+    onCancel,
+    onSave,
+    onToggleEditMode,
+    status: "ready",
+  };
 };

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -15,6 +15,14 @@ import type { VuuRowDataItemType, VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { BulkEditPanel, InputCell, Table } from "@vuu-ui/vuu-table";
 import { DataSourceStats, TableFooter } from "@vuu-ui/vuu-table-extras";
 import {
+  DataEditingProvider,
+  EditButtons,
+  isCopyOption,
+  type EditMode,
+  useEditableTable,
+  useEditSession,
+} from "@vuu-ui/vuu-data-editing";
+import {
   ColumnDescriptor,
   ColumnTypeRendering,
   DataRow,
@@ -28,17 +36,11 @@ import {
 } from "@vuu-ui/vuu-table-types";
 import { ModalProvider, useModal } from "@vuu-ui/vuu-ui-controls";
 import {
-  DataEditingProvider,
   DataSourceProvider,
-  isCopyOption,
   registerComponent,
   toColumnName,
   useData,
-  useEditableTable,
-  useEditSession,
 } from "@vuu-ui/vuu-utils";
-import { EditButtons } from "@vuu-ui/vuu-utils/src/data-editing/EditButtons";
-import { EditMode } from "@vuu-ui/vuu-utils/src/data-editing/useEditableTable";
 import cx from "clsx";
 import {
   HTMLAttributes,
@@ -121,7 +123,14 @@ const EditTableTemplate = ({
     setEditMode("view");
   }, []);
 
-  const { dataSource, editSession, onCancel, onSave } = useEditableTable({
+  const {
+    canCancel,
+    canSave,
+    dataSource,
+    editSession,
+    onCancel,
+    onSave,
+  } = useEditableTable({
     dataSource: sourceTableDataSource,
     isEditMode: editMode === "edit",
     onCancel: exitEditMode,
@@ -274,6 +283,8 @@ const EditTableTemplate = ({
           <DataSourceStats dataSource={dataSource} />
         ) : (
           <EditButtons
+            canCancel={canCancel}
+            canSave={canSave}
             editSession={editSession}
             onCancel={onCancel}
             onSave={onSave}
@@ -315,15 +326,25 @@ const EditableInstrumentsTemplate = ({
 
   const exitEditMode = useCallback(() => setEditMode("view"), []);
 
-  const { dataSource, editSession, hasSelection, onAddRows, onDelete, onSave, sessionDataSource } =
-    useEditableTable({
-      dataSource: sourceTableDataSource,
-      deleteMode: "soft",
-      editSessionMode,
-      isEditMode: editMode === "edit",
-      onCancel: exitEditMode,
-      onSave: exitEditMode,
-    });
+  const {
+    canCancel,
+    canSave,
+    dataSource,
+    editSession,
+    hasSelection,
+    onAddRows,
+    onCancel,
+    onDelete,
+    onSave,
+    sessionDataSource,
+  } = useEditableTable({
+    dataSource: sourceTableDataSource,
+    deleteMode: "soft",
+    editSessionMode,
+    isEditMode: editMode === "edit",
+    onCancel: exitEditMode,
+    onSave: exitEditMode,
+  });
 
   const onToggleEditMode = useCallback(
     (e: SyntheticEvent<HTMLButtonElement>) => {
@@ -412,9 +433,12 @@ const EditableInstrumentsTemplate = ({
           <DataSourceStats dataSource={dataSource} />
         ) : (
           <EditButtons
+            canCancel={canCancel}
+            canSave={canSave}
             editSession={editSession}
             hasSelection={hasSelection}
             onAddRows={onAddRows}
+            onCancel={onCancel}
             onDelete={onDelete}
             onSave={onSave}
             saveLabel="Submit"


### PR DESCRIPTION
## Summary
- move serialized edit lifecycle transitions into `EditSession`
- expose lifecycle state and derive save/cancel capabilities in `useEditableTable`
- migrate showcase editing imports from `vuu-utils` to `vuu-data-editing`
- add focused lifecycle and transition-ordering tests

## Scope
This change intentionally leaves `useDataSource` runtime datasource switching unchanged for a subsequent refactor.

## Validation
- lifecycle tests pass
- `vuu-data-editing` package builds
- changed files pass Biome checks