### PR TITLE
Test inline table editing

### DIFF
--- a/vuu-ui/packages/vuu-table-extras/src/inline-add-row/useInlineAddRow.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/inline-add-row/useInlineAddRow.ts
@@ -83,6 +83,7 @@ export const useInlineAddRow = ({ columns }: UseInlineAddRowProps) => {
     () => createSyntheticDataRow(newRowState, inlineAddColumns),
     [inlineAddColumns, newRowState],
   );
+  const previousValuesRef = useRef(newRowState.values);
 
   const focusEditor = useCallback((index: number) => {
     const cell =
@@ -104,6 +105,23 @@ export const useInlineAddRow = ({ columns }: UseInlineAddRowProps) => {
       focusEditor(firstInvalidIndex);
     }
   }, [focusEditor, newRowState.errors, visibleColumns]);
+
+  useEffect(() => {
+    const previousValues = previousValuesRef.current;
+    previousValuesRef.current = newRowState.values;
+    if (
+      Object.keys(previousValues).length > 0 &&
+      Object.keys(newRowState.values).length === 0 &&
+      Object.keys(newRowState.errors).length === 0
+    ) {
+      const firstEditableIndex = visibleColumns.findIndex((column) =>
+        isDataValueEditable(column, "insert"),
+      );
+      if (firstEditableIndex !== -1) {
+        requestAnimationFrame(() => focusEditor(firstEditableIndex));
+      }
+    }
+  }, [focusEditor, newRowState.errors, newRowState.values, visibleColumns]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -5,6 +5,8 @@ import {
   EditableInstruments,
   EditableInstrumentsInlineEdit,
   EditableInstrumentsWithInlineAddRow,
+  TestTableEmpty,
+  TestTableFIveRows,
   TwoEditableInstruments,
 } from "../../../../../showcase/src/examples/Table/Editing.examples";
 import { expect } from "../../../../../playwright/customAssertions";
@@ -97,6 +99,85 @@ test.describe("Inline add row", () => {
     await ric.dispatchEvent("vuu-commit");
 
     await expect(bbg).toBeFocused();
+  });
+});
+
+test.describe("Test table editing", () => {
+  test("inserts a valid row without leaving validation warnings in the inline add row", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestTableEmpty />);
+    await page.getByRole("radio", { name: "Edit" }).click();
+
+    const inlineAddRow = page.locator(".vuuInlineAddRow");
+    const id = inlineAddRow.getByRole("textbox", { name: "id", exact: true });
+    const description = inlineAddRow.getByRole("textbox", {
+      name: "description",
+    });
+    const quantity = inlineAddRow.getByRole("textbox", { name: "quantity" });
+    const price = inlineAddRow.getByRole("textbox", { name: "price" });
+    const externalId = inlineAddRow.getByRole("textbox", {
+      name: "externalId",
+    });
+
+    await id.fill("TEST-006");
+    await id.press("Enter");
+    await description.fill("Foxtrot");
+    await description.press("Enter");
+    await quantity.fill("72");
+    await quantity.press("Enter");
+    await price.fill("607.5");
+    await price.press("Enter");
+    await inlineAddRow.getByRole("checkbox").check();
+    await externalId.fill("1006");
+    await externalId.press("Enter");
+
+    await expect(id).toBeFocused();
+    await expect(id).toHaveValue("");
+    await expect(inlineAddRow.locator('[aria-invalid="true"]')).toHaveCount(0);
+    await expect(
+      page.getByRole("textbox", { name: "id", exact: true }).nth(1),
+    ).toHaveValue("TEST-006");
+  });
+
+  test("rejects alphabetic input in an existing numeric cell", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestTableFIveRows />);
+    await page.getByRole("radio", { name: "Edit" }).click();
+
+    const quantity = page.getByRole("textbox", { name: "quantity" }).nth(1);
+    await expect(quantity).toHaveValue("12");
+    await quantity.dblclick();
+    await quantity.pressSequentially("invalid");
+    await quantity.press("Enter");
+
+    await expect(quantity.locator("..")).toContainClass(
+      "vuuTableInputCell-error",
+    );
+  });
+
+  test("updates and deletes existing rows", async ({ mount, page }) => {
+    await mount(<TestTableFIveRows />);
+    await page.getByRole("radio", { name: "Edit" }).click();
+
+    const descriptionCell = page
+      .getByRole("textbox", { name: "description" })
+      .nth(1);
+    await expect(descriptionCell).toHaveValue("Alpha");
+    await descriptionCell.dblclick();
+    await descriptionCell.pressSequentially("Updated");
+    await descriptionCell.press("Enter");
+    await expect(page.getByRole("button", { name: "Submit" })).toBeEnabled();
+
+    await page
+      .getByRole("checkbox", { name: "Press space to select row" })
+      .first()
+      .click();
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByRole("button", { name: "Undo" })).toBeVisible();
   });
 });
 

--- a/vuu-ui/packages/vuu-table/src/cell-renderers/input-cell/useInputCell.ts
+++ b/vuu-ui/packages/vuu-table/src/cell-renderers/input-cell/useInputCell.ts
@@ -1,4 +1,4 @@
-import { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
+import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
 import type {
   RuntimeColumnDescriptor,
   TableCellEditHandler,
@@ -11,11 +11,11 @@ import {
   isRpcSuccess,
 } from "@vuu-ui/vuu-utils";
 import {
-  FocusEventHandler,
-  FormEventHandler,
-  KeyboardEvent,
+  type FocusEventHandler,
+  type FormEventHandler,
+  type KeyboardEvent,
   useCallback,
-  useMemo,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -55,13 +55,15 @@ export const useInputCell = <T extends string | number | boolean = string>({
   const initialValueRef = useRef<string>(value?.toString() ?? "");
   const isDirtyRef = useRef(false);
 
-  useMemo(() => {
-    if (initialValueRef.current !== value?.toString()) {
-      initialValueRef.current = stringValueOf(value);
+  useEffect(() => {
+    const nextValue = stringValueOf(value);
+    if (initialValueRef.current !== nextValue) {
+      initialValueRef.current = nextValue;
+      isDirtyRef.current = false;
       setEditState((editState) => ({
         ...editState,
         message: undefined,
-        value: stringValueOf(value),
+        value: nextValue,
       }));
     }
   }, [value]);


### PR DESCRIPTION
## Summary\n- add Playwright coverage for empty and five-row editable test tables\n- cover valid inserts, invalid numeric edits, updates, and deletes\n- reset inline-add draft cells and restore focus after successful insertion