### PR TITLE
Fix session editing row deletion state

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/src/edit-utils.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/edit-utils.tsx
@@ -4,6 +4,9 @@ import { formatDate } from "@vuu-ui/vuu-utils";
 const timeFormatter = formatDate({ time: "hh:mm:ss" });
 const dataRowEditErrors = Symbol("vuuDataRowEditErrors");
 
+export const isEditRowReadOnly = (dataRow: DataRow) =>
+  dataRow.vuu_action === "deleteRow";
+
 type DataRowWithEditErrors = DataRow & {
   [dataRowEditErrors]?: Record<string, string>;
 };

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -1,5 +1,9 @@
 export { DataEditingProvider, useEditSession } from "./DataEditingProvider";
-export { getVuuEditMessage, withDataRowEditErrors } from "./edit-utils";
+export {
+  getVuuEditMessage,
+  isEditRowReadOnly,
+  withDataRowEditErrors,
+} from "./edit-utils";
 export { EditButtons, type EditButtonProps } from "./EditButtons";
 export {
   EditModeProvider,

--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -50,7 +50,6 @@ export const useEditableTable = ({
 }: EditableTableHookProps) => {
   const { VuuDataSource } = useData();
   const [selectionCount, setSelectionCount] = useState(0);
-  const [deleteCount, setDeleteCount] = useState(0);
   useLayoutEffectSkipFirst(() => {
     console.warn("[useEditableTable] columns and or table changed");
   }, [columns, table]);
@@ -109,7 +108,6 @@ export const useEditableTable = ({
 
   const handleDelete = useCallback(async () => {
     await editSession.deleteSelectedRows();
-    setSelectionCount(0);
   }, [editSession]);
 
   const handleUndoRowChange = useCallback(
@@ -125,7 +123,6 @@ export const useEditableTable = ({
   useEffect(() => {
     const handleEditState = (nextEditState: EditState) => {
       setEditState(nextEditState);
-      setDeleteCount(editSession.deleteCount);
     };
     const handleLifecycle = (nextLifecycle: EditLifecycle) => {
       setLifecycle(nextLifecycle);
@@ -171,7 +168,7 @@ export const useEditableTable = ({
     dataSource,
     editSession,
     lifecycle,
-    hasSelection: selectionCount > 0 || deleteCount > 0,
+    hasSelection: selectionCount > 0,
     onCancel: handleCancel,
     onDelete: handleDelete,
     onSave: handleSave,

--- a/vuu-ui/packages/vuu-data-editing/test/editActionRowClassNameGenerator.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/editActionRowClassNameGenerator.test.ts
@@ -1,6 +1,7 @@
 import type { DataRow } from "@vuu-ui/vuu-table-types";
 import { describe, expect, it } from "vitest";
 import { editActionRowClassNameGenerator } from "../src/editActionRowClassNameGenerator";
+import { isEditRowReadOnly } from "../src/edit-utils";
 
 const dataRow = (vuu_action: string): DataRow => ({ vuu_action }) as DataRow;
 
@@ -14,5 +15,13 @@ describe("editActionRowClassNameGenerator", () => {
     expect(editActionRowClassNameGenerator(dataRow(action))).toBe(
       expectedClassName,
     );
+  });
+
+  describe("isEditRowReadOnly", () => {
+    it("only marks deleted edit-session rows as read-only", () => {
+      expect(isEditRowReadOnly(dataRow("deleteRow"))).toBe(true);
+      expect(isEditRowReadOnly(dataRow("addRow"))).toBe(false);
+      expect(isEditRowReadOnly(dataRow("editCell"))).toBe(false);
+    });
   });
 });

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -580,6 +580,12 @@ export abstract class VuuModule<T extends string = string>
       }
       if (targetTable) {
         try {
+          const sessionRow = sessionTable?.findByKey(key as string);
+          if (
+            sessionRow?.[sessionTable.map.vuu_action] === "deleteRow"
+          ) {
+            throw Error("editCell: cannot edit a deleted row");
+          }
           assertUpdateIsValid(targetTable.schema, column as string, data);
           targetTable.update(key as string, column as string, data);
           if (

--- a/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
@@ -137,4 +137,25 @@ describe("VuuModule edit actions", () => {
     });
     expect(sessionDataSource.getSelectedRowIds()).toEqual([]);
   });
+
+  it("rejects edits to deleted session rows", async () => {
+    await sessionDataSource.deleteRow("row-002", "soft");
+
+    const result = await sessionDataSource.editCell(
+      "row-002",
+      "name",
+      "Robert",
+    );
+
+    expect(result).toEqual({
+      type: "ERROR_RESULT",
+      errorMessage: "editCell: cannot edit a deleted row",
+    });
+    expect(sessionTable.findByKey("row-002")?.[sessionTable.map.name]).toBe(
+      "Bob",
+    );
+    expect(sessionTable.findByKey("row-002")?.[sessionTable.map.vuu_action]).toBe(
+      "deleteRow",
+    );
+  });
 });

--- a/vuu-ui/packages/vuu-table-extras/src/cell-renderers/dropdown-cell/DropdownCell.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/cell-renderers/dropdown-cell/DropdownCell.tsx
@@ -8,6 +8,7 @@ import {
   isRpcSuccess,
   registerComponent,
 } from "@vuu-ui/vuu-utils";
+import { isEditRowReadOnly } from "@vuu-ui/vuu-data-editing";
 import cx from "clsx";
 import { Dropdown, Option } from "@salt-ds/core";
 import { useComponentCssInjection } from "@salt-ds/styles";
@@ -47,6 +48,7 @@ export const DropdownCell = memo(
 
     const [open, setOpen] = useState(false);
     const dataValue = dataRow[column.name] as string | number;
+    const readOnly = isEditRowReadOnly(dataRow);
     const { values } = useLookupValues(column, dataValue);
     const valueRef = useRef<ListOption>(undefined);
 
@@ -117,6 +119,7 @@ export const DropdownCell = memo(
         onOpenChange={handleOpenChange}
         onSelectionChange={handleSelectionChange}
         open={open}
+        readOnly={readOnly}
         selected={selectedOption ? [selectedOption] : []}
         value={selectedOption?.label}
       >

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -1094,7 +1094,10 @@ test.describe("Session table editing (createSessionTable)", () => {
     ).not.toBeVisible();
 
     const table = new TableOM(page.getByRole("table"));
-    const deleteButton = page.getByRole("button", { name: "Delete" });
+    const deleteButton = page.getByRole("button", {
+      exact: true,
+      name: "Delete",
+    });
 
     await table.locateCell(2, 1).click();
     await deleteButton.click();

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -985,6 +985,9 @@ test.describe("Session table editing (createSessionTable)", () => {
 
     const undoButton = table.row(2).getByRole("button", { name: "Undo" });
     await expect(undoButton).toBeVisible();
+    await expect(table.locateCell(2, 2).getByRole("textbox")).toHaveAttribute(
+      "readonly",
+    );
     await expect(page.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 

--- a/vuu-ui/packages/vuu-table/src/cell-renderers/checkbox-cell/CheckboxCell.tsx
+++ b/vuu-ui/packages/vuu-table/src/cell-renderers/checkbox-cell/CheckboxCell.tsx
@@ -1,6 +1,7 @@
 import { MouseEvent, KeyboardEventHandler, memo, useCallback } from "react";
 import { TableCellRendererProps } from "@vuu-ui/vuu-table-types";
 import { Checkbox } from "@salt-ds/core";
+import { isEditRowReadOnly } from "@vuu-ui/vuu-data-editing";
 import {
   dataColumnAndKeyUnchanged,
   dispatchCustomEvent,
@@ -25,6 +26,7 @@ export const CheckboxCell = memo(
     });
 
     const isChecked = !!dataRow[column.name];
+    const readOnly = isEditRowReadOnly(dataRow);
 
     const handleCommit = useCallback(
       (value: boolean) => async (evt: MouseEvent) => {
@@ -61,6 +63,7 @@ export const CheckboxCell = memo(
       <Checkbox
         checked={isChecked}
         className={className}
+        disabled={readOnly}
         onClick={handleCommit(!isChecked)}
         onKeyDown={handleKeyDown}
       />

--- a/vuu-ui/packages/vuu-table/src/cell-renderers/input-cell/InputCell.tsx
+++ b/vuu-ui/packages/vuu-table/src/cell-renderers/input-cell/InputCell.tsx
@@ -3,7 +3,10 @@ import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
 import type { TableCellRendererProps } from "@vuu-ui/vuu-table-types";
 import { Icon } from "@vuu-ui/vuu-ui-controls";
-import { getVuuEditMessage } from "@vuu-ui/vuu-data-editing";
+import {
+  getVuuEditMessage,
+  isEditRowReadOnly,
+} from "@vuu-ui/vuu-data-editing";
 import {
   dataDescriptorTypeToVuuRowDataItemType,
   registerComponent,
@@ -28,6 +31,7 @@ export const InputCell = ({
     window: targetWindow,
   });
   const dataValue = dataRow[column.name] as number | string;
+  const readOnly = isEditRowReadOnly(dataRow);
 
   const { align = "left" } = column;
 
@@ -89,6 +93,7 @@ export const InputCell = ({
         "aria-invalid": editRejectedMessage ? true : undefined,
         "aria-label": column.label,
       }}
+      readOnly={readOnly}
       startAdornment={startAdornment}
     />
   );

--- a/vuu-ui/packages/vuu-table/src/cell-renderers/toggle-cell/ToggleCell.tsx
+++ b/vuu-ui/packages/vuu-table/src/cell-renderers/toggle-cell/ToggleCell.tsx
@@ -17,6 +17,7 @@ import cx from "clsx";
 
 import { memo, useCallback } from "react";
 import { CycleStateButton } from "@vuu-ui/vuu-ui-controls";
+import { isEditRowReadOnly } from "@vuu-ui/vuu-data-editing";
 
 import toggleCellCss from "./ToggleCell.css";
 
@@ -46,6 +47,7 @@ export const ToggleCell = memo(function ToggleCell({
 
   const values = getValueList(column);
   const value = dataRow[column.name] as string;
+  const readOnly = isEditRowReadOnly(dataRow);
 
   const handleCommit = useCallback<CommitHandler<HTMLButtonElement>>(
     async (evt, newValue) => {
@@ -65,6 +67,7 @@ export const ToggleCell = memo(function ToggleCell({
     <CycleStateButton
       appearance="solid"
       className={cx(classBase, `${classBase}-${column.name}`)}
+      disabled={readOnly}
       onCommit={handleCommit}
       sentiment="accented"
       value={value}

--- a/vuu-ui/packages/vuu-utils/src/column-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/column-utils.ts
@@ -1557,6 +1557,7 @@ export const dataColumnAndKeyUnchanged = (
 ) =>
   p.column === p1.column &&
   p.dataRow.key === p1.dataRow.key &&
+  p.dataRow.vuu_action === p1.dataRow.vuu_action &&
   p.column.valueFormatter(p.dataRow[p.column.name]) ===
   p1.column.valueFormatter(p1.dataRow[p1.column.name]);
 


### PR DESCRIPTION
## Summary
- disable the Delete button after a successful delete-selected operation clears row selection
- keep selection enabled when the delete RPC fails
- make deleted session rows read-only across input, dropdown, checkbox, and toggle renderers
- reject direct edit RPCs against deleted session rows
- refresh memoized editable cells when `vuu_action` changes

## Testing
- targeted Playwright component tests passed across Chromium, Firefox, and WebKit
- focused Vitest suites passed
- affected data-editing, table, table-extras, and data-test package builds passed