### PR TITLE
Refactor edit session action tracking

### DIFF
--- a/vuu-ui/package-lock.json
+++ b/vuu-ui/package-lock.json
@@ -15072,6 +15072,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@salt-ds/core": "1.67.0",
+        "@vuu-ui/vuu-ui-controls": "2.2.1",
         "@vuu-ui/vuu-utils": "2.2.1",
         "@vuu-ui/vuu-utils2": "2.2.1"
       },

--- a/vuu-ui/packages/vuu-data-editing/package.json
+++ b/vuu-ui/packages/vuu-data-editing/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@salt-ds/core": "1.67.0",
+    "@vuu-ui/vuu-ui-controls": "2.2.1",
     "@vuu-ui/vuu-utils": "2.2.1",
     "@vuu-ui/vuu-utils2": "2.2.1"
   },

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -342,8 +342,6 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     const rowEdits = this.#rowEdits.get(key);
     const wasDeleted = this.#deletedRows.has(key);
 
-    if (!rowEdits?.cellEdits.size && !wasDeleted) return;
-
     this.#rowEdits.delete(key);
     if (wasDeleted) this.#deletedRows.delete(key);
 

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -48,6 +48,7 @@ type EditSessionEvents = {
   editState: (editState: EditState) => void;
   lifecycle: (lifecycle: EditLifecycle) => void;
   newRow: (newRowState: NewRowState) => void;
+  rowChangeUndone: (key: string) => void;
 };
 
 export class EditSession extends EventEmitter<EditSessionEvents> {
@@ -367,6 +368,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     if (wasInsertedRow) {
       this.addCount = this.#addCount - 1;
     }
+    this.emit("rowChangeUndone", key);
   }
 
   #clearEdits() {

--- a/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
@@ -1,9 +1,5 @@
 import { Button, Tooltip } from "@salt-ds/core";
-import type {
-  ColumnTypeRendering,
-  DataValueTypeDescriptor,
-  TableCellRendererProps,
-} from "@vuu-ui/vuu-table-types";
+import type { TableCellRendererProps } from "@vuu-ui/vuu-table-types";
 import { registerComponent } from "@vuu-ui/vuu-utils";
 import { useEditSession } from "./DataEditingProvider";
 
@@ -21,27 +17,17 @@ export const getUndoTooltipContent = (
         ? "Undo row edits"
         : undefined;
 
-export const UndoCellRenderer = ({
-  column,
-  dataRow,
-}: TableCellRendererProps) => {
+export const UndoCellRenderer = ({ dataRow }: TableCellRendererProps) => {
   const editSession = useEditSession();
-  const renderer = (column.type as DataValueTypeDescriptor)
-    ?.renderer as ColumnTypeRendering;
-  const sessionTableMessageColumn =
-    (renderer?.componentProps?.sessionTableMessageColumn as string) ?? "vuuMsg";
   const tooltipContent = getUndoTooltipContent(
     dataRow.vuu_action,
     editSession?.hasRowChanges(dataRow.key),
   );
-  const isRowChanged =
-    tooltipContent !== undefined ||
-    dataRow[sessionTableMessageColumn] === "SOFT_DELETED";
 
-  if (!isRowChanged) return null;
+  if (tooltipContent === undefined) return null;
 
   return (
-    <Tooltip content={tooltipContent ?? "Undo delete row"}>
+    <Tooltip content={tooltipContent}>
       <Button
         appearance="transparent"
         onClick={() => editSession?.undoRowChange(dataRow.key)}

--- a/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
@@ -4,6 +4,7 @@ import type {
   DataValueTypeDescriptor,
   TableCellRendererProps,
 } from "@vuu-ui/vuu-table-types";
+import { Icon } from "@vuu-ui/vuu-ui-controls";
 import { registerComponent } from "@vuu-ui/vuu-utils";
 import { useEditSession } from "./DataEditingProvider";
 
@@ -61,7 +62,7 @@ export const UndoCellRenderer = ({
         onClick={() => editSession?.undoRowChange(dataRow.key)}
         style={{ height: "100%", width: "100%" }}
       >
-        {icon ? <span aria-hidden data-icon={icon} /> : null}
+        {icon ? <Icon aria-hidden name={icon} /> : null}
         {text}
       </Button>
     </Tooltip>

--- a/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
@@ -1,9 +1,28 @@
 import { Button, Tooltip } from "@salt-ds/core";
-import type { TableCellRendererProps } from "@vuu-ui/vuu-table-types";
+import type {
+  ColumnTypeRendering,
+  DataValueTypeDescriptor,
+  TableCellRendererProps,
+} from "@vuu-ui/vuu-table-types";
 import { registerComponent } from "@vuu-ui/vuu-utils";
 import { useEditSession } from "./DataEditingProvider";
 
 export const UNDO_CELL_RENDERER = "vuu.undo-cell";
+
+export interface UndoCellRendererComponentProps {
+  icon?: string;
+  text?: string | false;
+}
+
+export const getUndoButtonContent = (
+  componentProps?: UndoCellRendererComponentProps,
+) => ({
+  icon: componentProps?.icon,
+  text:
+    componentProps?.text === undefined
+      ? "UNDO"
+      : componentProps.text || undefined,
+});
 
 export const getUndoTooltipContent = (
   action: unknown,
@@ -17,8 +36,16 @@ export const getUndoTooltipContent = (
         ? "Undo row edits"
         : undefined;
 
-export const UndoCellRenderer = ({ dataRow }: TableCellRendererProps) => {
+export const UndoCellRenderer = ({
+  column,
+  dataRow,
+}: TableCellRendererProps) => {
   const editSession = useEditSession();
+  const renderer = (column.type as DataValueTypeDescriptor)
+    ?.renderer as ColumnTypeRendering;
+  const { icon, text } = getUndoButtonContent(
+    renderer?.componentProps as UndoCellRendererComponentProps | undefined,
+  );
   const tooltipContent = getUndoTooltipContent(
     dataRow.vuu_action,
     editSession?.hasRowChanges(dataRow.key),
@@ -30,10 +57,12 @@ export const UndoCellRenderer = ({ dataRow }: TableCellRendererProps) => {
     <Tooltip content={tooltipContent}>
       <Button
         appearance="transparent"
+        aria-label={tooltipContent}
         onClick={() => editSession?.undoRowChange(dataRow.key)}
         style={{ height: "100%", width: "100%" }}
       >
-        Undo
+        {icon ? <span aria-hidden data-icon={icon} /> : null}
+        {text}
       </Button>
     </Tooltip>
   );

--- a/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
@@ -62,7 +62,7 @@ export const UndoCellRenderer = ({
         onClick={() => editSession?.undoRowChange(dataRow.key)}
         style={{ height: "100%", width: "100%" }}
       >
-        {icon ? <Icon aria-hidden name={icon} /> : null}
+        {icon ? <Icon name={icon} /> : null}
         {text}
       </Button>
     </Tooltip>

--- a/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
@@ -1,0 +1,56 @@
+import { Button, Tooltip } from "@salt-ds/core";
+import type {
+  ColumnTypeRendering,
+  DataValueTypeDescriptor,
+  TableCellRendererProps,
+} from "@vuu-ui/vuu-table-types";
+import { registerComponent } from "@vuu-ui/vuu-utils";
+import { useEditSession } from "./DataEditingProvider";
+
+export const UNDO_CELL_RENDERER = "vuu.undo-cell";
+
+export const getUndoTooltipContent = (
+  action: unknown,
+  hasRowChanges = false,
+) =>
+  action === "deleteRow"
+    ? "Undo delete row"
+    : action === "addRow"
+      ? "Undo insert row"
+      : action === "editCell" || hasRowChanges
+        ? "Undo row edits"
+        : undefined;
+
+export const UndoCellRenderer = ({
+  column,
+  dataRow,
+}: TableCellRendererProps) => {
+  const editSession = useEditSession();
+  const renderer = (column.type as DataValueTypeDescriptor)
+    ?.renderer as ColumnTypeRendering;
+  const sessionTableMessageColumn =
+    (renderer?.componentProps?.sessionTableMessageColumn as string) ?? "vuuMsg";
+  const tooltipContent = getUndoTooltipContent(
+    dataRow.vuu_action,
+    editSession?.hasRowChanges(dataRow.key),
+  );
+  const isRowChanged =
+    tooltipContent !== undefined ||
+    dataRow[sessionTableMessageColumn] === "SOFT_DELETED";
+
+  if (!isRowChanged) return null;
+
+  return (
+    <Tooltip content={tooltipContent ?? "Undo delete row"}>
+      <Button
+        appearance="transparent"
+        onClick={() => editSession?.undoRowChange(dataRow.key)}
+        style={{ height: "100%", width: "100%" }}
+      >
+        Undo
+      </Button>
+    </Tooltip>
+  );
+};
+
+registerComponent(UNDO_CELL_RENDERER, UndoCellRenderer, "cell-renderer");

--- a/vuu-ui/packages/vuu-data-editing/src/editActionRowClassNameGenerator.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/editActionRowClassNameGenerator.ts
@@ -1,0 +1,22 @@
+import type { DataRow } from "@vuu-ui/vuu-table-types";
+import { registerComponent } from "@vuu-ui/vuu-utils";
+
+export const EDIT_ACTION_ROW_CLASS_NAME_GENERATOR = "vuu-edit-actions";
+
+export const editActionRowClassNameGenerator = (dataRow: DataRow) => {
+  switch (dataRow.vuu_action) {
+    case "addRow":
+      return "vuuTableRow-inserted";
+    case "deleteRow":
+      return "vuuTableRow-deleted";
+  }
+};
+
+registerComponent(
+  EDIT_ACTION_ROW_CLASS_NAME_GENERATOR,
+  {
+    fn: editActionRowClassNameGenerator,
+    id: EDIT_ACTION_ROW_CLASS_NAME_GENERATOR,
+  },
+  "row-class-generator",
+);

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -19,6 +19,11 @@ export {
   editActionRowClassNameGenerator,
 } from "./editActionRowClassNameGenerator";
 export {
+  getUndoTooltipContent,
+  UNDO_CELL_RENDERER,
+  UndoCellRenderer,
+} from "./UndoCellRenderer";
+export {
   useEditableTable,
   type EditableTableHookProps,
   type EditMode,

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -15,6 +15,10 @@ export {
 } from "./EditSession";
 export { StaleUpdateError } from "@vuu-ui/vuu-utils";
 export {
+  EDIT_ACTION_ROW_CLASS_NAME_GENERATOR,
+  editActionRowClassNameGenerator,
+} from "./editActionRowClassNameGenerator";
+export {
   useEditableTable,
   type EditableTableHookProps,
   type EditMode,

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -19,9 +19,11 @@ export {
   editActionRowClassNameGenerator,
 } from "./editActionRowClassNameGenerator";
 export {
+  getUndoButtonContent,
   getUndoTooltipContent,
   UNDO_CELL_RENDERER,
   UndoCellRenderer,
+  type UndoCellRendererComponentProps,
 } from "./UndoCellRenderer";
 export {
   useEditableTable,

--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -9,6 +9,11 @@ import { useLayoutEffectSkipFirst } from "@vuu-ui/vuu-utils";
 import { useData } from "@vuu-ui/vuu-utils2";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EditSession, type EditLifecycle, type EditState } from "./EditSession";
+import { EDIT_ACTION_ROW_CLASS_NAME_GENERATOR } from "./editActionRowClassNameGenerator";
+
+const EDIT_ACTION_ROW_CLASS_NAME_GENERATORS = [
+  EDIT_ACTION_ROW_CLASS_NAME_GENERATOR,
+];
 
 export type EditMode = "edit" | "view";
 
@@ -171,6 +176,9 @@ export const useEditableTable = ({
     onDelete: handleDelete,
     onSave: handleSave,
     onUndoRowChange: handleUndoRowChange,
+    rowClassNameGenerators: isEditMode
+      ? EDIT_ACTION_ROW_CLASS_NAME_GENERATORS
+      : undefined,
     sessionDataSource,
     sourceDataSource,
   };

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
@@ -239,4 +239,32 @@ describe("EditSession", () => {
     expect(undoRowChange).toHaveBeenCalledWith("row-001");
     expect(insertedRowSession.addCount).toBe(0);
   });
+
+  it("emits the row key after undoing row changes", async () => {
+    const undoRowChange = vi.fn().mockResolvedValue({
+      data: undefined,
+      type: "SUCCESS_RESULT",
+    });
+    let editApi: EditApi;
+    editApi = {
+      createSessionDataSource: vi.fn(
+        async () => editApi as unknown as DataSource,
+      ),
+      editCell: vi.fn().mockResolvedValue({
+        data: undefined,
+        type: "SUCCESS_RESULT",
+      }),
+      endEditSession: vi.fn(),
+      undoRowChange,
+    };
+    const rowEditSession = new EditSession(editApi);
+    const rowChangeUndone = vi.fn();
+    rowEditSession.on("rowChangeUndone", rowChangeUndone);
+    await rowEditSession.begin();
+    await rowEditSession.commit("row-001", "name", "Alice", "Alicia", true);
+
+    await rowEditSession.undoRowChange("row-001");
+
+    expect(rowChangeUndone).toHaveBeenCalledWith("row-001");
+  });
 });

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
@@ -212,4 +212,31 @@ describe("EditSession", () => {
 
     await editSession.end();
   });
+
+  it("allows a newly inserted row to be undone without local cell edits", async () => {
+    const undoRowChange = vi.fn().mockResolvedValue({
+      data: { wasInsertedRow: true },
+      type: "SUCCESS_RESULT",
+    });
+    let editApi: EditApi;
+    editApi = {
+      addRow: vi.fn().mockResolvedValue({
+        data: undefined,
+        type: "SUCCESS_RESULT",
+      }),
+      createSessionDataSource: vi.fn(
+        async () => editApi as unknown as DataSource,
+      ),
+      endEditSession: vi.fn(),
+      undoRowChange,
+    };
+    const insertedRowSession = new EditSession(editApi);
+    await insertedRowSession.begin();
+    await insertedRowSession.addRow({ id: "row-001" });
+
+    await insertedRowSession.undoRowChange("row-001");
+
+    expect(undoRowChange).toHaveBeenCalledWith("row-001");
+    expect(insertedRowSession.addCount).toBe(0);
+  });
 });

--- a/vuu-ui/packages/vuu-data-editing/test/UndoCellRenderer.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/UndoCellRenderer.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getUndoTooltipContent } from "../src/UndoCellRenderer";
+
+describe("getUndoTooltipContent", () => {
+  it.each([
+    ["deleteRow", false, "Undo delete row"],
+    ["addRow", false, "Undo insert row"],
+    ["editCell", false, "Undo row edits"],
+    ["", true, "Undo row edits"],
+    ["", false, undefined],
+  ])("maps action %s and row-change state %s to the expected tooltip", (action, hasRowChanges, expectedTooltip) => {
+    expect(getUndoTooltipContent(action, hasRowChanges)).toBe(expectedTooltip);
+  });
+});

--- a/vuu-ui/packages/vuu-data-editing/test/UndoCellRenderer.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/UndoCellRenderer.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getUndoTooltipContent } from "../src/UndoCellRenderer";
+import {
+  getUndoButtonContent,
+  getUndoTooltipContent,
+} from "../src/UndoCellRenderer";
 
 describe("getUndoTooltipContent", () => {
   it.each([
@@ -10,5 +13,29 @@ describe("getUndoTooltipContent", () => {
     ["", false, undefined],
   ])("maps action %s and row-change state %s to the expected tooltip", (action, hasRowChanges, expectedTooltip) => {
     expect(getUndoTooltipContent(action, hasRowChanges)).toBe(expectedTooltip);
+  });
+
+  describe("getUndoButtonContent", () => {
+    it("defaults to UNDO text with no icon", () => {
+      expect(getUndoButtonContent()).toEqual({
+        icon: undefined,
+        text: "UNDO",
+      });
+    });
+
+    it.each([
+      [{ text: "REVERT" }, { icon: undefined, text: "REVERT" }],
+      [{ icon: "undo" }, { icon: "undo", text: "UNDO" }],
+      [
+        { icon: "undo", text: false },
+        { icon: "undo", text: undefined },
+      ],
+      [
+        { icon: "undo", text: "" },
+        { icon: "undo", text: undefined },
+      ],
+    ])("maps component props %o to button content", (componentProps, expected) => {
+      expect(getUndoButtonContent(componentProps)).toEqual(expected);
+    });
   });
 });

--- a/vuu-ui/packages/vuu-data-editing/test/editActionRowClassNameGenerator.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/editActionRowClassNameGenerator.test.ts
@@ -1,0 +1,18 @@
+import type { DataRow } from "@vuu-ui/vuu-table-types";
+import { describe, expect, it } from "vitest";
+import { editActionRowClassNameGenerator } from "../src/editActionRowClassNameGenerator";
+
+const dataRow = (vuu_action: string): DataRow => ({ vuu_action }) as DataRow;
+
+describe("editActionRowClassNameGenerator", () => {
+  it.each([
+    ["addRow", "vuuTableRow-inserted"],
+    ["deleteRow", "vuuTableRow-deleted"],
+    ["editCell", undefined],
+    ["", undefined],
+  ])("maps %s to the expected row class", (action, expectedClassName) => {
+    expect(editActionRowClassNameGenerator(dataRow(action))).toBe(
+      expectedClassName,
+    );
+  });
+});

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -672,7 +672,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
       const sessionColumns = combineColumnsWithAutosubscribeColumns(
         this.columns,
-        [this.#sessionTableMessageColumn, "setToDelete"].filter(
+        [this.#sessionTableMessageColumn, "vuu_action"].filter(
           (column): column is string => column !== undefined,
         ),
       );

--- a/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
@@ -152,7 +152,7 @@ describe("VuuDataSource", () => {
         expect(sessionDataSource?.columns).toEqual([
           "id",
           "vuuMsg",
-          "setToDelete",
+          "vuu_action",
         ]);
         expect(sessionDataSource?.viewport).toBe("session-instruments");
       });

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -171,9 +171,9 @@ export class TickingArrayDataSource extends ArrayDataSource {
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
-      const columns = this.config.columns.includes("setToDelete")
+      const columns = this.config.columns.includes("vuu_action")
         ? this.config.columns
-        : this.config.columns.concat("setToDelete");
+        : this.config.columns.concat("vuu_action");
       return this.#vuuModule?.createDataSource(
         sessionTable.table,
         sessionTable.table,

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -481,6 +481,7 @@ export abstract class VuuModule<T extends string = string>
             }
             deletedKeys.push(key);
           }
+          dataSource.select({ type: "DESELECT_ALL" });
         }
         return { type: "SUCCESS_RESULT", data: { deletedKeys } };
       }

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -512,13 +512,26 @@ export abstract class VuuModule<T extends string = string>
             errorMessage: `undoRowChange: source table not found for viewport ${viewPortId}`,
           };
         }
-        const sourceRow = sourceTable.findByKey(key);
-        if (!sourceRow) {
+        const sessionRow = sessionTable.findByKey(key);
+        if (!sessionRow) {
+          return {
+            type: "ERROR_RESULT",
+            errorMessage: `undoRowChange: session row not found for key ${key}`,
+          };
+        }
+        const action = sessionRow[sessionTable.map.vuu_action];
+        if (action === "addRow") {
           sessionTable.delete(key);
           return { type: "SUCCESS_RESULT", data: { wasInsertedRow: true } };
         }
-        const sessionRow = sessionTable.findByKey(key);
-        if (sessionRow) {
+        if (action === "deleteRow" || action === "editCell") {
+          const sourceRow = sourceTable.findByKey(key);
+          if (!sourceRow) {
+            return {
+              type: "ERROR_RESULT",
+              errorMessage: `undoRowChange: source row not found for key ${key}`,
+            };
+          }
           const restoredRow = sessionRow.slice();
           for (const column of sourceTable.schema.columns) {
             restoredRow[sessionTable.map[column.name]] =

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -434,7 +434,7 @@ export abstract class VuuModule<T extends string = string>
       const sessionTable = this.getSessionTable(viewPortId, false);
       if (sessionTable) {
         if (mode === "soft") {
-          sessionTable.update(key, "setToDelete", true);
+          sessionTable.update(key, "vuu_action", "deleteRow");
         } else {
           sessionTable.delete(key);
         }
@@ -475,7 +475,7 @@ export abstract class VuuModule<T extends string = string>
         if (selectedRowIds.length > 0) {
           for (const key of selectedRowIds) {
             if ((mode as DeleteRowMode) === "soft") {
-              sessionTable.update(key, "setToDelete", true);
+              sessionTable.update(key, "vuu_action", "deleteRow");
             } else {
               sessionTable.delete(key);
             }
@@ -525,7 +525,7 @@ export abstract class VuuModule<T extends string = string>
               sourceRow[sourceTable.map[column.name]];
           }
           sessionTable.updateRow(restoredRow);
-          sessionTable.update(key, "setToDelete", false);
+          sessionTable.update(key, "vuu_action", "");
         }
         return { type: "SUCCESS_RESULT", data: undefined };
       }
@@ -556,7 +556,8 @@ export abstract class VuuModule<T extends string = string>
     if (isEditCellRpcRequest(rpcRequest)) {
       const { viewPortId } = rpcRequest.context;
       const { column, data, key } = rpcRequest.params;
-      let targetTable: Table = this.#sessionTableMap[viewPortId];
+      const sessionTable = this.#sessionTableMap[viewPortId];
+      let targetTable: Table | undefined = sessionTable;
       if (!targetTable) {
         const { dataSource } = this.getSubscriptionByViewport(viewPortId);
         if (dataSource.table) {
@@ -567,6 +568,14 @@ export abstract class VuuModule<T extends string = string>
         try {
           assertUpdateIsValid(targetTable.schema, column as string, data);
           targetTable.update(key as string, column as string, data);
+          if (
+            sessionTable &&
+            sessionTable.findByKey(key as string)?.[
+              sessionTable.map.vuu_action
+            ] !== "addRow"
+          ) {
+            sessionTable.update(key as string, "vuu_action", "editCell");
+          }
           return {
             type: "SUCCESS_RESULT",
             data: undefined,
@@ -749,7 +758,7 @@ export abstract class VuuModule<T extends string = string>
       const columnMap = sessionTable.map;
       const columnCount = Object.keys(columnMap).length;
       const row: VuuDataRow = new Array(columnCount).fill("");
-      row[columnMap.setToDelete] = false;
+      row[columnMap.vuu_action] = "addRow";
       for (const [col, idx] of Object.entries(columnMap)) {
         if (data[col] !== undefined) {
           row[idx] = data[col];
@@ -781,7 +790,7 @@ export abstract class VuuModule<T extends string = string>
         if (rpcRequest.params.save === true) {
           let rejectedCount = 0;
           const vuuMsgIdx = sessionTable.map[this.#sessionTableMessageColumn];
-          const setToDeleteIdx = sessionTable.map.setToDelete;
+          const actionIdx = sessionTable.map.vuu_action;
           const sessionTimestampIdx = sessionTable.map.vuuUpdatedTimestamp;
           const sourceTimestampIdx = sourceTable.map.vuuUpdatedTimestamp;
           const sourceColumns = sourceTable.schema.columns;
@@ -791,7 +800,8 @@ export abstract class VuuModule<T extends string = string>
               sessionRow[sessionTable.map[sourceTable.schema.key]],
             );
             const currentRow = sourceTable.findByKey(key);
-            if (sessionRow[setToDeleteIdx]) {
+            const action = sessionRow[actionIdx];
+            if (action === "deleteRow") {
               if (currentRow) {
                 const sessionTimestamp = sessionRow[sessionTimestampIdx];
                 const sourceTimestamp = currentRow[sourceTimestampIdx];
@@ -813,14 +823,14 @@ export abstract class VuuModule<T extends string = string>
               continue;
             }
             if (sessionRow[vuuMsgIdx]) continue;
-            if (currentRow) {
+            if (action === "editCell" && currentRow) {
               for (const column of sourceColumns) {
                 const value = sessionRow[sessionTable.map[column.name]];
                 if (currentRow[sourceTable.map[column.name]] !== value) {
                   sourceTable.update(key, column.name, value);
                 }
               }
-            } else {
+            } else if (action === "addRow" && !currentRow) {
               sourceTable.insert(
                 sourceColumns.map(
                   (column) => sessionRow[sessionTable.map[column.name]],

--- a/vuu-ui/packages/vuu-data-test/src/session-table-utils.ts
+++ b/vuu-ui/packages/vuu-data-test/src/session-table-utils.ts
@@ -13,8 +13,8 @@ export const sessionTableRow = (
   if (!schema.columns.some(({ name }) => name === "vuuMsg")) {
     sessionRow.push("");
   }
-  if (!schema.columns.some(({ name }) => name === "setToDelete")) {
-    sessionRow.push(false);
+  if (!schema.columns.some(({ name }) => name === "vuu_action")) {
+    sessionRow.push("");
   }
   return sessionRow;
 };
@@ -41,8 +41,8 @@ export const sessionTableSchema = (schema: TableSchema): TableSchema => {
   if (!columns.some(({ name }) => name === "vuuMsg")) {
     columns.push({ name: "vuuMsg", serverDataType: "string" });
   }
-  if (!columns.some(({ name }) => name === "setToDelete")) {
-    columns.push({ name: "setToDelete", serverDataType: "boolean" });
+  if (!columns.some(({ name }) => name === "vuu_action")) {
+    columns.push({ name: "vuu_action", serverDataType: "string" });
   }
   return { ...schema, columns };
 };

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -42,7 +42,7 @@ function createDataSource() {
 }
 
 describe("sessionTableSchema", () => {
-  it("adds setToDelete as a boolean session-only column", () => {
+  it("adds vuu_action as a string session-only column", () => {
     const sessionSchema = sessionTableSchema({
       ...schema,
       columns: schema.columns.slice(0, 2),
@@ -52,7 +52,7 @@ describe("sessionTableSchema", () => {
       { name: "id", serverDataType: "string" },
       { name: "name", serverDataType: "string" },
       { name: "vuuMsg", serverDataType: "string" },
-      { name: "setToDelete", serverDataType: "boolean" },
+      { name: "vuu_action", serverDataType: "string" },
     ]);
   });
 
@@ -63,7 +63,7 @@ describe("sessionTableSchema", () => {
       sessionSchema.columns.filter(({ name }) => name === "vuuMsg"),
     ).toHaveLength(1);
     expect(
-      sessionSchema.columns.filter(({ name }) => name === "setToDelete"),
+      sessionSchema.columns.filter(({ name }) => name === "vuu_action"),
     ).toHaveLength(1);
   });
 
@@ -72,17 +72,17 @@ describe("sessionTableSchema", () => {
       "row-001",
       "Alice",
       "",
-      false,
+      "",
     ]);
     expect(
-      sessionTableRow(["row-001", "Alice", "", false], {
+      sessionTableRow(["row-001", "Alice", "", ""], {
         ...schema,
         columns: schema.columns.concat({
-          name: "setToDelete",
-          serverDataType: "boolean",
+          name: "vuu_action",
+          serverDataType: "string",
         }),
       }),
-    ).toEqual(["row-001", "Alice", "", false]);
+    ).toEqual(["row-001", "Alice", "", ""]);
   });
 });
 

--- a/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
@@ -91,4 +91,29 @@ describe("VuuModule edit actions", () => {
       "Caroline",
     );
   });
+
+  it("uses vuu_action to undo inserts, edits, and deletes", async () => {
+    await sessionDataSource.editCell("row-001", "name", "Alicia");
+    await sessionDataSource.deleteRow("row-002", "soft");
+    await sessionDataSource.addRow({ id: "row-003", name: "Carol" });
+
+    await sessionDataSource.undoRowChange("row-001");
+    await sessionDataSource.undoRowChange("row-002");
+    const insertResult = await sessionDataSource.undoRowChange("row-003");
+
+    expect(sessionTable.findByKey("row-001")?.[sessionTable.map.name]).toBe(
+      "Alice",
+    );
+    expect(
+      sessionTable.findByKey("row-001")?.[sessionTable.map.vuu_action],
+    ).toBe("");
+    expect(
+      sessionTable.findByKey("row-002")?.[sessionTable.map.vuu_action],
+    ).toBe("");
+    expect(sessionTable.findByKey("row-003")).toBeUndefined();
+    expect(insertResult).toEqual({
+      type: "SUCCESS_RESULT",
+      data: { wasInsertedRow: true },
+    });
+  });
 });

--- a/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
@@ -1,0 +1,94 @@
+import type { DataSourceConfig, TableSchema } from "@vuu-ui/vuu-data-types";
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildDataColumnMapFromSchema, Table } from "../src/Table";
+import type { TickingArrayDataSource } from "../src/TickingArrayDataSource";
+import { VuuModule } from "../src/core/module/VuuModule";
+
+const schema: TableSchema = {
+  columns: [
+    { name: "id", serverDataType: "string" },
+    { name: "name", serverDataType: "string" },
+  ],
+  key: "id",
+  table: { module: "EDIT_TEST", table: "items" },
+};
+
+class EditingModule extends VuuModule<"items"> {
+  protected menus = { items: undefined };
+  protected schemas = { items: schema };
+  protected tables: Record<"items", Table>;
+  protected visualLinks = undefined;
+
+  constructor(table: Table) {
+    super("EDIT_TEST");
+    this.tables = { items: table };
+  }
+
+  getSessionTableForTest() {
+    const [sessionTable] = Object.values(this.sessionTableMap);
+    if (!sessionTable) {
+      throw Error("Expected an active session table");
+    }
+    return sessionTable;
+  }
+}
+
+describe("VuuModule edit actions", () => {
+  let module: EditingModule;
+  let sourceTable: Table;
+  let sessionDataSource: TickingArrayDataSource;
+  let sessionTable: Table;
+
+  beforeEach(async () => {
+    sourceTable = new Table(
+      schema,
+      [
+        ["row-001", "Alice"],
+        ["row-002", "Bob"],
+      ],
+      buildDataColumnMapFromSchema(schema),
+    );
+    module = new EditingModule(sourceTable);
+    const sourceDataSource = module.createDataSource("items", "source-vp", {
+      columns: ["id", "name"],
+    } as DataSourceConfig) as TickingArrayDataSource;
+    sessionDataSource = (await sourceDataSource.createSessionDataSource(
+      "All",
+    )) as TickingArrayDataSource;
+    sessionTable = module.getSessionTableForTest();
+  });
+
+  it("records each edit RPC and preserves addRow after editing an inserted row", async () => {
+    await sessionDataSource.editCell("row-001", "name", "Alicia");
+    await sessionDataSource.addRow({ id: "row-003", name: "Carol" });
+    await sessionDataSource.editCell("row-003", "name", "Caroline");
+    await sessionDataSource.deleteRow("row-002", "soft");
+
+    expect(
+      sessionTable.findByKey("row-001")?.[sessionTable.map.vuu_action],
+    ).toBe("editCell");
+    expect(
+      sessionTable.findByKey("row-002")?.[sessionTable.map.vuu_action],
+    ).toBe("deleteRow");
+    expect(
+      sessionTable.findByKey("row-003")?.[sessionTable.map.vuu_action],
+    ).toBe("addRow");
+  });
+
+  it("applies recorded actions to the source table when the session is saved", async () => {
+    await sessionDataSource.editCell("row-001", "name", "Alicia");
+    await sessionDataSource.addRow({ id: "row-003", name: "Carol" });
+    await sessionDataSource.editCell("row-003", "name", "Caroline");
+    await sessionDataSource.deleteRow("row-002", "soft");
+
+    await sessionDataSource.endEditSession(true);
+
+    expect(sourceTable.findByKey("row-001")?.[sourceTable.map.name]).toBe(
+      "Alicia",
+    );
+    expect(sourceTable.findByKey("row-002")).toBeUndefined();
+    expect(sourceTable.findByKey("row-003")?.[sourceTable.map.name]).toBe(
+      "Caroline",
+    );
+  });
+});

--- a/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
@@ -116,4 +116,25 @@ describe("VuuModule edit actions", () => {
       data: { wasInsertedRow: true },
     });
   });
+
+  it("deselects all rows after deleting the selected rows", async () => {
+    sessionDataSource.select({
+      preserveExistingSelection: false,
+      rowKey: "row-001",
+      type: "SELECT_ROW",
+    });
+    sessionDataSource.select({
+      preserveExistingSelection: true,
+      rowKey: "row-002",
+      type: "SELECT_ROW",
+    });
+
+    const result = await sessionDataSource.deleteSelectedRows("soft");
+
+    expect(result).toEqual({
+      type: "SUCCESS_RESULT",
+      data: { deletedKeys: ["row-001", "row-002"] },
+    });
+    expect(sessionDataSource.getSelectedRowIds()).toEqual([]);
+  });
 });

--- a/vuu-ui/packages/vuu-table/src/bulk-edit/BulkEditPanel.tsx
+++ b/vuu-ui/packages/vuu-table/src/bulk-edit/BulkEditPanel.tsx
@@ -1,9 +1,9 @@
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
-import { DataSource, RpcResponse } from "@vuu-ui/vuu-data-types";
+import type { DataSource, RpcResponse } from "@vuu-ui/vuu-data-types";
 import type { ColumnDescriptor } from "@vuu-ui/vuu-table-types";
 import cx from "clsx";
-import { HTMLAttributes, ReactElement, useMemo } from "react";
+import { type HTMLAttributes, type ReactElement, useMemo } from "react";
 import { Table } from "../Table";
 import { ColumnCascadingUpdateEditor } from "./ColumnCascadingUpdateEditor";
 import { InsertNewRowEditor } from "./InsertNewRowEditor";
@@ -24,6 +24,7 @@ export interface BulkEditPanelProps extends HTMLAttributes<HTMLDivElement> {
    */
   sessionDs: DataSource;
   response?: RpcResponse;
+  rowClassNameGenerators?: string[];
   mainTableName?: string;
   /**
    * The parent dataSource. This is where the edits will be applied once confirmed
@@ -39,6 +40,7 @@ export const BulkEditPanel = ({
   showColumnCascadingUpdateEditor = false,
   showInsertNewRowEditor = false,
   parentDs,
+  rowClassNameGenerators,
   style,
   width = 600,
   ...htmlAttributes
@@ -52,6 +54,7 @@ export const BulkEditPanel = ({
 
   const { onBulkChange, onRowChange, tableConfig } = useBulkEditPanel({
     columns,
+    rowClassNameGenerators,
     sessionDs,
   });
 

--- a/vuu-ui/packages/vuu-table/src/bulk-edit/useBulkEditPanel.ts
+++ b/vuu-ui/packages/vuu-table/src/bulk-edit/useBulkEditPanel.ts
@@ -1,10 +1,13 @@
 import { buildValidationChecker } from "@vuu-ui/vuu-data-react";
-import { VuuRpcServiceRequest } from "@vuu-ui/vuu-protocol-types";
-import { DataValueTypeDescriptor, TableConfig } from "@vuu-ui/vuu-table-types";
+import type { VuuRpcServiceRequest } from "@vuu-ui/vuu-protocol-types";
+import type {
+  DataValueTypeDescriptor,
+  TableConfig,
+} from "@vuu-ui/vuu-table-types";
 import { hasValidationRules, isTypeDescriptor } from "@vuu-ui/vuu-utils";
 import { useCallback, useMemo, useState } from "react";
 import type { BulkEditPanelProps } from "./BulkEditPanel";
-import { EditValueChangeHandler } from "./useColumnCascadingEditor";
+import type { EditValueChangeHandler } from "./useColumnCascadingEditor";
 
 const addRenderer = (
   colType: DataValueTypeDescriptor,
@@ -20,11 +23,12 @@ const addRenderer = (
 
 export type BulkEditPanelHookProps = Pick<
   BulkEditPanelProps,
-  "columns" | "sessionDs"
+  "columns" | "rowClassNameGenerators" | "sessionDs"
 >;
 
 export const useBulkEditPanel = ({
   columns,
+  rowClassNameGenerators,
   sessionDs: dataSource,
 }: BulkEditPanelHookProps) => {
   const [rowState, setRowState] = useState(true);
@@ -55,8 +59,9 @@ export const useBulkEditPanel = ({
       columnLayout: "fit",
       columnDefaultWidth: 100,
       rowSeparators: true,
+      rowClassNameGenerators,
     };
-  }, [columns, dataSource.columns]);
+  }, [columns, dataSource.columns, rowClassNameGenerators]);
 
   const handleRowChange = useCallback(
     (isValid: boolean) => {

--- a/vuu-ui/packages/vuu-table/src/data-row/DataRow.ts
+++ b/vuu-ui/packages/vuu-table/src/data-row/DataRow.ts
@@ -234,7 +234,7 @@ function createColumnMap(
           `[DataRow] calculated column with invalid serverDataType ${name}`,
         );
       }
-    } else if (name === "setToDelete" && i === cols.length - 1) {
+    } else if (name === "vuu_action" && i === cols.length - 1) {
       // column on a session table, always in last place
       columnMap[name] = { index: i + 10, type: "string" };
     } else {

--- a/vuu-ui/packages/vuu-table/src/table-cell/TableCell.tsx
+++ b/vuu-ui/packages/vuu-table/src/table-cell/TableCell.tsx
@@ -6,7 +6,12 @@ import type {
   TableCellProps,
 } from "@vuu-ui/vuu-table-types";
 import { isDataValueEditable } from "@vuu-ui/vuu-utils";
-import { type MouseEventHandler, useCallback, useState } from "react";
+import {
+  type MouseEventHandler,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { applyHighlighting } from "../applyHighlighting";
 import { useCell } from "../useCell";
 
@@ -35,6 +40,18 @@ export const TableCell = ({
   const [editedDuringCurrentSession, setEditingDuringCurrentSession] = useState<
     boolean | undefined
   >(undefined);
+
+  useEffect(() => {
+    const handleRowChangeUndone = (key: string) => {
+      if (key === dataRow.key) {
+        setEditingDuringCurrentSession(false);
+      }
+    };
+    editSession?.on("rowChangeUndone", handleRowChangeUndone);
+    return () => {
+      editSession?.removeListener("rowChangeUndone", handleRowChangeUndone);
+    };
+  }, [dataRow.key, editSession]);
 
   const handleDataItemEdited = useCallback<TableCellEditHandler>(
     async (editState, editPhase) => {

--- a/vuu-ui/packages/vuu-ui-controls/src/icon-button/Icon.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/icon-button/Icon.tsx
@@ -33,6 +33,7 @@ export const Icon = ({
   return (
     <span
       {...htmlAttributes}
+      aria-hidden
       className={cx(classBase, className)}
       data-icon={name}
       role="img"

--- a/vuu-ui/packages/vuu-utils/src/column-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/column-utils.ts
@@ -1116,8 +1116,8 @@ export const assertAllColumnsAreIncludedInSubscription = (
 ) => {
   const unsubscribedColumns: string[] = [];
   for (const column of columns) {
-    // temp exclusion for setToDelte, this will be removed later
-    if (column.source !== "client" && column.name !== 'setToDelete' && !columnNames?.includes(column.name)) {
+    // temp exclusion for vuu_action, this will be removed later
+    if (column.source !== "client" && column.name !== 'vuu_action' && !columnNames?.includes(column.name)) {
       unsubscribedColumns.push(column.name);
     }
   }

--- a/vuu-ui/sample-apps/feature-module-admin/src/useModuleAdmin.ts
+++ b/vuu-ui/sample-apps/feature-module-admin/src/useModuleAdmin.ts
@@ -27,23 +27,6 @@ export const useModuleAdmin = () => {
     });
   }, [VuuDataSource]);
 
-  const config = useMemo<TableConfig>(
-    () => ({
-      columnLayout: "static",
-      columns:
-        editMode === "edit"
-          ? moduleColumnDescriptors.map((col) =>
-              editableColumns.includes(col.name)
-                ? { ...col, editable: true }
-                : col,
-            )
-          : moduleColumnDescriptors,
-      rowSeparators: true,
-      zebraStripes: true,
-    }),
-    [editMode],
-  );
-
   const exitEditMode = useCallback(() => {
     setEditMode("view");
   }, []);
@@ -56,6 +39,7 @@ export const useModuleAdmin = () => {
     lifecycle,
     onCancel,
     onSave,
+    rowClassNameGenerators,
   } = useEditableTable({
     dataSource,
     isEditMode: editMode === "edit",
@@ -63,13 +47,23 @@ export const useModuleAdmin = () => {
     onSave: exitEditMode,
   });
 
-  // if (error) {
-  //   return { error, status: "error" };
-  // }
-
-  // if (!config || !dataSource) {
-  //   return { status: "loading" };
-  // }
+  const config = useMemo<TableConfig>(
+    () => ({
+      columnLayout: "static",
+      columns:
+        editMode === "edit"
+          ? moduleColumnDescriptors.map((col) =>
+              editableColumns.includes(col.name)
+                ? { ...col, editable: true }
+                : col,
+            )
+          : moduleColumnDescriptors,
+      rowClassNameGenerators,
+      rowSeparators: true,
+      zebraStripes: true,
+    }),
+    [editMode, rowClassNameGenerators],
+  );
 
   return {
     canCancel,

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -1,4 +1,4 @@
-import { Button, ToggleButton, ToggleButtonGroup, Tooltip } from "@salt-ds/core";
+import { Button, ToggleButton, ToggleButtonGroup } from "@salt-ds/core";
 import {
   ContextMenuItemDescriptor,
   ContextMenuProvider,
@@ -24,12 +24,11 @@ import {
   DataEditingProvider,
   EditButtons,
   type EditMode,
+  UNDO_CELL_RENDERER,
   useEditableTable,
-  useEditSession,
 } from "@vuu-ui/vuu-data-editing";
 import {
   ColumnDescriptor,
-  ColumnTypeRendering,
   DataRow,
   DataValueTypeDescriptor,
   TableCellEditHandler,
@@ -89,7 +88,7 @@ const UNDO_DELETE_COLUMN: ColumnDescriptor = {
   type: {
     name: "string",
     renderer: {
-      name: "example.undo-cell",
+      name: UNDO_CELL_RENDERER,
       componentProps: {
         sessionTableMessageColumn: "vuuMsg",
       },
@@ -734,41 +733,6 @@ const CustomCell = ({
 };
 
 registerComponent("example.color-coded-editor", CustomCell, "cell-renderer");
-
-const UndoCellRenderer = ({ column, dataRow }: TableCellRendererProps) => {
-  const editSession = useEditSession();
-  const renderer = (column.type as DataValueTypeDescriptor)
-    ?.renderer as ColumnTypeRendering;
-  const sessionTableMessageColumn =
-    (renderer?.componentProps?.sessionTableMessageColumn as string) ?? "vuuMsg";
-
-  const action = dataRow.vuu_action;
-  const tooltipContent =
-    action === "deleteRow"
-      ? "Undo delete row"
-      : action === "addRow"
-        ? "Undo insert row"
-        : action === "editCell" || editSession?.hasRowChanges(dataRow.key)
-          ? "Undo row edits"
-          : undefined;
-  const isRowChanged =
-    tooltipContent !== undefined ||
-    dataRow[sessionTableMessageColumn] === "SOFT_DELETED";
-
-  if (!isRowChanged) return null;
-  return (
-    <Tooltip content={tooltipContent ?? "Undo delete row"}>
-      <Button
-        appearance="transparent"
-        onClick={() => editSession?.undoRowChange(dataRow.key)}
-        style={{ height: "100%", width: "100%" }}
-      >
-        Undo
-      </Button>
-    </Tooltip>
-  );
-};
-registerComponent("example.undo-cell", UndoCellRenderer, "cell-renderer");
 
 export const EditableInstrumentsCustomCellRenderer = () => {
   const editableType = useMemo<DataValueTypeDescriptor>(

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -1,4 +1,4 @@
-import { Button, ToggleButton, ToggleButtonGroup } from "@salt-ds/core";
+import { Button, ToggleButton, ToggleButtonGroup, Tooltip } from "@salt-ds/core";
 import {
   ContextMenuItemDescriptor,
   ContextMenuProvider,
@@ -737,28 +737,35 @@ registerComponent("example.color-coded-editor", CustomCell, "cell-renderer");
 
 const UndoCellRenderer = ({ column, dataRow }: TableCellRendererProps) => {
   const editSession = useEditSession();
-  const renderer = (column.type as DataValueTypeDescriptor)?.renderer as ColumnTypeRendering;
+  const renderer = (column.type as DataValueTypeDescriptor)
+    ?.renderer as ColumnTypeRendering;
   const sessionTableMessageColumn =
     (renderer?.componentProps?.sessionTableMessageColumn as string) ?? "vuuMsg";
 
-  // For cell edits: #rowEdits is populated synchronously so hasRowChanges works immediately.
-  // For soft-deleted rows: #deletedRows is populated after the RPC await, so we read
-  // the sessionTableMessageColumn directly from the row data — it is always present
-  // when the row re-renders.
+  const action = dataRow.vuu_action;
+  const tooltipContent =
+    action === "deleteRow"
+      ? "Undo delete row"
+      : action === "addRow"
+        ? "Undo insert row"
+        : action === "editCell" || editSession?.hasRowChanges(dataRow.key)
+          ? "Undo row edits"
+          : undefined;
   const isRowChanged =
-    editSession?.hasRowChanges(dataRow.key) ||
-    dataRow.vuu_action === "deleteRow" ||
+    tooltipContent !== undefined ||
     dataRow[sessionTableMessageColumn] === "SOFT_DELETED";
 
   if (!isRowChanged) return null;
   return (
-    <Button
-      appearance="transparent"
-      onClick={() => editSession?.undoRowChange(dataRow.key)}
-      style={{ height: "100%", width: "100%" }}
-    >
-      Undo
-    </Button>
+    <Tooltip content={tooltipContent ?? "Undo delete row"}>
+      <Button
+        appearance="transparent"
+        onClick={() => editSession?.undoRowChange(dataRow.key)}
+        style={{ height: "100%", width: "100%" }}
+      >
+        Undo
+      </Button>
+    </Tooltip>
   );
 };
 registerComponent("example.undo-cell", UndoCellRenderer, "cell-renderer");

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -89,9 +89,6 @@ const UNDO_DELETE_COLUMN: ColumnDescriptor = {
     name: "string",
     renderer: {
       name: UNDO_CELL_RENDERER,
-      componentProps: {
-        sessionTableMessageColumn: "vuuMsg",
-      },
     },
   }
 };

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -152,6 +152,7 @@ const EditTableTemplate = ({
     editSession,
     onCancel,
     onSave,
+    rowClassNameGenerators,
     sourceDataSource,
   } = useEditableTable({
     dataSource: sourceTableDataSource,
@@ -242,14 +243,15 @@ const EditTableTemplate = ({
                       : { ...col, editable: true },
             ).concat({
               hidden: showInlineAddRow,
-              name: "setToDelete",
+              name: "vuu_action",
             } as ColumnDescriptor),
         columnDefaultWidth: 150,
+        rowClassNameGenerators,
         rowSeparators: true,
         zebraStripes: true,
       };
     },
-    [editMode, editableType, showInlineAddRow],
+    [editMode, editableType, rowClassNameGenerators, showInlineAddRow],
   );
 
   return (
@@ -386,6 +388,7 @@ const EditableInstrumentsTemplate = ({
     onCancel,
     onDelete,
     onSave,
+    rowClassNameGenerators,
     sourceDataSource,
   } = useEditableTable({
     dataSource: sourceTableDataSource,
@@ -404,7 +407,7 @@ const EditableInstrumentsTemplate = ({
   );
 
   const isRowSelectable = useCallback(
-    (dataRow: DataRow) => dataRow.setToDelete !== true,
+    (dataRow: DataRow) => dataRow.vuu_action !== "deleteRow",
     [],
   );
 
@@ -425,17 +428,18 @@ const EditableInstrumentsTemplate = ({
                 : { ...col, editable: true },
             ).concat(
               {
-                name: 'setToDelete',
+                name: "vuu_action",
                 hidden: true,
               },
               UNDO_DELETE_COLUMN),
 
         columnDefaultWidth: 150,
+        rowClassNameGenerators,
         rowSeparators: true,
         zebraStripes: true,
       };
     },
-    [editMode],
+    [editMode, rowClassNameGenerators],
   );
 
   return (
@@ -552,6 +556,7 @@ const EditableTestTableTemplate = ({
     onCancel,
     onDelete,
     onSave,
+    rowClassNameGenerators,
     sourceDataSource,
   } = useEditableTable({
     dataSource: sourceTableDataSource,
@@ -570,7 +575,7 @@ const EditableTestTableTemplate = ({
   );
 
   const isRowSelectable = useCallback(
-    (dataRow: DataRow) => dataRow.setToDelete !== true,
+    (dataRow: DataRow) => dataRow.vuu_action !== "deleteRow",
     [],
   );
 
@@ -583,12 +588,13 @@ const EditableTestTableTemplate = ({
           tableSchema.columns.map<ColumnDescriptor>((column) => ({
             ...column,
             editable: true,
-          })).concat({ hidden: true, name: "setToDelete" }, UNDO_DELETE_COLUMN),
+          })).concat({ hidden: true, name: "vuu_action" }, UNDO_DELETE_COLUMN),
       columnDefaultWidth: 150,
+      rowClassNameGenerators,
       rowSeparators: true,
       zebraStripes: true,
     }),
-    [editMode, tableSchema.columns],
+    [editMode, rowClassNameGenerators, tableSchema.columns],
   );
 
   return (
@@ -740,7 +746,9 @@ const UndoCellRenderer = ({ column, dataRow }: TableCellRendererProps) => {
   // the sessionTableMessageColumn directly from the row data — it is always present
   // when the row re-renders.
   const isRowChanged =
-    editSession?.hasRowChanges(dataRow.key) || dataRow.setToDelete === true || dataRow[sessionTableMessageColumn] === "SOFT_DELETED";
+    editSession?.hasRowChanges(dataRow.key) ||
+    dataRow.vuu_action === "deleteRow" ||
+    dataRow[sessionTableMessageColumn] === "SOFT_DELETED";
 
   if (!isRowChanged) return null;
   return (
@@ -886,6 +894,7 @@ const BulkEditTableTemplate = ({
     editSession,
     onCancel,
     onSave,
+    rowClassNameGenerators,
     sessionDataSource,
     sourceDataSource,
   } =
@@ -919,6 +928,7 @@ const BulkEditTableTemplate = ({
         <DataEditingProvider editSession={editSession}>
           <BulkEditPanel
             parentDs={sourceDataSource}
+            rowClassNameGenerators={rowClassNameGenerators}
             sessionDs={sessionDataSource}
           />
         </DataEditingProvider>,
@@ -1056,9 +1066,11 @@ const addRowsSessionTableConfig: TableConfig = {
 const AddRowPanel = ({
   addRowDataSource,
   editSessionDataSource,
+  rowClassNameGenerators,
 }: {
   addRowDataSource: DataSource;
   editSessionDataSource: DataSource;
+  rowClassNameGenerators?: string[];
 }) => {
   const [insertErrorMessage, setInsertErrorMessage] = useState<
     string | undefined
@@ -1098,7 +1110,10 @@ const AddRowPanel = ({
     >
       <div style={{ flex: "0 0 340px", minHeight: 0, overflow: "hidden" }}>
         <Table
-          config={addRowsSessionTableConfig}
+          config={{
+            ...addRowsSessionTableConfig,
+            rowClassNameGenerators,
+          }}
           dataSource={editSessionDataSource}
           renderBufferSize={5}
           style={{ height: "100%", width: "100%" }}
@@ -1146,6 +1161,7 @@ const AddRowTableTemplate = () => {
 
   const {
     dataSource: addRowDataSource,
+    rowClassNameGenerators,
     sessionDataSource: editSessionDataSource,
   } = useEditableTable({
     dataSource: instrumentsDataSource,
@@ -1170,6 +1186,7 @@ const AddRowTableTemplate = () => {
           <AddRowPanel
             addRowDataSource={addRowDataSource}
             editSessionDataSource={editSessionDataSource}
+            rowClassNameGenerators={rowClassNameGenerators}
           />
         ) : (
           <div


### PR DESCRIPTION
## Summary
- replace the session-table `setToDelete` flag with `vuu_action` values for add, edit, and delete RPCs
- preserve `addRow` when newly inserted rows are edited and apply recorded actions when saving
- add edit-mode row styling for inserted and deleted rows through a row class-name generator
- update affected data sources, examples, and tests

## Testing
- focused Vitest suite: 63 tests passed
- `vuu-data-editing`, `vuu-data-test`, and `vuu-table` package builds passed