### PR TITLE
Decouple stale update error from data editing

### DIFF
--- a/vuu-ui/package-lock.json
+++ b/vuu-ui/package-lock.json
@@ -15164,7 +15164,6 @@
       "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vuu-ui/vuu-data-editing": "2.2.1",
         "@vuu-ui/vuu-filter-parser": "2.2.1",
         "@vuu-ui/vuu-utils": "2.2.1"
       },
@@ -15199,7 +15198,6 @@
       "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vuu-ui/vuu-data-editing": "2.2.1",
         "@vuu-ui/vuu-data-local": "2.2.1",
         "@vuu-ui/vuu-utils": "2.2.1"
       },

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -7,7 +7,7 @@ import type {
   UndoRowChangeResult,
 } from "@vuu-ui/vuu-data-types";
 import type { RpcResult, VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
-import { EventEmitter, isRpcError } from "@vuu-ui/vuu-utils";
+import { EventEmitter, isRpcError, StaleUpdateError } from "@vuu-ui/vuu-utils";
 
 export type EditState = "clean" | "dirty" | "invalid" | "stale";
 
@@ -30,9 +30,6 @@ type CellEdit = {
   editedValue: VuuRowDataItemType;
   isValid: boolean;
 };
-
-// TODO can add more when when we know what the server implementation of error columns will look like
-export class StaleUpdateError extends Error {}
 
 type RowEditDetails = {
   /**

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -9,10 +9,10 @@ export {
 export {
   EditError,
   EditSession,
-  StaleUpdateError,
   type EditLifecycle,
   type EditState,
 } from "./EditSession";
+export { StaleUpdateError } from "@vuu-ui/vuu-utils";
 export {
   useEditableTable,
   type EditableTableHookProps,

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -3,8 +3,9 @@ import type {
   RpcResultError,
   RpcResultSuccess,
 } from "@vuu-ui/vuu-protocol-types";
+import { StaleUpdateError as UtilsStaleUpdateError } from "@vuu-ui/vuu-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { EditSession } from "../src";
+import { EditSession, StaleUpdateError } from "../src";
 
 type Editable = Required<EditApi>;
 type AddRow = Editable["addRow"];
@@ -180,6 +181,24 @@ describe("EditSession lifecycle", () => {
 
     await editSession.end();
     expect(editSession.lifecycle).toEqual({ status: "idle" });
+  });
+
+  it("re-exports and handles stale update errors", async () => {
+    const staleUpdateError = new StaleUpdateError("stale update");
+    const editStateListener = vi.fn();
+    endEdit = vi.fn().mockRejectedValue(staleUpdateError);
+    let dataSource: MockDataSource;
+    createSession = vi.fn(
+      async () => dataSource as unknown as DataSource,
+    ) as CreateSession;
+    dataSource = new MockDataSource(endEdit, createSession);
+    editSession = new EditSession(dataSource);
+    editSession.on("editState", editStateListener);
+
+    expect(StaleUpdateError).toBe(UtilsStaleUpdateError);
+    await editSession.begin();
+    await expect(editSession.end()).rejects.toBe(staleUpdateError);
+    expect(editStateListener).toHaveBeenCalledWith("stale");
   });
 
   it("runs edits and end operations on the created session datasource", async () => {

--- a/vuu-ui/packages/vuu-data-remote/package.json
+++ b/vuu-ui/packages/vuu-data-remote/package.json
@@ -19,7 +19,6 @@
     "@vuu-ui/vuu-protocol-types": "2.2.1"
   },
   "dependencies": {
-    "@vuu-ui/vuu-data-editing": "2.2.1",
     "@vuu-ui/vuu-filter-parser": "2.2.1",
     "@vuu-ui/vuu-utils": "2.2.1"
   }

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -1,4 +1,3 @@
-import { StaleUpdateError } from "@vuu-ui/vuu-data-editing";
 import type {
   CopyOption,
   DataSourceBase,
@@ -45,6 +44,7 @@ import {
   itemsOrOrderChanged,
   logger,
   Range,
+  StaleUpdateError,
   throttle,
   uuid,
 } from "@vuu-ui/vuu-utils";

--- a/vuu-ui/packages/vuu-data-test/package.json
+++ b/vuu-ui/packages/vuu-data-test/package.json
@@ -11,7 +11,6 @@
     "type-defs": "node ../../scripts/build-type-defs.mjs"
   },
   "dependencies": {
-    "@vuu-ui/vuu-data-editing": "2.2.1",
     "@vuu-ui/vuu-data-local": "2.2.1",
     "@vuu-ui/vuu-utils": "2.2.1"
   },

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -24,8 +24,12 @@ import type {
   VuuRpcServiceRequest,
   VuuTable,
 } from "@vuu-ui/vuu-protocol-types";
-import { StaleUpdateError } from "@vuu-ui/vuu-data-editing";
-import { isRpcSuccess, isTypeaheadRequest, uuid } from "@vuu-ui/vuu-utils";
+import {
+  isRpcSuccess,
+  isTypeaheadRequest,
+  StaleUpdateError,
+  uuid,
+} from "@vuu-ui/vuu-utils";
 import type {
   IVuuModule,
   RpcMenuService,

--- a/vuu-ui/packages/vuu-utils/src/errors.ts
+++ b/vuu-ui/packages/vuu-utils/src/errors.ts
@@ -1,0 +1,1 @@
+export class StaleUpdateError extends Error {}

--- a/vuu-ui/packages/vuu-utils/src/index.ts
+++ b/vuu-ui/packages/vuu-utils/src/index.ts
@@ -20,6 +20,7 @@ export * from "./datasource/datasource-utils";
 export * from "./date";
 export * from "./debug-utils";
 export * from "./event-emitter";
+export * from "./errors";
 export * from "./feature-utils";
 export * from "./filters";
 export * from "./form-utils";


### PR DESCRIPTION
## Summary
- move `StaleUpdateError` to `@vuu-ui/vuu-utils` and retain the data-editing re-export
- remove the data-editing dependency from data-remote and data-test
- verify stale-update lifecycle behavior and the compatibility re-export

## Validation
- `npx vitest run packages/vuu-data-editing/test/EditSession.lifecycle.test.ts packages/vuu-data-remote/test/VuuDataSource.test.ts`
- `npx biome check` on changed TypeScript files (pre-existing warnings only)