### PR TITLE
Add InlineAddRow showcase

### DIFF
--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -6,12 +6,21 @@ import {
   EditableInstrumentsInlineEdit,
   TwoEditableInstruments,
 } from "../../../../../showcase/src/examples/Table/Editing.examples";
+import { InlineAddRow } from "../../../../../showcase/src/examples/Table/InlineAddRow.examples";
 import { expect } from "../../../../../playwright/customAssertions";
 import { TableOM } from "./TableOM";
 
 const IS_EDITABLE = true;
 const NOT_EDITABLE = false;
 const NOT_EDITING = false;
+
+test.describe("Inline add row", () => {
+  test("renders inputs in the table custom header", async ({ mount, page }) => {
+    await mount(<InlineAddRow />);
+
+    await expect(page.getByPlaceholder("Enter value").first()).toBeVisible();
+  });
+});
 
 test.describe("Editable table navigation", () => {
   test("smoke test", async ({ mount, page }) => {

--- a/vuu-ui/showcase/src/examples/DataTable/Tree.data.ts
+++ b/vuu-ui/showcase/src/examples/DataTable/Tree.data.ts
@@ -2757,6 +2757,14 @@ export default [
               path: "src/examples/Table/TableEditing.examples.tsx",
             },
           },
+          {
+            id: "Table/TableEditing/InlineAddRow",
+            label: "InlineAddRow",
+            nodeData: {
+              componentName: "InlineAddRow",
+              path: "src/examples/Table/InlineAddRow.examples.tsx",
+            },
+          },
         ],
       },
       {

--- a/vuu-ui/showcase/src/examples/Table/InlineAddRow.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/InlineAddRow.examples.tsx
@@ -1,0 +1,55 @@
+import {
+  DataEditingProvider,
+  useEditableTable,
+} from "@vuu-ui/vuu-data-editing";
+import { LocalDataSourceProvider, getSchema } from "@vuu-ui/vuu-data-test";
+import { Table } from "@vuu-ui/vuu-table";
+import { InlineAddRow as InlineAddRowHeader } from "@vuu-ui/vuu-table-extras";
+import type { TableConfig } from "@vuu-ui/vuu-table-types";
+import { useData } from "@vuu-ui/vuu-utils";
+import { useCallback, useMemo } from "react";
+
+const schema = getSchema("instruments");
+
+const tableConfig: TableConfig = {
+  columns: schema.columns,
+  columnDefaultWidth: 120,
+  rowSeparators: true,
+  zebraStripes: true,
+};
+
+const InlineAddRowTable = () => {
+  const { VuuDataSource } = useData();
+  const sourceDataSource = useMemo(
+    () => new VuuDataSource({ table: schema.table }),
+    [VuuDataSource],
+  );
+  const keepEditSessionOpen = useCallback(() => {}, []);
+  const { dataSource, editSession } = useEditableTable({
+    copyOption: "Empty",
+    dataSource: sourceDataSource,
+    isEditMode: true,
+    onCancel: keepEditSessionOpen,
+    onSave: keepEditSessionOpen,
+  });
+
+  return (
+    <DataEditingProvider editSession={editSession}>
+      <Table
+        config={tableConfig}
+        customHeader={InlineAddRowHeader}
+        dataSource={dataSource}
+        height={645}
+        renderBufferSize={10}
+        width={920}
+      />
+    </DataEditingProvider>
+  );
+};
+
+/** tags=data-consumer */
+export const InlineAddRow = () => (
+  <LocalDataSourceProvider>
+    <InlineAddRowTable />
+  </LocalDataSourceProvider>
+);


### PR DESCRIPTION
## Summary
- add a Table editing showcase that renders `InlineAddRow` as a custom header during an active empty edit session
- register the example in the showcase tree
- add a component test for the inline add-row header

## Validation
- Playwright component test: Inline add row (Chromium, Firefox, WebKit)
- targeted formatting and diff checks

`npm run typecheck` remains blocked by unrelated existing workspace errors.