### PR TITLE
Add inline table row editor

### DIFF
--- a/vuu-ui/package-lock.json
+++ b/vuu-ui/package-lock.json
@@ -15101,6 +15101,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@salt-ds/core": "1.67.0",
+        "@salt-ds/styles": "0.2.1",
+        "@salt-ds/window": "0.1.1",
+        "@vuu-ui/vuu-ui-controls": "2.2.1",
         "@vuu-ui/vuu-utils": "2.2.1",
         "@vuu-ui/vuu-utils2": "2.2.1"
       },

--- a/vuu-ui/packages/vuu-data-editing/package.json
+++ b/vuu-ui/packages/vuu-data-editing/package.json
@@ -13,6 +13,9 @@
   },
   "dependencies": {
     "@salt-ds/core": "1.67.0",
+    "@salt-ds/styles": "0.2.1",
+    "@salt-ds/window": "0.1.1",
+    "@vuu-ui/vuu-ui-controls": "2.2.1",
     "@vuu-ui/vuu-utils": "2.2.1",
     "@vuu-ui/vuu-utils2": "2.2.1"
   },

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -7,7 +7,7 @@ import type {
   EditSessionMode,
   UndoRowChangeResult,
 } from "@vuu-ui/vuu-data-types";
-import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
+import type { RpcResult, VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
 import { EventEmitter, isRpcError } from "@vuu-ui/vuu-utils";
 
 export const isCopyOption = (
@@ -178,6 +178,26 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
         this.deleteCount = this.#deleteCount + newCount;
       }
     }
+  }
+
+  async addRow(
+    rowData: Record<string, VuuRowDataItemType> = {},
+  ): Promise<RpcResult> {
+    const addRow = this.#sourceTableDataSource?.addRow;
+    if (addRow === undefined) {
+      throw Error("[EditSession] datasource does not support adding rows");
+    }
+
+    const response = await addRow.call(this.#sourceTableDataSource, rowData);
+    if (response === undefined) {
+      throw Error(
+        "[EditSession] datasource returned no response when adding row",
+      );
+    }
+    if (!isRpcError(response)) {
+      this.addCount = this.#addCount + 1;
+    }
+    return response;
   }
 
   addRows(count = 15, rowData: Record<string, VuuRowDataItemType> = {}) {

--- a/vuu-ui/packages/vuu-data-editing/src/InlineAddRow.css
+++ b/vuu-ui/packages/vuu-data-editing/src/InlineAddRow.css
@@ -1,0 +1,58 @@
+.vuuInlineAddRow {
+  --inline-add-row-borderColor: var(--salt-separable-secondary-borderColor);
+  --inline-add-row-content-height: 22px;
+  --inline-add-row-padding: 1px 1px 1px 0;
+
+  display: flex;
+  height: var(--salt-size-base);
+
+  .vuuInlineAddRow-virtualColSpan {
+    display: inline-block;
+    flex: 0 0 auto;
+  }
+
+  .vuuInlineAddRowCell {
+    --saltInput-minHeight: var(--inline-add-row-content-height);
+
+    align-items: center;
+    display: inline-flex;
+    height: 100%;
+    padding: var(--inline-add-row-padding);
+
+    .saltInput-primary.vuuInput {
+      border-color: var(--inline-add-row-borderColor);
+      border-radius: 0;
+      border-style: solid;
+      border-width: 1px;
+      height: var(--inline-add-row-content-height);
+      min-height: var(--inline-add-row-content-height);
+    }
+  }
+
+  .vuuInlineAddRow-errorText {
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .vuuInlineAddRowCell:has(input:focus) {
+    --inline-add-row-borderColor: transparent;
+    --inline-add-row-content-height: 20px;
+    --inline-add-row-padding: 0 2px;
+    --saltInput-paddingLeft: 2px;
+
+    outline-color: var(--salt-focused-outlineColor);
+    outline-offset: -2px;
+    outline-style: dotted;
+    outline-width: 2px;
+  }
+}
+
+.vuuInlineAddRow:focus-within {
+  --inline-add-row-borderColor: var(--salt-separable-primary-borderColor);
+}

--- a/vuu-ui/packages/vuu-data-editing/src/InlineAddRow.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/InlineAddRow.tsx
@@ -1,0 +1,226 @@
+import { useComponentCssInjection } from "@salt-ds/styles";
+import { useWindow } from "@salt-ds/window";
+import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
+import type { BaseRowProps } from "@vuu-ui/vuu-table-types";
+import { VuuInput } from "@vuu-ui/vuu-ui-controls";
+import {
+  getTypedValue,
+  isNotHidden,
+  isRpcError,
+  type CommitHandler,
+} from "@vuu-ui/vuu-utils";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
+import { useEditSession } from "./DataEditingProvider";
+import {
+  getMissingValueErrors,
+  type InlineAddRowErrors,
+  type InlineAddRowValues,
+} from "./inline-add-row-utils";
+
+import inlineAddRowCss from "./InlineAddRow.css";
+
+const classBase = "vuuInlineAddRow";
+
+export interface InlineAddRowProps extends BaseRowProps {}
+
+export const InlineAddRow = ({
+  ariaRowIndex,
+  className,
+  columns,
+  style,
+  virtualColSpan = 0,
+}: InlineAddRowProps) => {
+  const targetWindow = useWindow();
+  useComponentCssInjection({
+    testId: "vuu-inline-add-row",
+    css: inlineAddRowCss,
+    window: targetWindow,
+  });
+
+  const editSession = useEditSession(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const errorIdPrefix = useId();
+  const submittingRef = useRef(false);
+  const [errorMessages, setErrorMessages] = useState<InlineAddRowErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [values, setValues] = useState<InlineAddRowValues>({});
+  const visibleColumns = useMemo(() => columns.filter(isNotHidden), [columns]);
+
+  const focusInput = useCallback((index: number) => {
+    const inputs = containerRef.current?.querySelectorAll("input");
+    inputs?.item(index).focus();
+  }, []);
+
+  const commitRow = useCallback(
+    async (nextValues: InlineAddRowValues, fieldErrors: InlineAddRowErrors) => {
+      const missingErrors = getMissingValueErrors(
+        visibleColumns.map(({ name }) => name),
+        nextValues,
+      );
+      const nextErrors = { ...fieldErrors, ...missingErrors };
+
+      if (Object.keys(nextErrors).length > 0) {
+        setErrorMessages(nextErrors);
+        const firstInvalidIndex = visibleColumns.findIndex(
+          ({ name }) => nextErrors[name] !== undefined,
+        );
+        focusInput(firstInvalidIndex);
+        return;
+      }
+
+      if (submittingRef.current) {
+        return;
+      }
+      submittingRef.current = true;
+      setSubmitting(true);
+
+      try {
+        const response = await editSession.addRow(nextValues);
+        if (isRpcError(response)) {
+          const finalColumn = visibleColumns.at(-1);
+          if (finalColumn) {
+            setErrorMessages({
+              [finalColumn.name]: response.errorMessage,
+            });
+          }
+          return;
+        }
+        setErrorMessages({});
+        setValues({});
+        setValues({});
+      } catch (error) {
+        const finalColumn = visibleColumns.at(-1);
+        if (finalColumn) {
+          setErrorMessages({
+            [finalColumn.name]:
+              error instanceof Error ? error.message : "Unable to add row",
+          });
+        }
+      } finally {
+        submittingRef.current = false;
+        setSubmitting(false);
+      }
+    },
+    [editSession, focusInput, visibleColumns],
+  );
+
+  const handleCommit = useCallback(
+    (columnIndex: number): CommitHandler<HTMLElement> =>
+      (_evt, value) => {
+        const column = visibleColumns[columnIndex];
+        const rawValue = value.toString();
+        if (rawValue.trim() === "") {
+          const nextValues = { ...values, [column.name]: rawValue };
+          setValues(nextValues);
+          if (columnIndex === visibleColumns.length - 1) {
+            void commitRow(nextValues, errorMessages);
+          } else {
+            focusInput(columnIndex + 1);
+          }
+          return;
+        }
+
+        const validation = column.clientSideEditValidationCheck?.(
+          rawValue,
+          "*",
+        );
+
+        if (validation?.ok === false) {
+          setErrorMessages((current) => ({
+            ...current,
+            [column.name]: validation.messages.join("\n"),
+          }));
+          return;
+        }
+
+        let typedValue: VuuRowDataItemType;
+        try {
+          typedValue = getTypedValue(
+            rawValue,
+            column.serverDataType ?? "string",
+            true,
+          );
+        } catch (error) {
+          setErrorMessages((current) => ({
+            ...current,
+            [column.name]:
+              error instanceof Error ? error.message : "Invalid value",
+          }));
+          return;
+        }
+
+        const nextValues = { ...values, [column.name]: typedValue };
+        const nextErrors = { ...errorMessages };
+        delete nextErrors[column.name];
+        setValues(nextValues);
+        setErrorMessages(nextErrors);
+
+        if (columnIndex === visibleColumns.length - 1) {
+          void commitRow(nextValues, nextErrors);
+        } else {
+          focusInput(columnIndex + 1);
+        }
+      },
+    [commitRow, errorMessages, focusInput, values, visibleColumns],
+  );
+
+  return (
+    <div
+      aria-rowindex={ariaRowIndex}
+      className={[classBase, className].filter(Boolean).join(" ")}
+      ref={containerRef}
+      role="row"
+      style={style}
+    >
+      {virtualColSpan > 0 ? (
+        <div
+          aria-hidden
+          className={`${classBase}-virtualColSpan`}
+          style={{ width: virtualColSpan }}
+        />
+      ) : null}
+      {visibleColumns.map((column, index) => {
+        const errorMessage = errorMessages[column.name];
+        const errorId = `${errorIdPrefix}-${column.name}-error`;
+        return (
+          <div
+            aria-colindex={column.ariaColIndex}
+            className={`${classBase}Cell vuuTableCell${
+              column.align === "right" ? " vuuTableCell-right" : ""
+            }`}
+            data-field={column.name}
+            key={column.name}
+            role="cell"
+            style={{ width: column.width }}
+          >
+            <VuuInput
+              className={errorMessage ? "vuuEditing" : undefined}
+              commitOnBlur={false}
+              disabled={submitting}
+              errorMessage={errorMessage}
+              inputProps={{
+                "aria-describedby": errorMessage ? errorId : undefined,
+                "aria-invalid": errorMessage ? true : undefined,
+                "aria-label": column.label,
+                onChange: (evt) =>
+                  setValues((current) => ({
+                    ...current,
+                    [column.name]: evt.target.value,
+                  })),
+                placeholder: "Enter value",
+                value: values[column.name]?.toString() ?? "",
+              }}
+              onCommit={handleCommit(index)}
+              variant="primary"
+            />
+            {errorMessage ? (
+              <span className={`${classBase}-errorText`} id={errorId}>
+                {errorMessage}
+              </span>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -6,6 +6,7 @@ export {
   useEditMode,
   type EditModeContextProps,
 } from "./EditModeProvider";
+export { InlineAddRow, type InlineAddRowProps } from "./InlineAddRow";
 export {
   EditError,
   EditSession,

--- a/vuu-ui/packages/vuu-data-editing/src/inline-add-row-utils.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/inline-add-row-utils.ts
@@ -1,0 +1,19 @@
+import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
+
+export type InlineAddRowValues = Record<string, VuuRowDataItemType>;
+export type InlineAddRowErrors = Record<string, string>;
+
+const requiredMessage = "Value required";
+
+const isMissing = (value: VuuRowDataItemType | undefined) =>
+  value === undefined || (typeof value === "string" && value.trim() === "");
+
+export const getMissingValueErrors = (
+  columnNames: string[],
+  values: InlineAddRowValues,
+): InlineAddRowErrors =>
+  Object.fromEntries(
+    columnNames
+      .filter((name) => isMissing(values[name]))
+      .map((name) => [name, requiredMessage]),
+  );

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EditSession } from "../src";
 
 type Editable = Required<EditApi>;
+type AddRow = Editable["addRow"];
 type BeginEdit = Editable["beginEditSession"];
 type CreateSession = Editable["createSessionDataSource"];
 type EndEdit = Editable["endEditSession"];
@@ -24,7 +25,12 @@ class MockDataSource implements EditApi {
     private endEdit: EndEdit,
     private createSession: CreateSession,
     private edit: EditCell = vi.fn().mockResolvedValue(SUCCESS),
+    private addRowImpl?: AddRow,
   ) {}
+
+  addRow(...args: Parameters<AddRow>) {
+    return this.addRowImpl?.(...args);
+  }
 
   beginEditSession(...args: Parameters<BeginEdit>) {
     return this.beginEdit(...args);
@@ -80,6 +86,47 @@ describe("EditSession lifecycle", () => {
     expect(lifecycleListener.mock.calls.map(([state]) => state.status)).toEqual(
       ["starting", "active", "ending", "idle"],
     );
+  });
+
+  it("adds a populated row and updates the add count after success", async () => {
+    const addRow = vi.fn<AddRow>().mockResolvedValue({
+      data: undefined,
+      type: "SUCCESS_RESULT",
+    });
+    editSession = new EditSession(
+      new MockDataSource(
+        beginEdit,
+        endEdit,
+        createSession,
+        editCell,
+        addRow,
+      ),
+    );
+
+    await editSession.addRow({ id: 7, name: "Alice" });
+
+    expect(addRow).toHaveBeenCalledWith({ id: 7, name: "Alice" });
+    expect(editSession.addCount).toBe(1);
+  });
+
+  it("does not update the add count when adding a row fails", async () => {
+    const addRow = vi.fn<AddRow>().mockResolvedValue({
+      errorMessage: "Insert rejected",
+      type: "ERROR_RESULT",
+    });
+    editSession = new EditSession(
+      new MockDataSource(
+        beginEdit,
+        endEdit,
+        createSession,
+        editCell,
+        addRow,
+      ),
+    );
+
+    await editSession.addRow({ id: 7 });
+
+    expect(editSession.addCount).toBe(0);
   });
 
   it("serializes end behind a pending begin", async () => {

--- a/vuu-ui/packages/vuu-data-editing/test/inline-add-row-utils.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/inline-add-row-utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getMissingValueErrors } from "../src/inline-add-row-utils";
+
+describe("getMissingValueErrors", () => {
+  it("returns an error for every omitted value", () => {
+    expect(
+      getMissingValueErrors(["id", "name", "active"], {
+        active: false,
+        id: " ",
+      }),
+    ).toEqual({
+      id: "Value required",
+      name: "Value required",
+    });
+  });
+
+  it("accepts zero and false as entered values", () => {
+    expect(
+      getMissingValueErrors(["id", "active"], {
+        active: false,
+        id: 0,
+      }),
+    ).toEqual({});
+  });
+});

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -873,16 +873,14 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
 
   async addRow(
     rowData: Record<string, VuuRowDataItemType> = {},
-  ): Promise<true | string> {
-    const response = await this.rpcRequest?.({
+  ): Promise<RpcResult> {
+    const rpcHost = this.#sessionDataSource ?? this;
+    const response = await rpcHost.rpcRequest?.({
       type: "RPC_REQUEST",
       rpcName: "addRow",
       params: { data: rowData },
     });
-    if (isRpcSuccess(response)) {
-      return true;
-    }
-    return response?.errorMessage ?? "addRow failed";
+    return response ?? { type: "ERROR_RESULT", errorMessage: "addRow failed" };
   }
 
   async undoRowChange(key: string): Promise<RpcResultSuccess | RpcResultError> {

--- a/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
@@ -18,26 +18,19 @@ import { Range } from "@vuu-ui/vuu-utils";
 
 type ConfigType = WithBaseFilter<WithFullConfig>;
 
-vi.mock("../src/ConnectionManager", () => ({
-  default: {
-    serverAPI: new Promise<ServerAPI>((resolve) => {
-      // biome-ignore lint/suspicious/noTsIgnore: <Test Mock>
-      // @ts-ignore
-      resolve({
-        send: vi.fn(),
-        subscribe: vi.fn(),
-      });
-    }),
-    serverAPIFor: new Promise<ServerAPI>((resolve) => {
-      // biome-ignore lint/suspicious/noTsIgnore: <Test Mock>
-      // @ts-ignore
-      resolve({
-        send: vi.fn(),
-        subscribe: vi.fn(),
-      });
-    }),
-  },
-}));
+vi.mock("../src/ConnectionManager", () => {
+  const serverAPI = Promise.resolve({
+    send: vi.fn(),
+    subscribe: vi.fn(),
+  } as ServerAPI);
+
+  return {
+    default: {
+      serverAPI,
+      serverAPIFor: vi.fn(() => serverAPI),
+    },
+  };
+});
 
 const defaultSubscribeOptions = {
   aggregations: [],
@@ -120,6 +113,27 @@ describe("VuuDataSource", () => {
       expect(dataSource.columns).toEqual(columns);
       expect(dataSource.filter).toEqual(filterSpec);
       expect(dataSource.sort).toEqual(sort);
+    });
+  });
+
+  describe("addRow", () => {
+    it("returns the successful RPC result", async () => {
+      const dataSource = new VuuDataSource({ table });
+      const response = { data: undefined, type: "SUCCESS_RESULT" } as const;
+      vi.spyOn(dataSource, "rpcRequest").mockResolvedValue(response);
+
+      await expect(dataSource.addRow({ id: 7 })).resolves.toEqual(response);
+    });
+
+    it("returns the failed RPC result", async () => {
+      const dataSource = new VuuDataSource({ table });
+      const response = {
+        errorMessage: "Insert rejected",
+        type: "ERROR_RESULT",
+      } as const;
+      vi.spyOn(dataSource, "rpcRequest").mockResolvedValue(response);
+
+      await expect(dataSource.addRow({ id: 7 })).resolves.toEqual(response);
     });
   });
 


### PR DESCRIPTION
## Summary
- add `InlineAddRow` for use as a table custom header during edit sessions
- validate required cells before submitting a row and preserve accessible errors
- normalize add-row RPC results and update datasource tests

## Validation
- `npm run build -w @vuu-ui/vuu-data-editing -w @vuu-ui/vuu-data-remote -- --no-dts`
- `npx vitest run --config vitest.config.js packages/vuu-data-editing/test/EditSession.lifecycle.test.ts packages/vuu-data-editing/test/inline-add-row-utils.test.ts`
- `npx vitest run --config vitest.config.js packages/vuu-data-remote/test/VuuDataSource.test.ts`