### PR TITLE
Track session table soft deletes

### DIFF
--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -433,8 +433,8 @@ export abstract class VuuModule<T extends string = string>
         if (mode === "soft") {
           sessionTable.update(
             key,
-            this.#sessionTableMessageColumn,
-            "SOFT_DELETED",
+            "setToDelete",
+            true,
           );
         } else {
           sessionTable.delete(key);
@@ -527,6 +527,7 @@ export abstract class VuuModule<T extends string = string>
               sourceRow[sourceTable.map[column.name]];
           }
           sessionTable.updateRow(restoredRow);
+          sessionTable.update(key, "setToDelete", false);
         }
         return { type: "SUCCESS_RESULT", data: undefined };
       }
@@ -753,6 +754,7 @@ export abstract class VuuModule<T extends string = string>
       const columnMap = sessionTable.map;
       const columnCount = Object.keys(columnMap).length;
       const row: VuuDataRow = new Array(columnCount).fill("");
+      row[columnMap.setToDelete] = false;
       for (const [col, idx] of Object.entries(columnMap)) {
         if (data[col] !== undefined) {
           row[idx] = data[col];
@@ -780,13 +782,38 @@ export abstract class VuuModule<T extends string = string>
         const sourceTable = this.tables[dataSource.table.table as T];
 
         if (rpcRequest.params.save === true) {
+          let rejectedCount = 0;
           const vuuMsgIdx = sessionTable.map[this.#sessionTableMessageColumn];
+          const setToDeleteIdx = sessionTable.map.setToDelete;
+          const sessionTimestampIdx = sessionTable.map.vuuUpdatedTimestamp;
+          const sourceTimestampIdx = sourceTable.map.vuuUpdatedTimestamp;
           const sourceColumns = sourceTable.schema.columns;
           for (let i = 0; i < sessionTable.data.length; i++) {
             const sessionRow = sessionTable.data[i];
-            if (sessionRow[vuuMsgIdx]) continue;
             const key = String(sessionRow[sessionTable.map[sourceTable.schema.key]]);
             const currentRow = sourceTable.findByKey(key);
+            if (sessionRow[setToDeleteIdx]) {
+              if (currentRow) {
+                const sessionTimestamp = sessionRow[sessionTimestampIdx];
+                const sourceTimestamp = currentRow[sourceTimestampIdx];
+                if (
+                  typeof sessionTimestamp === "number" &&
+                  typeof sourceTimestamp === "number" &&
+                  sourceTimestamp > sessionTimestamp
+                ) {
+                  rejectedCount += 1;
+                  sessionTable.update(
+                    key,
+                    this.#sessionTableMessageColumn,
+                    "stale delete",
+                  );
+                } else {
+                  sourceTable.delete(key);
+                }
+              }
+              continue;
+            }
+            if (sessionRow[vuuMsgIdx]) continue;
             if (currentRow) {
               for (const column of sourceColumns) {
                 const value = sessionRow[sessionTable.map[column.name]];
@@ -801,6 +828,12 @@ export abstract class VuuModule<T extends string = string>
                 ),
               );
             }
+          }
+          if (rejectedCount > 0) {
+            return {
+              errorMessage: "stale update",
+              type: "ERROR_RESULT",
+            };
           }
           return {
             type: "SUCCESS_RESULT",
@@ -888,7 +921,7 @@ export abstract class VuuModule<T extends string = string>
     const sessionSchema = sessionTableSchema(schema);
     return new Table(
       sessionSchema,
-      data.map((row) => row.slice()),
+      data.map((row) => [...row, "", false]),
       buildDataColumnMapFromSchema(sessionSchema),
     );
   }
@@ -921,7 +954,7 @@ export abstract class VuuModule<T extends string = string>
     for (let i = 0; i < selectedRowIds.length; i++) {
       for (let j = 0; j < data.length; j++) {
         if (data[j][keyIndex] === selectedRowIds[i]) {
-          sessionData.push(data[j].slice());
+          sessionData.push([...data[j], "", false]);
         }
       }
     }

--- a/vuu-ui/packages/vuu-data-test/src/session-table-utils.ts
+++ b/vuu-ui/packages/vuu-data-test/src/session-table-utils.ts
@@ -13,19 +13,23 @@ export const createSessionTableFromSelectedRows = (
   for (let i = 0; i < selectedRowIds.length; i++) {
     for (let j = 0; j < table.data.length; j++) {
       if (table.data[j][KEY] === selectedRowIds[i]) {
-        sessionData.push(table.data[j]);
+        sessionData.push([...table.data[j], "", false]);
       }
     }
   }
 
+  const schema = sessionTableSchema(table.schema);
   return new Table(
-    table.schema,
+    schema,
     sessionData,
-    buildDataColumnMapFromSchema(table.schema),
+    buildDataColumnMapFromSchema(schema),
   );
 };
 
 export const sessionTableSchema = (schema: TableSchema): TableSchema => ({
   ...schema,
-  columns: schema.columns.concat({ name: "vuuMsg", serverDataType: "string" }),
+  columns: schema.columns.concat(
+    { name: "vuuMsg", serverDataType: "string" },
+    { name: "setToDelete", serverDataType: "boolean" },
+  ),
 });

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { buildDataColumnMapFromSchema, Table } from "../src/Table";
 import { TickingArrayDataSource } from "../src/TickingArrayDataSource";
+import { sessionTableSchema } from "../src/session-table-utils";
 import type { TableSchema } from "@vuu-ui/vuu-data-types";
 import type { RpcResultError, RpcResultSuccess } from "@vuu-ui/vuu-protocol-types";
 
@@ -30,6 +31,22 @@ function createDataSource() {
   vi.spyOn(ds, "rpcRequest").mockResolvedValue(SUCCESS);
   return ds;
 }
+
+describe("sessionTableSchema", () => {
+  it("adds setToDelete as a boolean session-only column", () => {
+    const sessionSchema = sessionTableSchema({
+      ...schema,
+      columns: schema.columns.slice(0, 2),
+    });
+
+    expect(sessionSchema.columns).toEqual([
+      { name: "id", serverDataType: "string" },
+      { name: "name", serverDataType: "string" },
+      { name: "vuuMsg", serverDataType: "string" },
+      { name: "setToDelete", serverDataType: "boolean" },
+    ]);
+  });
+});
 
 describe("addRow", () => {
   it("dispatches addRow RPC with a generated key and provided row data", async () => {


### PR DESCRIPTION
## Summary
- add a session-only `setToDelete` boolean column
- mark soft-deleted session rows and apply the deletion when the session is saved
- reject stale deletes when the source row has a newer `vuuUpdatedTimestamp`

## Validation
- `git diff --check`
- UI test dependencies are not installed in this checkout