### PR TITLE
Unify edit session datasources

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/DESIGN.md
+++ b/vuu-ui/packages/vuu-data-editing/DESIGN.md
@@ -12,11 +12,19 @@ migrate to this package.
 
 ## Architecture
 
-`useEditableTable` creates or accepts a data source and owns an `EditSession`.
-The session opens an editable session data source, tracks cell edits and row
-changes, and commits or discards those changes. `DataEditingProvider` makes
-the session available to nested controls, while `EditButtons` reflects session
-state in the available editing actions.
+`useEditableTable` creates or accepts a source data source and owns an
+`EditSession`. The session calls `createSessionDataSource` with a `CopyOption`
+and tracks cell edits and row changes against the returned data source.
+
+The hook exposes `dataSource` as the lifecycle-selected active data source for
+direct use by `Table`, plus `sourceDataSource` for source-only statistics,
+filters, menus, and external workflows. During inline editing, React passes the
+session data source to `Table`; after save or cancel succeeds it passes the
+source data source back. `useDataSource` owns subscription suspend/resume and
+ignores callbacks from obsolete data-source bindings.
+
+`DataEditingProvider` makes the session available to nested controls, while
+`EditButtons` reflects session state in the available editing actions.
 
 ## Files
 
@@ -27,7 +35,7 @@ state in the available editing actions.
 | `src/DataEditingProvider.tsx` | Provides the active `EditSession` through React context.                                                                           |
 | `src/EditModeProvider.tsx`    | Provides shared view/edit mode state for editing controls.                                                                         |
 | `src/EditButtons.tsx`         | Renders save, cancel, delete, and add-row controls based on edit-session state.                                                    |
-| `src/edit-utils.tsx`          | Supplies edit-mode detection and user-facing stale-update messages.                                                                |
+| `src/edit-utils.tsx`          | Supplies user-facing stale-update messages.                                                                                        |
 | `src/index.ts`                | Defines the package's public API.                                                                                                  |
 
 ## Dependencies

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -4,24 +4,18 @@ import type {
   DeleteRowMode,
   DeleteSelectedRowsResult,
   EditApi,
-  EditSessionMode,
   UndoRowChangeResult,
 } from "@vuu-ui/vuu-data-types";
 import type { RpcResult, VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
 import { EventEmitter, isRpcError } from "@vuu-ui/vuu-utils";
-
-export const isCopyOption = (
-  mode?: EditSessionMode | CopyOption,
-): mode is CopyOption =>
-  mode === "All" || mode === "Empty" || mode === "Selected";
 
 export type EditState = "clean" | "dirty" | "invalid" | "stale";
 
 export type EditLifecycle =
   | { status: "idle" }
   | { status: "starting" }
-  | { status: "active"; sessionDataSource?: DataSource }
-  | { status: "ending"; sessionDataSource?: DataSource }
+  | { status: "active"; sessionDataSource: DataSource }
+  | { status: "ending"; sessionDataSource: DataSource }
   | {
       status: "error";
       operation: "begin" | "end";
@@ -183,12 +177,12 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   async addRow(
     rowData: Record<string, VuuRowDataItemType> = {},
   ): Promise<RpcResult> {
-    const addRow = this.#sourceTableDataSource?.addRow;
+    const addRow = this.dataSource?.addRow;
     if (addRow === undefined) {
       throw Error("[EditSession] datasource does not support adding rows");
     }
 
-    const response = await addRow.call(this.#sourceTableDataSource, rowData);
+    const response = await addRow.call(this.dataSource, rowData);
     if (response === undefined) {
       throw Error(
         "[EditSession] datasource returned no response when adding row",
@@ -202,7 +196,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
 
   addRows(count = 15, rowData: Record<string, VuuRowDataItemType> = {}) {
     for (let i = 0; i < count; i++) {
-      this.#sourceTableDataSource?.addRow?.(rowData);
+      this.dataSource?.addRow?.(rowData);
     }
     this.addCount = this.#addCount + count;
   }
@@ -280,32 +274,45 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     return result;
   }
 
-  /** @deprecated Pass a `CopyOption` ("All" | "Empty" | "Selected") to use `createSessionDataSource` instead. Long-form `EditSessionMode` values will be removed in a future release. */
-  begin(mode: EditSessionMode): Promise<DataSource | undefined>;
-  begin(mode?: CopyOption): Promise<DataSource | undefined>;
-  begin(mode?: EditSessionMode | CopyOption): Promise<DataSource | undefined>;
-  begin(mode?: EditSessionMode | CopyOption): Promise<DataSource | undefined> {
+  begin(copyOption: CopyOption = "All"): Promise<DataSource> {
     return this.#enqueue(async () => {
       if (
         this.#lifecycle.status === "active" ||
         (this.#lifecycle.status === "error" &&
           this.#lifecycle.operation === "end")
       ) {
+        const sessionDataSource = this.#sessionDataSource;
+        if (!sessionDataSource) {
+          throw new Error("[EditSession] active lifecycle has no datasource");
+        }
         if (this.#lifecycle.status === "error") {
           this.#setLifecycle({
             status: "active",
-            sessionDataSource: this.#sessionDataSource,
+            sessionDataSource,
           });
         }
-        return this.#sessionDataSource;
+        return sessionDataSource;
       }
 
       this.#setLifecycle({ status: "starting" });
 
       try {
-        const sessionDataSource = isCopyOption(mode)
-          ? await this.#sourceTableDataSource?.createSessionDataSource?.(mode)
-          : await this.#sourceTableDataSource?.beginEditSession?.(mode);
+        const createSessionDataSource =
+          this.#sourceTableDataSource?.createSessionDataSource;
+        if (!createSessionDataSource) {
+          throw new Error(
+            "[EditSession] datasource does not support createSessionDataSource",
+          );
+        }
+        const sessionDataSource = await createSessionDataSource.call(
+          this.#sourceTableDataSource,
+          copyOption,
+        );
+        if (!sessionDataSource) {
+          throw new Error(
+            "[EditSession] datasource did not create a session datasource",
+          );
+        }
 
         this.#sessionDataSource = sessionDataSource;
         this.#setLifecycle({ status: "active", sessionDataSource });
@@ -336,6 +343,9 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
       }
 
       const sessionDataSource = this.#sessionDataSource;
+      if (!sessionDataSource) {
+        throw new Error("[EditSession] ending lifecycle has no datasource");
+      }
       this.#setLifecycle({ status: "ending", sessionDataSource });
 
       try {

--- a/vuu-ui/packages/vuu-data-editing/src/edit-utils.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/edit-utils.tsx
@@ -1,11 +1,5 @@
-import type { EditSessionMode, InlineEditSessionMode } from "@vuu-ui/vuu-data-types";
 import type { DataRow, RuntimeColumnDescriptor } from "@vuu-ui/vuu-table-types";
 import { formatDate } from "@vuu-ui/vuu-utils";
-
-export const isInlineEditingSession = (
-  editSessionMode: EditSessionMode,
-): editSessionMode is InlineEditSessionMode =>
-  editSessionMode.startsWith("inline");
 
 const timeFormatter = formatDate({ time: "hh:mm:ss" });
 

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -1,5 +1,5 @@
 export { DataEditingProvider, useEditSession } from "./DataEditingProvider";
-export { getVuuEditMessage, isInlineEditingSession } from "./edit-utils";
+export { getVuuEditMessage } from "./edit-utils";
 export { EditButtons, type EditButtonProps } from "./EditButtons";
 export {
   EditModeProvider,
@@ -9,7 +9,6 @@ export {
 export {
   EditError,
   EditSession,
-  isCopyOption,
   StaleUpdateError,
   type EditLifecycle,
   type EditState,

--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -3,7 +3,6 @@ import type {
   DataSource,
   DeleteRowMode,
   EditApi,
-  EditSessionMode,
 } from "@vuu-ui/vuu-data-types";
 import type { VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { useLayoutEffectSkipFirst } from "@vuu-ui/vuu-utils";
@@ -22,7 +21,7 @@ export interface EditableTableHookProps {
   dataSource?: DataSource;
   addRowsCount?: number;
   deleteMode?: DeleteRowMode;
-  editSessionMode?: EditSessionMode | CopyOption;
+  copyOption?: CopyOption;
   isEditMode: boolean;
   onCancel: () => void;
   onSave: () => void;
@@ -38,7 +37,7 @@ export const useEditableTable = ({
   columns,
   dataSource: dataSourceProp,
   deleteMode = "soft",
-  editSessionMode = "inline-all-rows" as EditSessionMode | CopyOption,
+  copyOption = "All",
   isEditMode,
   onCancel,
   onSave,
@@ -51,7 +50,7 @@ export const useEditableTable = ({
     console.warn("[useEditableTable] columns and or table changed");
   }, [columns, table]);
 
-  const dataSource = useMemo(() => {
+  const sourceDataSource = useMemo(() => {
     if (dataSourceProp) {
       return dataSourceProp;
     } else if (table) {
@@ -66,8 +65,8 @@ export const useEditableTable = ({
   // The editSession will be made available to all the edit controls in scope
   // by wrapping the edit component with a DataEditingProvider.
   const editSession = useMemo(
-    () => new EditSession(dataSource as EditApi, deleteMode),
-    [dataSource, deleteMode],
+    () => new EditSession(sourceDataSource as EditApi, deleteMode),
+    [deleteMode, sourceDataSource],
   );
   const [lifecycle, setLifecycle] = useState<EditLifecycle>(
     editSession.lifecycle,
@@ -78,6 +77,7 @@ export const useEditableTable = ({
 
   const sessionDataSource =
     "sessionDataSource" in lifecycle ? lifecycle.sessionDataSource : undefined;
+  const dataSource = sessionDataSource ?? sourceDataSource;
 
   const handleCancel = useCallback(async () => {
     try {
@@ -91,7 +91,6 @@ export const useEditableTable = ({
 
   const handleSave = useCallback(
     async (force = false) => {
-      dataSource.resume?.();
       try {
         await editSession.end(true, force);
         setSelectionCount(0);
@@ -100,7 +99,7 @@ export const useEditableTable = ({
         console.error("[useEditableTable] save edit session failed", error);
       }
     },
-    [dataSource, editSession, onSave],
+    [editSession, onSave],
   );
 
   const handleDelete = useCallback(async () => {
@@ -118,11 +117,9 @@ export const useEditableTable = ({
   );
 
   useEffect(() => {
-    const activeDataSource = sessionDataSource ?? dataSource;
-    activeDataSource.on("row-selection", setSelectionCount);
-    return () =>
-      activeDataSource.removeListener("row-selection", setSelectionCount);
-  }, [dataSource, sessionDataSource]);
+    dataSource.on("row-selection", setSelectionCount);
+    return () => dataSource.removeListener("row-selection", setSelectionCount);
+  }, [dataSource]);
 
   useEffect(() => {
     const handleEditState = (nextEditState: EditState) => {
@@ -145,7 +142,7 @@ export const useEditableTable = ({
 
   useEffect(() => {
     const transition = isEditMode
-      ? editSession.begin(editSessionMode)
+      ? editSession.begin(copyOption)
       : editSession.end();
 
     void transition.catch((error) => {
@@ -156,7 +153,7 @@ export const useEditableTable = ({
         console.error("[useEditableTable] end edit session failed", error);
       }
     });
-  }, [editSession, editSessionMode, isEditMode]);
+  }, [copyOption, editSession, isEditMode]);
 
   const canCancel =
     lifecycle.status === "active" ||
@@ -180,5 +177,6 @@ export const useEditableTable = ({
     onSave: handleSave,
     onUndoRowChange: handleUndoRowChange,
     sessionDataSource,
+    sourceDataSource,
   };
 };

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -1,4 +1,4 @@
-import type { EditApi } from "@vuu-ui/vuu-data-types";
+import type { DataSource, EditApi } from "@vuu-ui/vuu-data-types";
 import type {
   RpcResultError,
   RpcResultSuccess,
@@ -8,7 +8,6 @@ import { EditSession } from "../src";
 
 type Editable = Required<EditApi>;
 type AddRow = Editable["addRow"];
-type BeginEdit = Editable["beginEditSession"];
 type CreateSession = Editable["createSessionDataSource"];
 type EndEdit = Editable["endEditSession"];
 type EditCell = Editable["editCell"];
@@ -21,7 +20,6 @@ const ERROR: RpcResultError = {
 
 class MockDataSource implements EditApi {
   constructor(
-    private beginEdit: BeginEdit,
     private endEdit: EndEdit,
     private createSession: CreateSession,
     private edit: EditCell = vi.fn().mockResolvedValue(SUCCESS),
@@ -30,10 +28,6 @@ class MockDataSource implements EditApi {
 
   addRow(...args: Parameters<AddRow>) {
     return this.addRowImpl?.(...args);
-  }
-
-  beginEditSession(...args: Parameters<BeginEdit>) {
-    return this.beginEdit(...args);
   }
 
   endEditSession(...args: Parameters<EndEdit>) {
@@ -60,20 +54,20 @@ const deferred = <T>() => {
 };
 
 describe("EditSession lifecycle", () => {
-  let beginEdit: BeginEdit;
   let createSession: CreateSession;
   let editSession: EditSession;
   let editCell: EditCell;
   let endEdit: EndEdit;
 
   beforeEach(() => {
-    beginEdit = vi.fn();
-    createSession = vi.fn();
     endEdit = vi.fn();
     editCell = vi.fn().mockResolvedValue(SUCCESS);
-    editSession = new EditSession(
-      new MockDataSource(beginEdit, endEdit, createSession, editCell),
-    );
+    let dataSource: MockDataSource;
+    createSession = vi.fn(
+      async () => dataSource as unknown as DataSource,
+    ) as CreateSession;
+    dataSource = new MockDataSource(endEdit, createSession, editCell);
+    editSession = new EditSession(dataSource);
   });
 
   it("publishes lifecycle transitions", async () => {
@@ -94,13 +88,7 @@ describe("EditSession lifecycle", () => {
       type: "SUCCESS_RESULT",
     });
     editSession = new EditSession(
-      new MockDataSource(
-        beginEdit,
-        endEdit,
-        createSession,
-        editCell,
-        addRow,
-      ),
+      new MockDataSource(endEdit, createSession, editCell, addRow),
     );
 
     await editSession.addRow({ id: 7, name: "Alice" });
@@ -115,13 +103,7 @@ describe("EditSession lifecycle", () => {
       type: "ERROR_RESULT",
     });
     editSession = new EditSession(
-      new MockDataSource(
-        beginEdit,
-        endEdit,
-        createSession,
-        editCell,
-        addRow,
-      ),
+      new MockDataSource(endEdit, createSession, editCell, addRow),
     );
 
     await editSession.addRow({ id: 7 });
@@ -130,11 +112,10 @@ describe("EditSession lifecycle", () => {
   });
 
   it("serializes end behind a pending begin", async () => {
-    const pendingBegin = deferred<undefined>();
-    beginEdit = vi.fn(() => pendingBegin.promise);
-    editSession = new EditSession(
-      new MockDataSource(beginEdit, endEdit, createSession),
-    );
+    const pendingBegin = deferred<DataSource | undefined>();
+    createSession = vi.fn(() => pendingBegin.promise);
+    const dataSource = new MockDataSource(endEdit, createSession);
+    editSession = new EditSession(dataSource);
 
     const beginPromise = editSession.begin();
     await Promise.resolve();
@@ -143,11 +124,11 @@ describe("EditSession lifecycle", () => {
     const endPromise = editSession.end();
     expect(endEdit).not.toHaveBeenCalled();
 
-    pendingBegin.resolve(undefined);
+    pendingBegin.resolve(dataSource as unknown as DataSource);
     await beginPromise;
     await endPromise;
 
-    expect(beginEdit).toHaveBeenCalledTimes(1);
+    expect(createSession).toHaveBeenCalledTimes(1);
     expect(endEdit).toHaveBeenCalledTimes(1);
     expect(editSession.lifecycle).toEqual({ status: "idle" });
   });
@@ -155,23 +136,23 @@ describe("EditSession lifecycle", () => {
   it("does not begin a second session when begin is queued twice", async () => {
     await Promise.all([editSession.begin(), editSession.begin()]);
 
-    expect(beginEdit).toHaveBeenCalledTimes(1);
+    expect(createSession).toHaveBeenCalledTimes(1);
     expect(editSession.lifecycle.status).toBe("active");
   });
 
-  it("routes standalone and inline sessions to the appropriate datasource API", async () => {
-    await editSession.begin("All");
-
+  it("forwards copy options and defaults to All", async () => {
+    await editSession.begin();
     expect(createSession).toHaveBeenCalledWith("All");
-    expect(beginEdit).not.toHaveBeenCalled();
 
     await editSession.end();
-    editSession = new EditSession(
-      new MockDataSource(beginEdit, endEdit, createSession),
-    );
-    await editSession.begin("inline-all-rows");
-
-    expect(beginEdit).toHaveBeenCalledWith("inline-all-rows");
+    let selectedDataSource: MockDataSource;
+    createSession = vi.fn(
+      async () => selectedDataSource as unknown as DataSource,
+    ) as CreateSession;
+    selectedDataSource = new MockDataSource(endEdit, createSession);
+    editSession = new EditSession(selectedDataSource);
+    await editSession.begin("Selected");
+    expect(createSession).toHaveBeenCalledWith("Selected");
   });
 
   it("keeps a failed end session active and allows retry", async () => {
@@ -180,9 +161,12 @@ describe("EditSession lifecycle", () => {
       .fn()
       .mockRejectedValueOnce(endError)
       .mockResolvedValueOnce(undefined);
-    editSession = new EditSession(
-      new MockDataSource(beginEdit, endEdit, createSession),
-    );
+    let dataSource: MockDataSource;
+    createSession = vi.fn(
+      async () => dataSource as unknown as DataSource,
+    ) as CreateSession;
+    dataSource = new MockDataSource(endEdit, createSession);
+    editSession = new EditSession(dataSource);
 
     await editSession.begin();
     await expect(editSession.end()).rejects.toBe(endError);
@@ -198,12 +182,68 @@ describe("EditSession lifecycle", () => {
     expect(editSession.lifecycle).toEqual({ status: "idle" });
   });
 
+  it("runs edits and end operations on the created session datasource", async () => {
+    const sessionEnd = vi.fn<EndEdit>().mockResolvedValue(undefined);
+    const sessionEdit = vi.fn<EditCell>().mockResolvedValue(SUCCESS);
+    const unusedCreate = vi.fn<CreateSession>();
+    const sessionDataSource = new MockDataSource(
+      sessionEnd,
+      unusedCreate,
+      sessionEdit,
+    );
+    const sourceEnd = vi.fn<EndEdit>();
+    const sourceEdit = vi.fn<EditCell>();
+    const sourceCreate = vi
+      .fn<CreateSession>()
+      .mockResolvedValue(sessionDataSource as unknown as DataSource);
+    const sourceDataSource = new MockDataSource(
+      sourceEnd,
+      sourceCreate,
+      sourceEdit,
+    );
+    editSession = new EditSession(sourceDataSource);
+
+    await editSession.begin();
+    await editSession.commit("row-1", "price", 100, 101, true);
+    await editSession.end(true);
+
+    expect(sessionEdit).toHaveBeenCalledWith("row-1", "price", 101);
+    expect(sessionEnd).toHaveBeenCalledWith(true, false);
+    expect(sourceEdit).not.toHaveBeenCalled();
+    expect(sourceEnd).not.toHaveBeenCalled();
+    expect(editSession.dataSource).toBe(sourceDataSource);
+  });
+
+  it("keeps the session datasource selected after an end failure", async () => {
+    const endError = new Error("end failed");
+    const sessionEnd = vi.fn<EndEdit>().mockRejectedValue(endError);
+    const sessionDataSource = new MockDataSource(
+      sessionEnd,
+      vi.fn<CreateSession>(),
+    );
+    const sourceDataSource = new MockDataSource(
+      vi.fn<EndEdit>(),
+      vi
+        .fn<CreateSession>()
+        .mockResolvedValue(sessionDataSource as unknown as DataSource),
+    );
+    editSession = new EditSession(sourceDataSource);
+
+    await editSession.begin();
+    await expect(editSession.end(true)).rejects.toBe(endError);
+
+    expect(editSession.dataSource).toBe(sessionDataSource);
+    expect(editSession.lifecycle).toMatchObject({
+      operation: "end",
+      sessionDataSource,
+      status: "error",
+    });
+  });
+
   it("reports begin failures without entering edit mode", async () => {
     const beginError = new Error("begin failed");
-    beginEdit = vi.fn().mockRejectedValueOnce(beginError);
-    editSession = new EditSession(
-      new MockDataSource(beginEdit, endEdit, createSession),
-    );
+    createSession = vi.fn().mockRejectedValueOnce(beginError);
+    editSession = new EditSession(new MockDataSource(endEdit, createSession));
 
     await expect(editSession.begin()).rejects.toBe(beginError);
 
@@ -259,9 +299,12 @@ describe("EditSession lifecycle", () => {
       .mockResolvedValueOnce(SUCCESS)
       .mockResolvedValueOnce(ERROR)
       .mockResolvedValueOnce(SUCCESS);
-    editSession = new EditSession(
-      new MockDataSource(beginEdit, endEdit, createSession, editCell),
-    );
+    let dataSource: MockDataSource;
+    createSession = vi.fn(
+      async () => dataSource as unknown as DataSource,
+    ) as CreateSession;
+    dataSource = new MockDataSource(endEdit, createSession, editCell);
+    editSession = new EditSession(dataSource);
     await editSession.begin();
 
     await editSession.commit("row-1", "price", 100, 101, true);

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
@@ -1,21 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { EditApi } from "@vuu-ui/vuu-data-types";
+import type { DataSource, EditApi } from "@vuu-ui/vuu-data-types";
 import { EditSession } from "../src";
 
 type Editable = Required<EditApi>;
-type BeginEdit = Editable["beginEditSession"];
+type CreateSession = Editable["createSessionDataSource"];
 type EndEdit = Editable["endEditSession"];
 type EditCell = Editable["editCell"];
 
 export class MockDataSource implements EditApi {
   constructor(
-    private beginEdit: BeginEdit,
+    private createSession: CreateSession,
     private endEdit: EndEdit,
     private edit: EditCell,
   ) {}
 
-  beginEditSession(...args: Parameters<BeginEdit>) {
-    return this.beginEdit(...args);
+  createSessionDataSource(...args: Parameters<CreateSession>) {
+    return this.createSession(...args);
   }
 
   endEditSession(...args: Parameters<EndEdit>) {
@@ -29,15 +29,18 @@ export class MockDataSource implements EditApi {
 
 describe("EditSession", () => {
   let editSession: EditSession;
-  let beginEdit: BeginEdit;
+  let createSession: CreateSession;
   let endEdit: EndEdit;
   let edit: EditCell;
 
   beforeEach(() => {
-    beginEdit = vi.fn();
     endEdit = vi.fn();
     edit = vi.fn();
-    const editApi = new MockDataSource(beginEdit, endEdit, edit);
+    let editApi: MockDataSource;
+    createSession = vi.fn(
+      async () => editApi as unknown as DataSource,
+    ) as CreateSession;
+    editApi = new MockDataSource(createSession, endEdit, edit);
     editSession = new EditSession(editApi);
   });
 

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -1,7 +1,6 @@
-import { isInlineEditingSession, StaleUpdateError } from '@vuu-ui/vuu-data-editing';
+import { StaleUpdateError } from "@vuu-ui/vuu-data-editing";
 import type {
   CopyOption,
-  DataSource,
   DataSourceBase,
   DataSourceCallbackMessage,
   DataSourceConstructorProps,
@@ -10,7 +9,6 @@ import type {
   DataSourceSubscribeProps,
   DataSourceVisualLinkCreatedMessage,
   DeleteRowMode,
-  EditSessionMode,
   OptimizeStrategy,
   ServerAPI,
   TableSchema,
@@ -20,6 +18,7 @@ import type {
 import type { MenuRpcResponse } from "@vuu-ui/vuu-data-types";
 import type {
   LinkDescriptorWithLabel,
+  RpcResult,
   RpcResultError,
   RpcResultSuccess,
   SelectRequest,
@@ -101,7 +100,6 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   #menu: VuuMenu | undefined;
   #optimize: OptimizeStrategy = "throttle";
   #selectedRowsCount = 0;
-  #sessionDataSource: DataSource | undefined = undefined;
   #sessionTableMessageColumn: string | undefined = undefined;
   #status: DataSourceStatus = "initialising";
   #tableSchema: TableSchema | undefined;
@@ -144,8 +142,11 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   ) {
     // super.subscribe(subscribeProps, this.handleMessageFromServer);
     super.subscribe(subscribeProps, callback);
-    const { viewport = this.viewport || (this.viewport = uuid()) } =
-      subscribeProps;
+    let viewport = subscribeProps.viewport ?? this.viewport;
+    if (!viewport) {
+      viewport = uuid();
+      this.viewport = viewport;
+    }
 
     if (
       this.#status === "disabled" ||
@@ -220,19 +221,6 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
           this.size = message.size;
           this.emit("resize", message.size, this.#maxRangeEnd);
         }
-
-        if (
-          Array.isArray(message.rows) &&
-          message.rows.length > 0 &&
-          this.#sessionDataSource
-        ) {
-          this.emit("remote-update-during-local-edit", message.rows);
-          console.log(
-            `updates incoming whilst edit in progress ${this.viewport}`,
-          );
-          console.table(message.rows);
-          return;
-        }
       } else if (message.type === "viewport-clear") {
         this.size = 0;
         this.emit("resize", 0);
@@ -261,18 +249,6 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
       if (this.optimize === "debounce") {
         this.revertDebounce();
       }
-    }
-  };
-
-  handleSessionMessageFromServer = (msg: DataSourceCallbackMessage) => {
-    if (msg.type === "subscribed") {
-      console.log(`[VuuDataSource subscribed to session table]`);
-    } else if (msg.type === "viewport-update") {
-      if (msg.size !== undefined && msg.size !== this.size) {
-        this.size = msg.size;
-        this.emit("resize", msg.size);
-      }
-      this._clientCallback?.(msg);
     }
   };
 
@@ -407,7 +383,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
         this.#selectedRowsCount = response.selectedRowCount;
         this.emit("row-selection", response.selectedRowCount);
       } else {
-        console.warn(`select error`);
+        console.warn("select error");
       }
     }
   }
@@ -616,9 +592,6 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
 
   set range(range: Range) {
     super.range = range;
-    if (this.#sessionDataSource) {
-      this.#sessionDataSource.range = range;
-    }
   }
 
   get title() {
@@ -697,9 +670,17 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
+      const sessionColumns = combineColumnsWithAutosubscribeColumns(
+        this.columns,
+        [this.#sessionTableMessageColumn, "setToDelete"].filter(
+          (column): column is string => column !== undefined,
+        ),
+      );
       return new VuuDataSource({
         ...this.config,
+        columns: sessionColumns,
         connectionId: this.#connectionId,
+        sessionTableMessageColumn: this.#sessionTableMessageColumn,
         table: sessionTable,
         viewport: sessionTable.table,
       });
@@ -710,59 +691,8 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     }
   }
 
-  async beginEditSession(editSessionMode: EditSessionMode = "all-rows") {
-    const rpcResponse = await this?.rpcRequest?.({
-      type: "RPC_REQUEST",
-      rpcName: "beginEditSession",
-      params: {
-        editSessionMode,
-      },
-    });
-
-    if (isRpcSuccess(rpcResponse)) {
-      const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
-
-      if (isInlineEditingSession(editSessionMode)) {
-        const columns = this.#sessionTableMessageColumn
-          ? this.columns.concat(this.#sessionTableMessageColumn)
-          : this.columns;
-        this.#sessionDataSource = new VuuDataSource({
-          ...this.config,
-          columns,
-          connectionId: this.#connectionId,
-          table: sessionTable,
-          viewport: sessionTable.table,
-        });
-
-        this.#sessionDataSource.subscribe(
-          {
-            range: this.range,
-          },
-          this.handleSessionMessageFromServer,
-        );
-      } else {
-        return new VuuDataSource({
-          ...this.config,
-          connectionId: this.#connectionId,
-          table: sessionTable,
-          viewport: sessionTable.table,
-        });
-      }
-
-      // we need to route messages from the session datasource to listening
-      // client whilst still monitoring responses on the source table to which
-      // we are currently subscribed.
-    } else {
-      throw Error(
-        `[VuuDataSource] beginEditSession ${rpcResponse.errorMessage}`,
-      );
-      ///
-    }
-  }
-
   async editCell(key: string, column: string, data: VuuRowDataItemType) {
-    const rpcHost = this.#sessionDataSource ?? this;
-    return rpcHost.rpcRequest?.({
+    return this.rpcRequest({
       type: "RPC_REQUEST",
       rpcName: "editCell",
       params: {
@@ -776,36 +706,21 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   async endEditSession(saveChanges = false, force = false) {
     const type = "RPC_REQUEST";
     const rpcName = "endEditSession";
-    const sessionDataSource = this.#sessionDataSource;
-    const rpcHost = sessionDataSource ?? this;
-
-    if (sessionDataSource) {
-      // timing is important here. By breaking this reference before
-      // we send the endEdit RPC call, the application of session edits
-      // to the source table will be handled correctly.
-      this.#sessionDataSource = undefined;
-    }
-
-    const rpcResponse = await rpcHost.rpcRequest?.(
+    const rpcResponse = await this.rpcRequest(
       saveChanges
         ? { type, rpcName, params: { save: true, force } }
         : { type, rpcName, params: {} },
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      if (sessionDataSource) {
-        sessionDataSource?.unsubscribe();
-      }
+      this.sendResumeMessage();
     } else {
       if (rpcResponse?.errorMessage === "stale update") {
-        this.#sessionDataSource = sessionDataSource;
         throw new StaleUpdateError(rpcResponse.errorMessage);
       } else {
-        throw Error("unknown error");
+        throw Error(rpcResponse?.errorMessage ?? "endEditSession failed");
       }
     }
-
-    this.sendResumeMessage();
   }
 
   async rpcRequest(rpcRequest: Omit<VuuRpcServiceRequest, "context">) {
@@ -815,7 +730,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
         context: { type: "VIEWPORT_CONTEXT", viewPortId: this.viewport },
       } as VuuRpcServiceRequest);
     } else {
-      throw Error(`rpcCall server or viewport are undefined`);
+      throw Error("rpcCall server or viewport are undefined");
     }
   }
 
@@ -842,8 +757,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     key: string,
     mode: DeleteRowMode = "hard",
   ): Promise<true | string> {
-    const rpcHost = this.#sessionDataSource ?? this;
-    const response = await rpcHost.rpcRequest?.({
+    const response = await this.rpcRequest({
       type: "RPC_REQUEST",
       rpcName: "deleteRow",
       params: { key, mode },
@@ -857,8 +771,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   async deleteSelectedRows(
     mode: DeleteRowMode = "soft",
   ): Promise<RpcResultSuccess | RpcResultError> {
-    const rpcHost = this.#sessionDataSource ?? this;
-    const response = await rpcHost.rpcRequest?.({
+    const response = await this.rpcRequest({
       type: "RPC_REQUEST",
       rpcName: "deleteSelectedRows",
       params: { mode },
@@ -874,8 +787,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   async addRow(
     rowData: Record<string, VuuRowDataItemType> = {},
   ): Promise<RpcResult> {
-    const rpcHost = this.#sessionDataSource ?? this;
-    const response = await rpcHost.rpcRequest?.({
+    const response = await this.rpcRequest({
       type: "RPC_REQUEST",
       rpcName: "addRow",
       params: { data: rowData },
@@ -884,8 +796,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   }
 
   async undoRowChange(key: string): Promise<RpcResultSuccess | RpcResultError> {
-    const rpcHost = this.#sessionDataSource ?? this;
-    const response = await rpcHost.rpcRequest?.({
+    const response = await this.rpcRequest({
       type: "RPC_REQUEST",
       rpcName: "undoRowChange",
       params: { key },

--- a/vuu-ui/packages/vuu-data-remote/src/inlined-worker.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/inlined-worker.ts
@@ -132,45 +132,6 @@ var EventEmitter = class {
 };
 _events = new WeakMap();
 
-// ../vuu-utils/src/protocol-message-utils.ts
-var MENU_RPC_TYPES = [
-  "VIEW_PORT_MENUS_SELECT_RPC",
-  "VIEW_PORT_MENU_TABLE_RPC",
-  "VIEW_PORT_MENU_ROW_RPC",
-  "VIEW_PORT_MENU_CELL_RPC"
-];
-var INVALID_SESSION = "Invalid session";
-var SESSION_LIMIT_EXCEEDED = "User session limit exceeded";
-var INVALID_TOKEN = "Invalid token";
-var TOKEN_EXPIRED = "Token has expired";
-var InvalidLoginMessages = [
-  INVALID_SESSION,
-  SESSION_LIMIT_EXCEEDED,
-  INVALID_TOKEN,
-  TOKEN_EXPIRED
-];
-var isErrorMessage = (message) => typeof message == "object" && (message == null ? void 0 : message.type) === "ERROR";
-var isLoginErrorMessage = (message) => typeof message === "string" && InvalidLoginMessages.includes(message);
-var isSelectRequest = (message) => message && typeof message === "object" && "type" in message && (message.type === "SELECT_ROW" || message.type === "DESELECT_ROW" || message.type === "SELECT_ROW_RANGE" || message.type === "SELECT_ALL" || message.type === "DESELECT_ALL");
-var isRpcServiceRequest = (message) => message.type === "RPC_REQUEST";
-var hasViewPortContext = (message) => message.context.type === "VIEWPORT_CONTEXT";
-var isVuuMenuRpcRequest = (message) => MENU_RPC_TYPES.includes(message["type"]);
-var isOpenDialogAction = (action) => action !== void 0 && action.type === "OPEN_DIALOG_ACTION";
-var isCreateVpSuccess = (response) => response.type === "CREATE_VP_SUCCESS";
-var isSessionTable = (table) => {
-  if (table !== null && typeof table === "object" && "table" in table && "module" in table) {
-    return table.table.startsWith("session");
-  }
-  return false;
-};
-function isActionMessage(rpcResponse) {
-  return rpcResponse.type === "VIEW_PORT_MENU_RESP";
-}
-function isSessionTableActionMessage(rpcResponse) {
-  var _a, _b;
-  return isActionMessage(rpcResponse) && isOpenDialogAction(rpcResponse.action) && isSessionTable(rpcResponse.action.table) && (((_a = rpcResponse.action) == null ? void 0 : _a.renderComponent) === "inline-form" || ((_b = rpcResponse.action) == null ? void 0 : _b.renderComponent) === "grid");
-}
-
 // ../vuu-utils/src/datasource/datasource-utils.ts
 var isConnectionQualityMetrics = (msg) => msg.type === "connection-metrics";
 var isVisualLinkMessage = (msg) => msg.type.endsWith("_VISUAL_LINK");
@@ -344,6 +305,45 @@ var RangeMonitor = class {
     }
   }
 };
+
+// ../vuu-utils/src/protocol-message-utils.ts
+var MENU_RPC_TYPES = [
+  "VIEW_PORT_MENUS_SELECT_RPC",
+  "VIEW_PORT_MENU_TABLE_RPC",
+  "VIEW_PORT_MENU_ROW_RPC",
+  "VIEW_PORT_MENU_CELL_RPC"
+];
+var INVALID_SESSION = "Invalid session";
+var SESSION_LIMIT_EXCEEDED = "User session limit exceeded";
+var INVALID_TOKEN = "Invalid token";
+var TOKEN_EXPIRED = "Token has expired";
+var InvalidLoginMessages = [
+  INVALID_SESSION,
+  SESSION_LIMIT_EXCEEDED,
+  INVALID_TOKEN,
+  TOKEN_EXPIRED
+];
+var isErrorMessage = (message) => typeof message == "object" && (message == null ? void 0 : message.type) === "ERROR";
+var isLoginErrorMessage = (message) => typeof message === "string" && InvalidLoginMessages.includes(message);
+var isSelectRequest = (message) => message && typeof message === "object" && "type" in message && (message.type === "SELECT_ROW" || message.type === "DESELECT_ROW" || message.type === "SELECT_ROW_RANGE" || message.type === "SELECT_ALL" || message.type === "DESELECT_ALL");
+var isRpcServiceRequest = (message) => message.type === "RPC_REQUEST";
+var hasViewPortContext = (message) => message.context.type === "VIEWPORT_CONTEXT";
+var isVuuMenuRpcRequest = (message) => MENU_RPC_TYPES.includes(message["type"]);
+var isOpenDialogAction = (action) => action !== void 0 && action.type === "OPEN_DIALOG_ACTION";
+var isCreateVpSuccess = (response) => response.type === "CREATE_VP_SUCCESS";
+var isSessionTable = (table) => {
+  if (table !== null && typeof table === "object" && "table" in table && "module" in table) {
+    return table.table.startsWith("session");
+  }
+  return false;
+};
+function isActionMessage(rpcResponse) {
+  return rpcResponse.type === "VIEW_PORT_MENU_RESP";
+}
+function isSessionTableActionMessage(rpcResponse) {
+  var _a, _b;
+  return isActionMessage(rpcResponse) && isOpenDialogAction(rpcResponse.action) && isSessionTable(rpcResponse.action.table) && (((_a = rpcResponse.action) == null ? void 0 : _a.renderComponent) === "inline-form" || ((_b = rpcResponse.action) == null ? void 0 : _b.renderComponent) === "grid");
+}
 
 // ../vuu-utils/src/keyset.ts
 var EMPTY = [];

--- a/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
@@ -125,6 +125,51 @@ describe("VuuDataSource", () => {
       await expect(dataSource.addRow({ id: 7 })).resolves.toEqual(response);
     });
 
+    describe("createSessionDataSource", () => {
+      it("forwards CopyOption and adds required session columns once", async () => {
+        const dataSource = new VuuDataSource({
+          columns: ["id", "vuuMsg"],
+          sessionTableMessageColumn: "vuuMsg",
+          table,
+        });
+        const rpcRequest = vi
+          .spyOn(dataSource, "rpcRequest")
+          .mockResolvedValue({
+            data: {
+              table: { module: "SIMUL", table: "session-instruments" },
+            },
+            type: "SUCCESS_RESULT",
+          });
+
+        const sessionDataSource =
+          await dataSource.createSessionDataSource("Selected");
+
+        expect(rpcRequest).toHaveBeenCalledWith({
+          params: { copyOption: "Selected" },
+          rpcName: "createSessionTable",
+          type: "RPC_REQUEST",
+        });
+        expect(sessionDataSource?.columns).toEqual([
+          "id",
+          "vuuMsg",
+          "setToDelete",
+        ]);
+        expect(sessionDataSource?.viewport).toBe("session-instruments");
+      });
+
+      it("propagates session creation errors", async () => {
+        const dataSource = new VuuDataSource({ table });
+        vi.spyOn(dataSource, "rpcRequest").mockResolvedValue({
+          errorMessage: "session creation failed",
+          type: "ERROR_RESULT",
+        });
+
+        await expect(dataSource.createSessionDataSource("All")).rejects.toThrow(
+          "session creation failed",
+        );
+      });
+    });
+
     it("returns the failed RPC result", async () => {
       const dataSource = new VuuDataSource({ table });
       const response = {

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -1,23 +1,20 @@
 import {
   ArrayDataSource,
-  ArrayDataSourceConstructorProps,
+  type ArrayDataSourceConstructorProps,
 } from "@vuu-ui/vuu-data-local";
 import type {
   DataSourceBase,
-  DataSourceCallbackMessage,
   DataSourceRowWithBigint,
   DataSourceSubscribeCallback,
   DataSourceSubscribeProps,
   DataSourceVisualLinkCreatedMessage,
   DeleteRowMode,
-  EditSessionMode,
   CopyOption,
 } from "@vuu-ui/vuu-data-types";
 import type {
   LinkDescriptorWithLabel,
   RpcResultError,
   RpcResultSuccess,
-  SelectRequest,
   VuuCreateVisualLink,
   VuuMenu,
   VuuRemoveVisualLink,
@@ -27,21 +24,15 @@ import type {
   VuuRpcServiceRequest,
   VuuTable,
 } from "@vuu-ui/vuu-protocol-types";
-import { isInlineEditingSession } from "@vuu-ui/vuu-data-editing";
-import {
-  isRpcSuccess,
-  isTypeaheadRequest,
-  Range,
-  uuid,
-} from "@vuu-ui/vuu-utils";
-import {
+import { StaleUpdateError } from "@vuu-ui/vuu-data-editing";
+import { isRpcSuccess, isTypeaheadRequest, uuid } from "@vuu-ui/vuu-utils";
+import type {
   IVuuModule,
   RpcMenuService,
   RpcService,
-  SessionTableMap,
 } from "./core/module/VuuModule";
 import { makeSuggestions } from "./makeSuggestions";
-import { Table } from "./Table";
+import type { Table } from "./Table";
 
 export type VisualLinkHandler = (
   message: VuuCreateVisualLink | VuuRemoveVisualLink,
@@ -54,7 +45,6 @@ export interface TickingArrayDataSourceConstructorProps
   menu?: VuuMenu;
   rpcMenuServices?: RpcMenuService[];
   rpcServices?: RpcService[];
-  sessionTables?: SessionTableMap;
   table?: Table;
   visualLinkService?: VisualLinkHandler;
   vuuModule?: IVuuModule;
@@ -71,10 +61,6 @@ export class TickingArrayDataSource extends ArrayDataSource {
   #pendingVisualLink?: LinkDescriptorWithLabel;
   #rpcMenuServices: RpcMenuService[] | undefined;
   #rpcServices: RpcService[] | undefined;
-  // A reference to session tables hosted within client side module
-  #sessionTables: SessionTableMap | undefined;
-  #sessionDataSource: DataSourceBase<DataSourceRowWithBigint> | undefined =
-    undefined;
   #table?: Table;
   #selectionLinkSubscribers: Map<string, LinkSubscription> | undefined;
   #visualLinkService?: VisualLinkHandler;
@@ -88,7 +74,6 @@ export class TickingArrayDataSource extends ArrayDataSource {
     getVisualLinks,
     rpcServices,
     rpcMenuServices,
-    sessionTables,
     table,
     menu,
     visualLink,
@@ -109,7 +94,6 @@ export class TickingArrayDataSource extends ArrayDataSource {
     this.#rpcMenuServices = rpcMenuServices;
     this.#pendingVisualLink = visualLink;
     this.#rpcServices = rpcServices;
-    this.#sessionTables = sessionTables;
     this.#table = table;
     this.#visualLinkService = visualLinkService;
     this.#getVisualLinks = getVisualLinks;
@@ -135,9 +119,6 @@ export class TickingArrayDataSource extends ArrayDataSource {
     } else if (sessionId) {
       // will never happen
       console.warn("THIS IS NEVER EXPECTED TO HAPPEN");
-    } else if (this.#sessionDataSource) {
-      // queue updates for deferred application, issue warnings when edits in progress
-      // this.emit("remote-update-during-local-edit", row);
     } else {
       this.updateRow(row, columnName);
     }
@@ -164,18 +145,6 @@ export class TickingArrayDataSource extends ArrayDataSource {
     this.#table = undefined;
   }
 
-  set range(range: Range) {
-    super.range = range;
-    // Keep session datasource range in sync while editing.
-    if (this.#sessionDataSource) {
-      (this.#sessionDataSource as ArrayDataSource).range = range;
-    }
-    // this.#updateGenerator?.setRange(range);
-  }
-  get range() {
-    return super.range;
-  }
-
   set links(links: LinkDescriptorWithLabel[] | undefined) {
     super.links = links;
   }
@@ -188,51 +157,6 @@ export class TickingArrayDataSource extends ArrayDataSource {
     return Array.from(this.selectedRows);
   }
 
-  /**
-   * Suppress row flushes from the source datasource while a session is active.
-   *
-   * `updateRowWithSessionCheck` already blocks individual row updates arriving
-   * via the table's "update" event.  However, `sendRowsToClient` can also be
-   * reached through other paths that bypass that handler:
-   *   - `setRange` (user scrolls the viewport)
-   *   - config changes (filter / sort / group-by)
-   *   - row inserts into the backing table
-   *
-   * Without this guard those paths would push source-table rows to the
-   * client and overwrite the edited session view.
-   */
-  sendRowsToClient(forceFullRefresh = false, row?: DataSourceRowWithBigint) {
-    if (this.#sessionDataSource) {
-      console.warn(
-        `[TickingArrayDataSource] sendRowsToClient suppressed during active edit session` +
-        ` (forceFullRefresh=${forceFullRefresh}, ${row ? `rowKey=${row[6]}` : "full batch - likely setRange/scroll"})`,
-      );
-      return;
-    }
-    super.sendRowsToClient(forceFullRefresh, row);
-  }
-
-  select(selectRequest: Omit<SelectRequest, "vpId">) {
-    // Forwarding the select request to the session
-    // datasource causes it to update its own selectedRows
-    // and re-send its rows
-    super.select(selectRequest);
-    if (this.#sessionDataSource) {
-      (this.#sessionDataSource as ArrayDataSource).select(selectRequest);
-    }
-  }
-
-  handleSessionMessage = (msg: DataSourceCallbackMessage) => {
-    if (msg.type === "subscribed") {
-      // console.log(`[VuuDataSource subscribed to session table]`);
-    } else if (msg.type === "viewport-update") {
-      if (msg.size !== undefined && msg.size !== this.size) {
-        this.emit("resize", msg.size);
-      }
-      this.clientCallback?.(msg);
-    }
-  };
-
   async createSessionDataSource(
     copyOption: CopyOption,
   ): Promise<DataSourceBase<DataSourceRowWithBigint> | undefined> {
@@ -243,10 +167,13 @@ export class TickingArrayDataSource extends ArrayDataSource {
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
+      const columns = this.config.columns.includes("setToDelete")
+        ? this.config.columns
+        : this.config.columns.concat("setToDelete");
       return this.#vuuModule?.createDataSource(
         sessionTable.table,
         sessionTable.table,
-        this.config,
+        { ...this.config, columns },
       );
     } else {
       throw Error(
@@ -255,63 +182,8 @@ export class TickingArrayDataSource extends ArrayDataSource {
     }
   }
 
-  async beginEditSession(editSessionMode: EditSessionMode = "inline-all-rows") {
-    const rpcResponse = await this?.rpcRequest?.({
-      type: "RPC_REQUEST",
-      rpcName: "beginEditSession",
-      params: {
-        editSessionMode,
-      },
-    });
-
-    if (isRpcSuccess(rpcResponse)) {
-      const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
-
-      const config = {
-        ...this.config,
-        columns: this.config.columns.concat('setToDelete')
-      }
-
-      if (isInlineEditingSession(editSessionMode)) {
-        this.#sessionDataSource = this.#vuuModule?.createDataSource(
-          sessionTable.table,
-          sessionTable.table,
-          config,
-        );
-
-        this.#sessionDataSource?.subscribe(
-          {
-            range: this.range,
-          },
-          this.handleSessionMessage,
-        );
-      } else {
-        return this.#vuuModule?.createDataSource(
-          sessionTable.table,
-          sessionTable.table,
-          config,
-        );
-      }
-
-      // we need to route messages from the session datasource to listening
-      // client whilst still monitoring responses on the source table to which
-      // we are currently subscribed.
-    } else {
-      throw Error(
-        `[VuuDataSource] beginEditSession ${rpcResponse.errorMessage}`,
-      );
-      ///
-    }
-  }
-
   async editCell(key: string, column: string, data: VuuRowDataItemType) {
-    console.log(
-      `[VuuDataSource] editCell ${this.#sessionDataSource?.viewport} rowKey ${key}, column ${column}, value ${data}`,
-    );
-
-    const rpcHost = this.#sessionDataSource ?? this;
-
-    return rpcHost.rpcRequest?.({
+    return this.rpcRequest({
       type: "RPC_REQUEST",
       rpcName: "editCell",
       params: {
@@ -347,8 +219,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
     key: string,
     mode: DeleteRowMode = "hard",
   ): Promise<true | string> => {
-    const rpcHost = this.#sessionDataSource ?? this;
-    const response = await rpcHost.rpcRequest?.({
+    const response = await this.rpcRequest({
       type: "RPC_REQUEST",
       rpcName: "deleteRow",
       params: { key, mode },
@@ -362,8 +233,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
   deleteSelectedRows = async (
     mode: DeleteRowMode = "soft",
   ): Promise<RpcResultSuccess | RpcResultError> => {
-    const rpcHost = this.#sessionDataSource ?? this;
-    const response = await rpcHost.rpcRequest?.({
+    const response = await this.rpcRequest({
       type: "RPC_REQUEST",
       rpcName: "deleteSelectedRows",
       params: { mode },
@@ -379,8 +249,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
   undoRowChange = async (
     key: string,
   ): Promise<RpcResultSuccess | RpcResultError> => {
-    const rpcHost = this.#sessionDataSource ?? this;
-    const response = await rpcHost.rpcRequest?.({
+    const response = await this.rpcRequest({
       type: "RPC_REQUEST",
       rpcName: "undoRowChange",
       params: { key },
@@ -395,44 +264,26 @@ export class TickingArrayDataSource extends ArrayDataSource {
   }
 
   get columns() {
-    if (this.#sessionDataSource) {
-      return this.#sessionDataSource.config.columns;
-    } else {
-      return super.columns;
-    }
+    return super.columns;
   }
 
   async endEditSession(saveChanges = false) {
     const type = "RPC_REQUEST";
     const rpcName = "endEditSession";
 
-    const sessionDataSource = this.#sessionDataSource;
-
-    const rpcHost = sessionDataSource ?? this;
-
-    if (sessionDataSource) {
-      // timing is important here. By breaking this reference before
-      // we send the endEdit RPC call, the application of session edits
-      // to the source table will be handled correctly.
-      this.#sessionDataSource = undefined;
-    }
-
-    const rpcResponse = await rpcHost.rpcRequest?.(
+    const rpcResponse = await this.rpcRequest(
       saveChanges
         ? { type, rpcName, params: { save: true } }
         : { type, rpcName, params: {} },
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      sessionDataSource?.unsubscribe();
       this.sendRowsToClient(true);
     } else {
-      // TODO do we reinstate the sessionDataSource ?
       if (rpcResponse?.errorMessage === "stale update") {
-        sessionDataSource?.unsubscribe();
-        this.sendRowsToClient(true);
+        throw new StaleUpdateError(rpcResponse.errorMessage);
       } else {
-        throw Error("unknown error");
+        throw Error(rpcResponse?.errorMessage ?? "endEditSession failed");
       }
     }
   }

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DataSourceBase,
   DataSourceConfig,
   DataSourceRowWithBigint,
@@ -9,7 +9,7 @@ import {
   CopyOption,
   TableSchema,
 } from "@vuu-ui/vuu-data-types";
-import {
+import type {
   VuuMenu,
   VuuRowDataItemType,
   VuuLink,
@@ -39,7 +39,7 @@ import { Table, buildDataColumnMapFromSchema } from "../../Table";
 import { TickingArrayDataSource } from "../../TickingArrayDataSource";
 import { RuntimeVisualLink } from "../../RuntimeVisualLink";
 import moduleContainer from "./ModuleContainer";
-import { sessionTableSchema } from "../../session-table-utils";
+import { sessionTableRow, sessionTableSchema } from "../../session-table-utils";
 
 const assertUpdateIsValid = (
   schema: TableSchema,
@@ -96,6 +96,7 @@ type Subscription = {
   viewportId: string;
   dataSource: DataSourceBase<DataSourceRowWithBigint>;
   sessionTableName?: string;
+  sourceTableName?: string;
 };
 export abstract class VuuModule<T extends string = string>
   implements IVuuModule<T>
@@ -103,6 +104,7 @@ export abstract class VuuModule<T extends string = string>
   #name: string;
   #sessionTableMessageColumn: string;
   #runtimeVisualLinks = new Map<string, RuntimeVisualLink>();
+  #sessionSourceTableMap: Record<string, T> = {};
   #sessionTableMap: SessionTableMap = {};
   #tableServices: Record<T, RpcService[] | undefined> | undefined;
   #subscriptionMap: Map<string, Subscription[]> = new Map();
@@ -356,7 +358,6 @@ export abstract class VuuModule<T extends string = string>
         menu: this.menus?.[tableName],
         rpcServices: this.getServices(tableName),
         rpcMenuServices: this.getMenuServices(tableName),
-        sessionTables: this.#sessionTableMap,
         viewport,
         visualLinkService: this.visualLinkService,
         vuuModule,
@@ -369,6 +370,8 @@ export abstract class VuuModule<T extends string = string>
     const subscription = {
       viewportId: dataSource.viewport as string,
       dataSource,
+      sessionTableName: sessionTable ? tableName : undefined,
+      sourceTableName: this.#sessionSourceTableMap[tableName],
     };
     if (existingSubscriptions) {
       existingSubscriptions.push(subscription);
@@ -431,11 +434,7 @@ export abstract class VuuModule<T extends string = string>
       const sessionTable = this.getSessionTable(viewPortId, false);
       if (sessionTable) {
         if (mode === "soft") {
-          sessionTable.update(
-            key,
-            "setToDelete",
-            true,
-          );
+          sessionTable.update(key, "setToDelete", true);
         } else {
           sessionTable.delete(key);
         }
@@ -476,11 +475,7 @@ export abstract class VuuModule<T extends string = string>
         if (selectedRowIds.length > 0) {
           for (const key of selectedRowIds) {
             if ((mode as DeleteRowMode) === "soft") {
-              sessionTable.update(
-                key,
-                "setToDelete",
-                true,
-              );
+              sessionTable.update(key, "setToDelete", true);
             } else {
               sessionTable.delete(key);
             }
@@ -506,8 +501,11 @@ export abstract class VuuModule<T extends string = string>
       const { key } = rpcRequest.params;
       const sessionTable = this.getSessionTable(viewPortId, false);
       if (sessionTable) {
-        const { dataSource } = this.getSubscriptionByViewport(viewPortId);
-        const sourceTable = this.tables[dataSource.table?.table as T];
+        const subscription = this.getSubscriptionByViewport(viewPortId);
+        const { dataSource } = subscription;
+        const sourceTableName =
+          subscription.sourceTableName ?? dataSource.table?.table;
+        const sourceTable = this.tables[sourceTableName as T];
         if (!sourceTable) {
           return {
             type: "ERROR_RESULT",
@@ -584,7 +582,7 @@ export abstract class VuuModule<T extends string = string>
         throw Error("[VuuModule] editCell unable to find table for dataSource");
       }
     } else {
-      throw Error(`[VuuModule] editCell invalid rpc type`);
+      throw Error("[VuuModule] editCell invalid rpc type");
     }
   };
 
@@ -658,11 +656,10 @@ export abstract class VuuModule<T extends string = string>
               sourceTable,
               sessionTableName,
               copyOption,
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
               dataSource as TickingArrayDataSource,
             );
             this.#sessionTableMap[sessionTableName] = sessionTable;
+            this.#sessionSourceTableMap[sessionTableName] = vuuTable.table as T;
             subscription.sessionTableName = sessionTableName;
             return {
               data: {
@@ -701,11 +698,10 @@ export abstract class VuuModule<T extends string = string>
               sourceTable,
               sessionTableName,
               editSessionMode as EditSessionMode,
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
               dataSource as TickingArrayDataSource,
             );
             this.#sessionTableMap[sessionTableName] = sessionTable;
+            this.#sessionSourceTableMap[sessionTableName] = vuuTable.table as T;
             subscription.sessionTableName = sessionTableName;
 
             return {
@@ -727,7 +723,7 @@ export abstract class VuuModule<T extends string = string>
         }
       }
     } else {
-      throw Error(`[VuuModule] endEditSession invalid rpc type`);
+      throw Error("[VuuModule] endEditSession invalid rpc type");
     }
 
     return {
@@ -740,9 +736,8 @@ export abstract class VuuModule<T extends string = string>
     if (isAddRowRpcRequest(rpcRequest)) {
       const { viewPortId } = rpcRequest.context;
       const subscription = this.getSubscriptionByViewport(viewPortId);
-      const sessionTable = subscription.sessionTableName
-        ? this.#sessionTableMap[subscription.sessionTableName]
-        : undefined;
+      const sessionTableName = subscription.sessionTableName ?? viewPortId;
+      const sessionTable = this.#sessionTableMap[sessionTableName];
       if (!sessionTable) {
         return {
           type: "ERROR_RESULT",
@@ -779,7 +774,9 @@ export abstract class VuuModule<T extends string = string>
       const { dataSource } = subscription;
 
       if (dataSource.table) {
-        const sourceTable = this.tables[dataSource.table.table as T];
+        const sourceTableName =
+          subscription.sourceTableName ?? dataSource.table.table;
+        const sourceTable = this.tables[sourceTableName as T];
 
         if (rpcRequest.params.save === true) {
           let rejectedCount = 0;
@@ -790,7 +787,9 @@ export abstract class VuuModule<T extends string = string>
           const sourceColumns = sourceTable.schema.columns;
           for (let i = 0; i < sessionTable.data.length; i++) {
             const sessionRow = sessionTable.data[i];
-            const key = String(sessionRow[sessionTable.map[sourceTable.schema.key]]);
+            const key = String(
+              sessionRow[sessionTable.map[sourceTable.schema.key]],
+            );
             const currentRow = sourceTable.findByKey(key);
             if (sessionRow[setToDeleteIdx]) {
               if (currentRow) {
@@ -849,7 +848,7 @@ export abstract class VuuModule<T extends string = string>
         throw Error("[VuuModule], exitEditMode");
       }
     } else {
-      throw Error(`[VuuModule] endEditSession invalid rpc type`);
+      throw Error("[VuuModule] endEditSession invalid rpc type");
     }
 
     // return {
@@ -881,14 +880,14 @@ export abstract class VuuModule<T extends string = string>
         data: undefined,
       };
     } else {
-      throw Error(`[VuuModule] applyBulkEdits invalid rpc type`);
+      throw Error("[VuuModule] applyBulkEdits invalid rpc type");
     }
   };
 
   protected createSessionTable(
     sourceTable: Table,
     sessionTableName: string,
-    editSessionMode: EditSessionMode | CopyOption = "inline-all-rows",
+    editSessionMode: EditSessionMode | CopyOption,
     dataSource: TickingArrayDataSource,
   ) {
     if (editSessionMode === "All" || editSessionMode.endsWith("all-rows")) {
@@ -921,7 +920,7 @@ export abstract class VuuModule<T extends string = string>
     const sessionSchema = sessionTableSchema(schema);
     return new Table(
       sessionSchema,
-      data.map((row) => [...row, "", false]),
+      data.map((row) => sessionTableRow(row, schema)),
       buildDataColumnMapFromSchema(sessionSchema),
     );
   }
@@ -954,7 +953,7 @@ export abstract class VuuModule<T extends string = string>
     for (let i = 0; i < selectedRowIds.length; i++) {
       for (let j = 0; j < data.length; j++) {
         if (data[j][keyIndex] === selectedRowIds[i]) {
-          sessionData.push([...data[j], "", false]);
+          sessionData.push(sessionTableRow(data[j], schema));
         }
       }
     }

--- a/vuu-ui/packages/vuu-data-test/src/session-table-utils.ts
+++ b/vuu-ui/packages/vuu-data-test/src/session-table-utils.ts
@@ -1,9 +1,23 @@
-import { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
+import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
 import { Table, buildDataColumnMapFromSchema } from "./Table";
 import { metadataKeys } from "@vuu-ui/vuu-utils";
-import { TableSchema } from "@vuu-ui/vuu-data-types";
+import type { TableSchema } from "@vuu-ui/vuu-data-types";
 
 const { KEY } = metadataKeys;
+
+export const sessionTableRow = (
+  row: Array<bigint | VuuRowDataItemType>,
+  schema: TableSchema,
+) => {
+  const sessionRow = row.slice();
+  if (!schema.columns.some(({ name }) => name === "vuuMsg")) {
+    sessionRow.push("");
+  }
+  if (!schema.columns.some(({ name }) => name === "setToDelete")) {
+    sessionRow.push(false);
+  }
+  return sessionRow;
+};
 
 export const createSessionTableFromSelectedRows = (
   table: Table,
@@ -13,23 +27,22 @@ export const createSessionTableFromSelectedRows = (
   for (let i = 0; i < selectedRowIds.length; i++) {
     for (let j = 0; j < table.data.length; j++) {
       if (table.data[j][KEY] === selectedRowIds[i]) {
-        sessionData.push([...table.data[j], "", false]);
+        sessionData.push(sessionTableRow(table.data[j], table.schema));
       }
     }
   }
 
   const schema = sessionTableSchema(table.schema);
-  return new Table(
-    schema,
-    sessionData,
-    buildDataColumnMapFromSchema(schema),
-  );
+  return new Table(schema, sessionData, buildDataColumnMapFromSchema(schema));
 };
 
-export const sessionTableSchema = (schema: TableSchema): TableSchema => ({
-  ...schema,
-  columns: schema.columns.concat(
-    { name: "vuuMsg", serverDataType: "string" },
-    { name: "setToDelete", serverDataType: "boolean" },
-  ),
-});
+export const sessionTableSchema = (schema: TableSchema): TableSchema => {
+  const columns = schema.columns.slice();
+  if (!columns.some(({ name }) => name === "vuuMsg")) {
+    columns.push({ name: "vuuMsg", serverDataType: "string" });
+  }
+  if (!columns.some(({ name }) => name === "setToDelete")) {
+    columns.push({ name: "setToDelete", serverDataType: "boolean" });
+  }
+  return { ...schema, columns };
+};

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import { buildDataColumnMapFromSchema, Table } from "../src/Table";
 import { TickingArrayDataSource } from "../src/TickingArrayDataSource";
-import { sessionTableSchema } from "../src/session-table-utils";
+import {
+  sessionTableRow,
+  sessionTableSchema,
+} from "../src/session-table-utils";
 import type { TableSchema } from "@vuu-ui/vuu-data-types";
-import type { RpcResultError, RpcResultSuccess } from "@vuu-ui/vuu-protocol-types";
+import type {
+  RpcResultError,
+  RpcResultSuccess,
+} from "@vuu-ui/vuu-protocol-types";
 
 const schema: TableSchema = {
   columns: [
@@ -16,7 +22,10 @@ const schema: TableSchema = {
 };
 
 const SUCCESS: RpcResultSuccess = { type: "SUCCESS_RESULT", data: undefined };
-const ERROR = (msg: string): RpcResultError => ({ type: "ERROR_RESULT", errorMessage: msg });
+const ERROR = (msg: string): RpcResultError => ({
+  type: "ERROR_RESULT",
+  errorMessage: msg,
+});
 
 function createDataSource() {
   const table = new Table(
@@ -45,6 +54,35 @@ describe("sessionTableSchema", () => {
       { name: "vuuMsg", serverDataType: "string" },
       { name: "setToDelete", serverDataType: "boolean" },
     ]);
+  });
+
+  it("does not duplicate existing session-only columns", () => {
+    const sessionSchema = sessionTableSchema(schema);
+
+    expect(
+      sessionSchema.columns.filter(({ name }) => name === "vuuMsg"),
+    ).toHaveLength(1);
+    expect(
+      sessionSchema.columns.filter(({ name }) => name === "setToDelete"),
+    ).toHaveLength(1);
+  });
+
+  it("only appends values for missing session-only columns", () => {
+    expect(sessionTableRow(["row-001", "Alice", ""], schema)).toEqual([
+      "row-001",
+      "Alice",
+      "",
+      false,
+    ]);
+    expect(
+      sessionTableRow(["row-001", "Alice", "", false], {
+        ...schema,
+        columns: schema.columns.concat({
+          name: "setToDelete",
+          serverDataType: "boolean",
+        }),
+      }),
+    ).toEqual(["row-001", "Alice", "", false]);
   });
 });
 
@@ -172,7 +210,10 @@ describe("deleteSelectedRows", () => {
 
   it("returns the RpcResult unchanged on success", async () => {
     const ds = createDataSource();
-    const success = { type: "SUCCESS_RESULT" as const, data: { deletedKeys: ["row-001", "row-002"] } };
+    const success = {
+      type: "SUCCESS_RESULT" as const,
+      data: { deletedKeys: ["row-001", "row-002"] },
+    };
     vi.mocked(ds.rpcRequest).mockResolvedValue(success);
 
     const result = await ds.deleteSelectedRows();
@@ -276,80 +317,6 @@ describe("undoRowChange", () => {
   });
 });
 
-describe("beginEditSession", () => {
-  const sessionSuccess = {
-    type: "SUCCESS_RESULT" as const,
-    data: { table: { module: "TEST", table: "session-xyz" } },
-  };
-
-  it("keeps 'inline-all-rows' unchanged in the RPC params (client-only concept)", async () => {
-    const ds = createDataSource();
-    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
-
-    await ds.beginEditSession("inline-all-rows");
-
-    expect(ds.rpcRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rpcName: "beginEditSession",
-        params: { editSessionMode: "inline-all-rows" },
-      }),
-    );
-  });
-
-  it("sends 'all-rows' unchanged in the RPC params", async () => {
-    const ds = createDataSource();
-    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
-
-    await ds.beginEditSession("all-rows");
-
-    expect(ds.rpcRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rpcName: "beginEditSession",
-        params: { editSessionMode: "all-rows" },
-      }),
-    );
-  });
-
-  it("sends 'selected-rows' unchanged in the RPC params", async () => {
-    const ds = createDataSource();
-    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
-
-    await ds.beginEditSession("selected-rows");
-
-    expect(ds.rpcRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rpcName: "beginEditSession",
-        params: { editSessionMode: "selected-rows" },
-      }),
-    );
-  });
-
-  it("sends 'empty-session-table' unchanged in the RPC params", async () => {
-    const ds = createDataSource();
-    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
-
-    await ds.beginEditSession("empty-session-table");
-
-    expect(ds.rpcRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rpcName: "beginEditSession",
-        params: { editSessionMode: "empty-session-table" },
-      }),
-    );
-  });
-
-  it("throws with the server error message on failure", async () => {
-    const ds = createDataSource();
-    vi.mocked(ds.rpcRequest).mockResolvedValue(
-      ERROR("edit session already active"),
-    );
-
-    await expect(ds.beginEditSession("inline-all-rows")).rejects.toThrow(
-      "edit session already active",
-    );
-  });
-});
-
 describe("endEditSession", () => {
   it("dispatches endEditSession RPC with { save: true } when saving changes", async () => {
     const ds = createDataSource();
@@ -379,18 +346,20 @@ describe("endEditSession", () => {
     );
   });
 
-  it("throws 'unknown error' for an unrecognised server error", async () => {
+  it("propagates the server error message", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(ERROR("something unexpected"));
 
-    await expect(ds.endEditSession(true)).rejects.toThrow("unknown error");
+    await expect(ds.endEditSession(true)).rejects.toThrow(
+      "something unexpected",
+    );
   });
 
-  it("handles a stale-update error gracefully and does not throw", async () => {
+  it("throws a stale-update error so the session can be retried", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(ERROR("stale update"));
 
-    await expect(ds.endEditSession(true)).resolves.toBeUndefined();
+    await expect(ds.endEditSession(true)).rejects.toThrow("stale update");
   });
 });
 
@@ -441,7 +410,9 @@ describe("createSessionDataSource", () => {
 
   it("throws with the server error message on failure", async () => {
     const ds = createDataSource();
-    vi.mocked(ds.rpcRequest).mockResolvedValue(ERROR("session table creation failed"));
+    vi.mocked(ds.rpcRequest).mockResolvedValue(
+      ERROR("session table creation failed"),
+    );
     await expect(ds.createSessionDataSource?.("All")).rejects.toThrow(
       "session table creation failed",
     );

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -577,47 +577,22 @@ export declare type DataSourceSuspenseProps = {
   escalateDelay?: number;
 };
 
-/**
- * An inline edit session allows user to apply edits directly to
- * the existing component. e.g. directly edit cells within a table.
- */
-export declare type InlineEditSessionMode = "inline-all-rows";
+/** Controls which source rows are copied into a newly created session table. */
+export declare type CopyOption = "All" | "Empty" | "Selected";
 
 /**
- * A standalone edit session re-renders editable data in an edit component.
- * e.g an edit panel may be displayed in a dialog.
+ * Wire-level values used by the legacy beginEditSession menu/server service.
+ * Client edit lifecycles use CopyOption with createSessionDataSource instead.
  */
-export declare type StandaloneEditSessionMode =
+export declare type EditSessionMode =
+  | "inline-all-rows"
   | "selected-rows"
   | "all-rows"
   | "empty-session-table";
 
-/**
- * Short-form values accepted by the beginEditSession RPC (remote and local).
- * The client-side EditApi maps the long-form StandaloneEditSessionMode values
- * to one of these before dispatching the RPC call:
- * - `"All"`      ← `"all-rows"`
- * - `"Empty"`    ← `"empty-session-table"`
- * - `"Selected"` ← `"selected-rows"`
- * `"inline-all-rows"` is a client-only concept and is NOT mapped — it passes
- * through to the RPC unchanged so the server can create an all-rows session table.
- */
-export declare type CopyOption = "All" | "Empty" | "Selected";
-/**
- * @deprecated Prefer `CopyOption` ("All" | "Empty" | "Selected") for standalone
- * edit sessions supported by vuu server. Long-form values (e.g. `"all-rows"`) are used 
- * by `beginEditSession`; new code should use `CopyOption` with `createSessionDataSource`.
- */
-export declare type EditSessionMode =
-  | InlineEditSessionMode
-  | StandaloneEditSessionMode;
-
 export interface EditApi<
   T extends DataSourceRow | DataSourceRowWithBigint = DataSourceRow,
 > {
-  beginEditSession?: (
-    editSessionMode?: EditSessionMode,
-  ) => Promise<DataSource<T> | undefined>;
   addRow?: (
     rowData?: Record<string, VuuRowDataItemType>,
   ) => Promise<RpcResult> | undefined;

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -44,9 +44,9 @@ test.describe("Editable table navigation", () => {
     await editButton.click();
 
     // get the first data cell
-    let cell1 = table.locateCell(2, 1);
-    let cell2 = table.locateCell(3, 1);
-    let cell3 = table.locateCell(3, 2);
+    const cell1 = table.locateCell(2, 1);
+    const cell2 = table.locateCell(3, 1);
+    const cell3 = table.locateCell(3, 2);
     await cell1.click();
     await table.assertCellIsFocused(cell1, "textbox");
     await cell1.press("ArrowDown");
@@ -68,10 +68,10 @@ test.describe("Editable table navigation", () => {
     const editButton = page.getByRole("radio", { name: "Edit" });
     await editButton.click();
 
-    let cell4 = table.locateCell(2, 4);
-    let cell5 = table.locateCell(2, 5);
-    let cell6 = table.locateCell(2, 6);
-    let cell7 = table.locateCell(2, 7);
+    const cell4 = table.locateCell(2, 4);
+    const cell5 = table.locateCell(2, 5);
+    const cell6 = table.locateCell(2, 6);
+    const cell7 = table.locateCell(2, 7);
 
     // focus is in not editable, followed by 2 editable cells
     await cell5.click();
@@ -108,7 +108,7 @@ test.describe("Editable table navigation", () => {
     await editButton.click();
 
     // get the description  cell
-    let cell = table.locateCell(3, 3);
+    const cell = table.locateCell(3, 3);
     await cell.click();
     await table.assertCellIsFocused(cell, "textbox");
     await cell.press("Enter");
@@ -134,8 +134,8 @@ test.describe("Editable table navigation", () => {
     await editButton.click();
 
     // get the currency cell
-    let cell = table.locateCell(3, 2);
-    let nextCell = table.locateCell(4, 2);
+    const cell = table.locateCell(3, 2);
+    const nextCell = table.locateCell(4, 2);
     const originalValue =
       (await cell.getByRole("combobox").textContent()) ?? "";
     await cell.click();
@@ -163,7 +163,7 @@ test.describe("Editable table navigation", () => {
     await editButton.click();
 
     // get the description  cell
-    let cell = table.locateCell(3, 3);
+    const cell = table.locateCell(3, 3);
     await cell.click();
     await table.assertCellIsFocused(cell, "textbox");
     await cell.press("Enter");
@@ -187,7 +187,7 @@ test.describe("Editable table navigation", () => {
     await editButton.click();
 
     // get the description  cell
-    let cell = table.locateCell(3, 3);
+    const cell = table.locateCell(3, 3);
     await cell.click();
     await table.assertCellIsFocused(cell, "textbox");
     await cell.press("Enter");
@@ -228,7 +228,7 @@ test.describe("Cell editing", () => {
     await editButton.click();
 
     // get the lotsize  cell
-    let cell = table.locateCell(3, 6);
+    const cell = table.locateCell(3, 6);
     const originalValue = await cell.getByRole("textbox").inputValue();
     await cell.dblclick();
     await table.assertCellIsFocused(cell, "textbox");
@@ -412,6 +412,57 @@ test.describe("Edit conflicts", () => {
       await table2.assertRenderedRows({ from: 0, to: 10 }, 10, 10_000, 1);
       await table2.assertCellIsEditable(2, 1, NOT_EDITABLE, "AAOO L");
     });
+
+    test("switches source to session and back while ignoring old-source updates", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <LocalDataSourceProvider>
+          <TwoEditableInstruments />
+        </LocalDataSourceProvider>,
+      );
+
+      const first = page.getByTestId("edit-table-1");
+      const second = page.getByTestId("edit-table-2");
+      const firstTableElement = first.getByTestId("table-1");
+      const firstTable = new TableOM(firstTableElement);
+      const secondTable = new TableOM(second.getByTestId("table-2"));
+
+      const sourceViewport =
+        (await firstTableElement.getAttribute("data-viewport")) ?? "";
+      expect(sourceViewport).not.toBe("");
+      await first.getByTestId("toggle-edit-1").click();
+      await expect(firstTableElement).not.toHaveAttribute(
+        "data-viewport",
+        sourceViewport,
+      );
+      await firstTable.assertRenderedRows({ from: 0, to: 10 }, 10, 10_000, 1);
+
+      const firstValue = await firstTable
+        .locateCell(3, 6)
+        .getByRole("textbox")
+        .inputValue();
+
+      await second.getByTestId("toggle-edit-2").click();
+      const secondCell = secondTable.locateCell(3, 6);
+      await secondCell.dblclick();
+      await secondCell.pressSequentially("321");
+      await secondCell.press("Enter");
+      await second.getByRole("button", { name: "Save" }).click();
+
+      await expect(
+        firstTable.locateCell(3, 6).getByRole("textbox"),
+      ).toHaveValue(firstValue);
+
+      await first.getByRole("button", { name: "Cancel" }).click();
+      await expect(firstTableElement).toHaveAttribute(
+        "data-viewport",
+        sourceViewport,
+      );
+      await firstTable.assertRenderedRows({ from: 0, to: 10 }, 10, 10_000, 1);
+      await expect(firstTable.locateCell(3, 6)).toContainText("321");
+    });
   });
 
   test.describe("Save Cancel buttons", () => {
@@ -508,7 +559,9 @@ test.describe("Inline row editing (session)", () => {
     await mount(<EditableInstrumentsInlineEdit />);
 
     // View mode: no Delete/Add Rows/Submit buttons visible
-    await expect(page.getByRole("button", { name: "Delete" })).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Delete" }),
+    ).not.toBeVisible();
 
     await page.getByRole("radio", { name: "Edit" }).click();
 
@@ -518,7 +571,9 @@ test.describe("Inline row editing (session)", () => {
     await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();
 
     // Undo column header is visible
-    await expect(page.getByRole("columnheader", { name: "undo" })).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "undo" }),
+    ).toBeVisible();
   });
 
   test("Submit is disabled until at least one row is changed", async ({
@@ -630,7 +685,9 @@ test.describe("Inline row editing (session)", () => {
     await page.getByRole("radio", { name: "View" }).click();
 
     // Returns to view mode — action buttons gone
-    await expect(page.getByRole("button", { name: "Submit" })).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Submit" }),
+    ).not.toBeVisible();
     await expect(page.getByRole("radio", { name: "View" })).toBeVisible();
   });
 });
@@ -644,7 +701,9 @@ test.describe("Session table editing (createSessionTable)", () => {
     const table = new TableOM(page.getByRole("table"));
 
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     // Column 2 = bbg (column 1 is the checkbox selector)
     const cell = table.locateCell(2, 2);
@@ -658,7 +717,9 @@ test.describe("Session table editing (createSessionTable)", () => {
   }) => {
     await mount(<CreateSessionTableInstruments />);
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     const table = new TableOM(page.getByRole("table"));
     // Column 2 = bbg
@@ -672,13 +733,12 @@ test.describe("Session table editing (createSessionTable)", () => {
     await expect(page.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 
-  test("selecting a row enables the Delete button", async ({
-    mount,
-    page,
-  }) => {
+  test("selecting a row enables the Delete button", async ({ mount, page }) => {
     await mount(<CreateSessionTableInstruments />);
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     const table = new TableOM(page.getByRole("table"));
     const deleteButton = page.getByRole("button", { name: "Delete" });
@@ -696,7 +756,9 @@ test.describe("Session table editing (createSessionTable)", () => {
   }) => {
     await mount(<CreateSessionTableInstruments />);
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     const table = new TableOM(page.getByRole("table"));
     const checkboxCell = table.locateCell(2, 1);
@@ -714,13 +776,19 @@ test.describe("Session table editing (createSessionTable)", () => {
   }) => {
     await mount(<CreateSessionTableInstruments />);
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     const submitButton = page.getByRole("button", { name: "Submit" });
     await expect(submitButton).toBeDisabled();
 
     await page.getByRole("button", { name: "Add Rows" }).click();
     await expect(submitButton).toBeEnabled();
+    await expect(page.getByRole("table")).toHaveAttribute(
+      "aria-rowcount",
+      "10015",
+    );
   });
 
   test("soft-deleted row retains vuuTableRow-noSelect class after another row is selected", async ({
@@ -729,7 +797,9 @@ test.describe("Session table editing (createSessionTable)", () => {
   }) => {
     await mount(<CreateSessionTableInstruments />);
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     const table = new TableOM(page.getByRole("table"));
 
@@ -747,7 +817,9 @@ test.describe("Session table editing (createSessionTable)", () => {
 
     // Row 2 is no longer server-selected but remains non-selectable (vuuMsg still SOFT_DELETED)
     await expect(table.row(2)).toHaveClass(/vuuTableRow-noSelect/);
-    await expect(table.row(2).getByRole("button", { name: "Undo" })).toBeVisible();
+    await expect(
+      table.row(2).getByRole("button", { name: "Undo" }),
+    ).toBeVisible();
   });
 
   test("clicking a soft-deleted row checkbox does not change row 3's selection state", async ({
@@ -756,7 +828,9 @@ test.describe("Session table editing (createSessionTable)", () => {
   }) => {
     await mount(<CreateSessionTableInstruments />);
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     const table = new TableOM(page.getByRole("table"));
     const checkboxRow2 = table.locateCell(2, 1).getByRole("checkbox");
@@ -781,7 +855,9 @@ test.describe("Session table editing (createSessionTable)", () => {
   }) => {
     await mount(<CreateSessionTableInstruments />);
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     const table = new TableOM(page.getByRole("table"));
     const deleteButton = page.getByRole("button", { name: "Delete" });
@@ -799,7 +875,9 @@ test.describe("Session table editing (createSessionTable)", () => {
   }) => {
     await mount(<CreateSessionTableInstruments />);
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     const table = new TableOM(page.getByRole("table"));
     const deleteButton = page.getByRole("button", { name: "Delete" });
@@ -823,7 +901,9 @@ test.describe("Session table editing (createSessionTable)", () => {
   }) => {
     await mount(<CreateSessionTableInstruments />);
     await page.getByRole("radio", { name: "Edit" }).click();
-    await expect(page.getByRole("status", { name: "Loading session table" })).not.toBeVisible();
+    await expect(
+      page.getByRole("status", { name: "Loading session table" }),
+    ).not.toBeVisible();
 
     const table = new TableOM(page.getByRole("table"));
 
@@ -841,6 +921,8 @@ test.describe("Session table editing (createSessionTable)", () => {
     await expect(table.row(4)).toHaveAttribute("aria-selected", "true");
     await expect(table.row(5)).toHaveAttribute("aria-selected", "true");
     // Row 3 is still soft-deleted — undo button remains
-    await expect(table.row(3).getByRole("button", { name: "Undo" })).toBeVisible();
+    await expect(
+      table.row(3).getByRole("button", { name: "Undo" }),
+    ).toBeVisible();
   });
 });

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -17,7 +17,6 @@ import { DataSourceStats, TableFooter } from "@vuu-ui/vuu-table-extras";
 import {
   DataEditingProvider,
   EditButtons,
-  isCopyOption,
   type EditMode,
   useEditableTable,
   useEditSession,
@@ -51,7 +50,7 @@ import {
   useState,
 } from "react";
 import { SimulTable } from "./SimulTableTemplate";
-import { DataSource, EditSessionMode } from "@vuu-ui/vuu-data-types";
+import type { CopyOption, DataSource } from "@vuu-ui/vuu-data-types";
 import { LayoutProvider, Stack, View } from "@vuu-ui/vuu-layout";
 import { ColumnFilter } from "@vuu-ui/vuu-filters";
 import {
@@ -130,6 +129,7 @@ const EditTableTemplate = ({
     editSession,
     onCancel,
     onSave,
+    sourceDataSource,
   } = useEditableTable({
     dataSource: sourceTableDataSource,
     isEditMode: editMode === "edit",
@@ -140,7 +140,7 @@ const EditTableTemplate = ({
   const handleColumnFilterCommit = useCallback<ColumnFilterCommitHandler>(
     (column, op, value) => {
       if (column.name === "bbg") {
-        dataSource?.setFilter?.({
+        sourceDataSource.setFilter?.({
           column: column.name,
           op: "starts",
           value,
@@ -151,7 +151,7 @@ const EditTableTemplate = ({
         op !== "between-inclusive" &&
         op !== "in"
       ) {
-        dataSource?.setFilter?.({
+        sourceDataSource.setFilter?.({
           column: column.name,
           op,
           value,
@@ -159,7 +159,7 @@ const EditTableTemplate = ({
         setFilterValue(`${value}`);
       }
     },
-    [dataSource],
+    [sourceDataSource],
   );
 
   const handleColumnFilterChange = useCallback<ColumnFilterChangeHandler>(
@@ -175,12 +175,6 @@ const EditTableTemplate = ({
   );
   const config = useMemo<TableConfig>(
     () => {
-
-      if (editMode === 'view' && dataSource.columns.includes('setToDelete')) {
-        dataSource.columns = dataSource.columns.filter(col => col !== 'setToDelete')
-      } else if (editMode === 'edit' && !dataSource.columns.includes('setToDelete')) {
-        dataSource.columns = dataSource.columns.concat('setToDelete');
-      }
 
       return {
         columns:
@@ -211,7 +205,7 @@ const EditTableTemplate = ({
                           "USD",
                         ],
                       },
-                    },
+                    } as DataValueTypeDescriptor,
                   }
                   : col.name === "isin" ||
                     col.name === "vuuCreatedTimestamp" ||
@@ -219,19 +213,18 @@ const EditTableTemplate = ({
                     col.name === "vuuMsg"
                     ? col
                     : { ...col, editable: true },
-            ).concat({
-              name: 'setToDelete'
-            }),
+            ).concat({ name: "setToDelete" } as ColumnDescriptor),
         columnDefaultWidth: 150,
         rowSeparators: true,
         zebraStripes: true,
       };
     },
-    [dataSource, editMode, editableType],
+    [editMode, editableType],
   );
 
   return (
     <div
+      data-testid={`edit-table${testId}`}
       style={{
         display: "flex",
         flexDirection: "column",
@@ -265,7 +258,7 @@ const EditTableTemplate = ({
           value={keyFilterValue}
         />
         {filterColumn ? (
-          <DataSourceProvider dataSource={dataSource}>
+          <DataSourceProvider dataSource={sourceDataSource}>
             <ColumnFilter
               TypeaheadProps={{ minCharacterCountToTriggerSuggestions: 0 }}
               column={{ name: "currency", serverDataType: "string" }}
@@ -282,6 +275,7 @@ const EditTableTemplate = ({
           <Table
             {...htmlAttributes}
             config={config}
+            data-viewport={dataSource.viewport}
             data-testid={`table${testId}`}
             dataSource={dataSource}
             renderBufferSize={10}
@@ -291,7 +285,7 @@ const EditTableTemplate = ({
       </div>
       <TableFooter>
         {editMode === "view" ? (
-          <DataSourceStats dataSource={dataSource} />
+          <DataSourceStats dataSource={sourceDataSource} />
         ) : (
           <EditButtons
             canCancel={canCancel}
@@ -316,9 +310,9 @@ export const EditableInstruments = () => {
 };
 
 const EditableInstrumentsTemplate = ({
-  editSessionMode,
+  copyOption,
 }: {
-  editSessionMode?: Parameters<typeof useEditableTable>[0]["editSessionMode"];
+  copyOption?: CopyOption;
 }) => {
   const [editMode, setEditMode] = useState<EditMode>("view");
   const { VuuDataSource } = useData();
@@ -347,11 +341,11 @@ const EditableInstrumentsTemplate = ({
     onCancel,
     onDelete,
     onSave,
-    sessionDataSource,
+    sourceDataSource,
   } = useEditableTable({
     dataSource: sourceTableDataSource,
+    copyOption,
     deleteMode: "soft",
-    editSessionMode,
     isEditMode: editMode === "edit",
     onCancel: exitEditMode,
     onSave: exitEditMode,
@@ -371,13 +365,6 @@ const EditableInstrumentsTemplate = ({
 
   const config = useMemo<TableConfig>(
     () => {
-
-      const { columns } = dataSource;
-      if (editMode === 'view' && columns.includes('setToDelete')) {
-        dataSource.columns = columns.filter(col => col !== 'setToDelete')
-      } else if (editMode === 'edit' && !columns.includes('setToDelete')) {
-        dataSource.columns = columns.concat('setToDelete');
-      }
 
       return {
         columns:
@@ -416,7 +403,7 @@ const EditableInstrumentsTemplate = ({
         zebraStripes: true,
       };
     },
-    [dataSource, editMode],
+    [editMode],
   );
 
   return (
@@ -437,25 +424,20 @@ const EditableInstrumentsTemplate = ({
         </ToggleButtonGroup>
       </div>
       <div style={{ flex: "1 1 auto" }}>
-        {editMode === "edit" && isCopyOption(editSessionMode) && !sessionDataSource ? (
-          <div role="status" aria-label="Loading session table">
-            Loading session…
-          </div>
-        ) : (
-          <DataEditingProvider editSession={editSession}>
-            <Table
-              config={config}
-              dataSource={sessionDataSource ?? dataSource}
-              renderBufferSize={10}
-              isRowSelectable={editMode === "edit" ? isRowSelectable : undefined}
-              selectionModel={editMode === "edit" ? "checkbox" : "none"}
-            />
-          </DataEditingProvider>
-        )}
+        <DataEditingProvider editSession={editSession}>
+          <Table
+            config={config}
+            data-viewport={dataSource.viewport}
+            dataSource={dataSource}
+            renderBufferSize={10}
+            isRowSelectable={editMode === "edit" ? isRowSelectable : undefined}
+            selectionModel={editMode === "edit" ? "checkbox" : "none"}
+          />
+        </DataEditingProvider>
       </div>
       <TableFooter>
         {editMode === "view" ? (
-          <DataSourceStats dataSource={dataSource} />
+          <DataSourceStats dataSource={sourceDataSource} />
         ) : (
           <EditButtons
             canCancel={canCancel}
@@ -478,7 +460,7 @@ const EditableInstrumentsTemplate = ({
 export const EditableInstrumentsInlineEdit = () => (
   <LocalDataSourceProvider>
     <NotificationsProvider>
-      <EditableInstrumentsTemplate editSessionMode="all-rows" />
+      <EditableInstrumentsTemplate copyOption="All" />
     </NotificationsProvider>
   </LocalDataSourceProvider>
 );
@@ -487,7 +469,7 @@ export const EditableInstrumentsInlineEdit = () => (
 export const CreateSessionTableInstruments = () => (
   <LocalDataSourceProvider>
     <NotificationsProvider>
-      <EditableInstrumentsTemplate editSessionMode="All" />
+      <EditableInstrumentsTemplate copyOption="All" />
     </NotificationsProvider>
   </LocalDataSourceProvider>
 );
@@ -694,8 +676,8 @@ const BulkEditTableTemplate = ({
   const [editState, setEditState] = useState<{
     editing: boolean;
     dialog?: ReactElement;
-    editSessionMode: EditSessionMode;
-  }>({ editing: false, editSessionMode: "selected-rows" });
+    copyOption: CopyOption;
+  }>({ editing: false, copyOption: "Selected" });
 
   const sourceTableDataSource = useMemo(
     () =>
@@ -708,15 +690,21 @@ const BulkEditTableTemplate = ({
 
   const clearEditState = useCallback(() => {
     closeDialog();
-    setEditState({ editing: false, editSessionMode: "selected-rows" });
+    setEditState({ editing: false, copyOption: "Selected" });
   }, [closeDialog]);
 
   const exitEditMode = useCallback(() => clearEditState(), [clearEditState]);
 
-  const { dataSource, editSession, onCancel, onSave, sessionDataSource } =
+  const {
+    editSession,
+    onCancel,
+    onSave,
+    sessionDataSource,
+    sourceDataSource,
+  } =
     useEditableTable({
       dataSource: sourceTableDataSource,
-      editSessionMode: editState.editSessionMode,
+      copyOption: editState.copyOption,
       isEditMode: editState.editing,
       onCancel: exitEditMode,
       onSave: exitEditMode,
@@ -727,11 +715,11 @@ const BulkEditTableTemplate = ({
   }, []);
 
   const editSelectedRows = useCallback(async () => {
-    setEditState({ editing: true, editSessionMode: "selected-rows" });
+    setEditState({ editing: true, copyOption: "Selected" });
   }, []);
 
   const insertRows = useCallback(async () => {
-    setEditState({ editing: true, editSessionMode: "empty-session-table" });
+    setEditState({ editing: true, copyOption: "Empty" });
   }, []);
 
   const handleSave = useCallback(() => {
@@ -742,7 +730,10 @@ const BulkEditTableTemplate = ({
     if (sessionDataSource) {
       showDialog(
         <DataEditingProvider editSession={editSession}>
-          <BulkEditPanel parentDs={dataSource} sessionDs={sessionDataSource} />
+          <BulkEditPanel
+            parentDs={sourceDataSource}
+            sessionDs={sessionDataSource}
+          />
         </DataEditingProvider>,
         "Edit rows",
         [
@@ -759,7 +750,6 @@ const BulkEditTableTemplate = ({
     }
   }, [
     closeDialog,
-    dataSource,
     editSession,
     handleSave,
     onCancel,
@@ -776,7 +766,7 @@ const BulkEditTableTemplate = ({
   return (
     <ContextMenuProvider {...contextMenuProps}>
       <SimulTable
-        dataSource={dataSource}
+        dataSource={sourceDataSource}
         tableName={vuuTable.table as SimulTableName}
       />
     </ContextMenuProvider>
@@ -972,7 +962,7 @@ const AddRowTableTemplate = () => {
     sessionDataSource: editSessionDataSource,
   } = useEditableTable({
     dataSource: instrumentsDataSource,
-    editSessionMode: "empty-session-table",
+    copyOption: "Empty",
     isEditMode: true,
     onCancel: keepEditSessionOpen,
     onSave: keepEditSessionOpen,

--- a/vuu-ui/showcase/src/examples/Table/Editing.mdx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.mdx
@@ -18,7 +18,10 @@ available for editing (the rows are copied from the source table). Exactly which
 
 ## I am an application author, I use vuu-ui components, how do I implement data editing in my app ?
 
-An EditSession should be instantiated and made available to the Table and its subcomponents through a _DataEditingProvider_.
+An EditSession should be instantiated and made available to the Table and its subcomponents through a _DataEditingProvider_. `useEditableTable`
+creates the session through the source datasource's `createSessionDataSource(copyOption)` API. Pass the hook's active `dataSource` directly to
+`Table`; it is the source datasource in view mode and the session datasource while editing. Use `sourceDataSource` for source-only controls such
+as statistics, filters, and external workflows.
 
 Table cells can be rendered with editable content for one or more table columns. Editing is enabled on a colunm, not on individual cells. Editing is enabled by setting the _editable_
 attribute to true on one or more of the ColumnDescriptors included in TableConfig. The actual edit control used to render the editable content will be an InputCell by default. This is
@@ -30,8 +33,7 @@ depending on the data.
 
 ```DataValueTypeDescriptor
     <DataEditingProvider editSession={editSession}>
-      <Table config={config} dataSource={dataSource}
-      />
+      <Table config={config} dataSource={dataSource} />
     </DataEditingProvider>
 ```
 
@@ -47,7 +49,7 @@ controls must implement the _onEdit_ callback prop, defined on the _TableCellRen
 - the number of edits currently applied
 - the number of invalid edits
 
-The edit lifecycle operations, beginEditSession, editCell and endEditSession are all instigated through the _EditSession_. It also
+The edit lifecycle operations, createSessionDataSource, editCell and endEditSession are all instigated through the _EditSession_. It also
 acts as an _EventEmitter_ emitting a state change event whenever significant status changes occur. UI controls that manage the overall edit session, e.g Save and Cancel buttons, use state maneged by the _EditSession_
 to determine their correct render status.
 


### PR DESCRIPTION
## Summary
- create every edit session through `createSessionDataSource` and expose lifecycle-selected active/source datasources from `useEditableTable`
- remove client datasource `beginEditSession` proxy state and route edits through each session datasource viewport
- preserve local session/source metadata, required session columns, failure retries, standalone workflows, and runtime Table switching

## Validation
- 80 focused Vitest tests passed
- Table editing Playwright component suite: 32 passed, 1 pre-existing skipped
- affected package builds passed (`vuu-data-editing`, `vuu-data-remote`, `vuu-data-test`)
- targeted Biome checks passed with pre-existing warnings only
- workspace TypeScript check remains blocked by 67 pre-existing errors (including the existing `EditSessionEvents`/`EventEmitter` constraint error)