### PR TITLE
Fix edit session state ownership

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/src/EditButtons.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditButtons.tsx
@@ -27,7 +27,9 @@ export const EditButtons = ({
   onSave,
   saveLabel = "Save",
 }: EditButtonProps) => {
-  const [editState, setEditState] = useState<EditState>("clean");
+  const [editState, setEditState] = useState<EditState>(
+    () => editSession?.editState ?? "clean",
+  );
 
   const handleSave = useCallback(async () => {
     if (confirmSave) {
@@ -47,6 +49,7 @@ export const EditButtons = ({
 
   useEffect(() => {
     if (editSession) {
+      setEditState(editSession.editState);
       editSession.on("editState", setEditState);
       return () => editSession.removeListener("editState", setEditState);
     }

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -30,6 +30,7 @@ export type EditLifecycle =
     };
 
 export class EditError extends Error {}
+export class SupersededEditError extends Error {}
 
 type CellEdit = {
   originalValue: VuuRowDataItemType;
@@ -45,10 +46,10 @@ type RowEditDetails = {
 };
 
 type EditSessionEvents = {
+  cellEditChanged: (key: string, columnName: string) => void;
   editState: (editState: EditState) => void;
   lifecycle: (lifecycle: EditLifecycle) => void;
   newRow: (newRowState: NewRowState) => void;
-  rowChangeUndone: (key: string) => void;
 };
 
 export class EditSession extends EventEmitter<EditSessionEvents> {
@@ -58,10 +59,15 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
    */
   #rowEdits = new Map<string, RowEditDetails>();
   #deletedRows = new Set<string>();
+  #deleteRevision = 0;
+  #rowDeleteRevisions = new Map<string, number>();
   #editCount = 0;
   #deleteCount = 0;
   #addCount = 0;
   #invalidCount = 0;
+  #isStale = false;
+  #commitRevision = 0;
+  #cellCommitRevisions = new Map<string, Map<string, number>>();
   #deleteMode: DeleteRowMode;
   #sourceTableDataSource?: EditApi;
   #sessionDataSource?: DataSource;
@@ -127,6 +133,9 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     if (this.#invalidCount > 0) {
       return "invalid";
     }
+    if (this.#isStale) {
+      return "stale";
+    }
     return this.#editCount === 0 &&
       this.#deleteCount === 0 &&
       this.#addCount === 0
@@ -146,6 +155,14 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
       const oldState = this.editState;
       this.#editCount = editCount;
       this.#invalidCount = invalidCount;
+      this.#emitEditStateChange(oldState);
+    }
+  }
+
+  #setStale(isStale: boolean) {
+    if (isStale !== this.#isStale) {
+      const oldState = this.editState;
+      this.#isStale = isStale;
       this.#emitEditStateChange(oldState);
     }
   }
@@ -295,6 +312,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     if (deletedKeys && deletedKeys.length > 0) {
       let newCount = 0;
       for (const key of deletedKeys) {
+        this.#rowDeleteRevisions.set(key, ++this.#deleteRevision);
         if (!this.#deletedRows.has(key)) {
           this.#deletedRows.add(key);
           newCount++;
@@ -330,6 +348,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     for (const key of keys) {
       if (this.#deletedRows.has(key)) {
         this.#deletedRows.delete(key);
+        this.#rowDeleteRevisions.delete(key);
         this.deleteCount = this.#deleteCount - 1;
       }
     }
@@ -339,27 +358,58 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     return this.#rowEdits.has(key) || this.#deletedRows.has(key);
   }
 
+  isCellEdited(key: string, columnName: string): boolean {
+    const cellEdit = this.#rowEdits.get(key)?.cellEdits.get(columnName);
+    return (
+      cellEdit?.isValid === true &&
+      cellEdit.originalValue !== cellEdit.editedValue
+    );
+  }
+
   async undoRowChange(key: string): Promise<void> {
     if (!this.inEditMode) return;
 
-    const rowEdits = this.#rowEdits.get(key);
+    const undoRevision = this.#commitRevision;
+    const deleteRevisionAtRequest = this.#rowDeleteRevisions.get(key);
+    const rowEditsAtRequest = this.#rowEdits.get(key);
+    const columnsAtRequest = new Set(rowEditsAtRequest?.cellEdits.keys());
     const wasDeleted = this.#deletedRows.has(key);
-
-    this.#rowEdits.delete(key);
-    if (wasDeleted) this.#deletedRows.delete(key);
-
     const response = await this.dataSource?.undoRowChange?.(key);
 
     if (isRpcError(response)) {
-      // Restore on failure
-      if (rowEdits) this.#rowEdits.set(key, rowEdits);
-      if (wasDeleted) this.#deletedRows.add(key);
       return;
     }
 
-    // Update counters after confirmed success
-    if (rowEdits) this.#refreshEditCounts();
-    if (wasDeleted) {
+    const rowEdits = this.#rowEdits.get(key);
+    if (rowEdits) {
+      const changedColumns: string[] = [];
+      for (const columnName of columnsAtRequest) {
+        const latestRevision =
+          this.#cellCommitRevisions.get(key)?.get(columnName) ?? 0;
+        if (latestRevision > undoRevision) {
+          continue;
+        }
+        if (this.isCellEdited(key, columnName)) {
+          changedColumns.push(columnName);
+        }
+        rowEdits.cellEdits.delete(columnName);
+        this.#setCellCommitRevision(key, columnName);
+      }
+      if (rowEdits.cellEdits.size === 0) {
+        this.#rowEdits.delete(key);
+      }
+      this.#refreshEditCounts();
+      for (const columnName of changedColumns) {
+        this.emit("cellEditChanged", key, columnName);
+      }
+    }
+    if (
+      wasDeleted &&
+      this.#deletedRows.has(key) &&
+      this.#rowDeleteRevisions.get(key) === deleteRevisionAtRequest
+    ) {
+      this.#deletedRows.delete(key);
+      this.#rowDeleteRevisions.delete(key);
       this.deleteCount = this.#deleteCount - 1;
     }
 
@@ -370,22 +420,34 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     if (wasInsertedRow) {
       this.addCount = this.#addCount - 1;
     }
-    this.emit("rowChangeUndone", key);
   }
 
   #clearEdits() {
+    const oldState = this.editState;
+    const editedCells = [...this.#rowEdits].flatMap(([key, { cellEdits }]) =>
+      [...cellEdits.keys()]
+        .filter((columnName) => this.isCellEdited(key, columnName))
+        .map((columnName) => [key, columnName] as const),
+    );
     this.#rowEdits.clear();
     this.#deletedRows.clear();
+    this.#rowDeleteRevisions.clear();
+    this.#cellCommitRevisions.clear();
     this.#editCount = 0;
     this.#deleteCount = 0;
     this.#addCount = 0;
     this.#invalidCount = 0;
+    this.#isStale = false;
     this.#setNewRowState({
       columns: this.#newRowState.columns,
       errors: {},
       submitting: false,
       values: {},
     });
+    for (const [key, columnName] of editedCells) {
+      this.emit("cellEditChanged", key, columnName);
+    }
+    this.#emitEditStateChange(oldState);
   }
 
   #setLifecycle(lifecycle: EditLifecycle) {
@@ -445,6 +507,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
         }
 
         this.#sessionDataSource = sessionDataSource;
+        this.#setStale(false);
         this.#setLifecycle({ status: "active", sessionDataSource });
         return sessionDataSource;
       } catch (cause) {
@@ -490,7 +553,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
       } catch (cause) {
         const error = cause instanceof Error ? cause : new Error(String(cause));
         if (error instanceof StaleUpdateError) {
-          this.emit("editState", "stale");
+          this.#setStale(true);
         }
         this.#setLifecycle({
           status: "error",
@@ -516,7 +579,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     );
   }
 
-  getOrCreateRowEdits(key: string): RowEditDetails {
+  #getOrCreateRowEdits(key: string): RowEditDetails {
     const rowEditDetails = this.#rowEdits.get(key);
     if (rowEditDetails) {
       return rowEditDetails;
@@ -529,13 +592,15 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     }
   }
 
-  storeCellEdit(
+  #storeCellEdit(
+    key: string,
     cellEdits: Map<string, CellEdit>,
     column: string,
     originalValue: VuuRowDataItemType,
     editedValue: VuuRowDataItemType,
     isValid: boolean,
   ) {
+    const wasEdited = this.isCellEdited(key, column);
     const existingCellEdit = cellEdits.get(column);
     const cellEdit: CellEdit = {
       originalValue: existingCellEdit?.originalValue ?? originalValue,
@@ -549,7 +614,23 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
       cellEdits.set(column, cellEdit);
     }
     this.#refreshEditCounts();
+    if (wasEdited !== this.isCellEdited(key, column)) {
+      this.emit("cellEditChanged", key, column);
+    }
     return cellEdit;
+  }
+
+  #setCellCommitRevision(key: string, columnName: string) {
+    const revision = ++this.#commitRevision;
+    const rowRevisions =
+      this.#cellCommitRevisions.get(key) ?? new Map<string, number>();
+    rowRevisions.set(columnName, revision);
+    this.#cellCommitRevisions.set(key, rowRevisions);
+    return revision;
+  }
+
+  #isLatestCellCommit(key: string, columnName: string, revision: number) {
+    return this.#cellCommitRevisions.get(key)?.get(columnName) === revision;
   }
 
   async commit(
@@ -558,7 +639,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     originalValue: VuuRowDataItemType,
     typedValue: string | number | boolean,
     isValid: boolean,
-  ) {
+  ): Promise<RpcResult> {
     if (
       this.#lifecycle.status !== "active" &&
       !(
@@ -568,12 +649,13 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     ) {
       throw new Error("No edit session in progress");
     }
-    const rowEditDetails = this.getOrCreateRowEdits(key);
+    const revision = this.#setCellCommitRevision(key, columnName);
+    const rowEditDetails = this.#getOrCreateRowEdits(key);
+    const { cellEdits } = rowEditDetails;
 
     if (isValid) {
-      const { cellEdits } = rowEditDetails;
-
-      const cellEdit = this.storeCellEdit(
+      const cellEdit = this.#storeCellEdit(
+        key,
         cellEdits,
         columnName,
         originalValue,
@@ -587,36 +669,41 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
           columnName,
           typedValue,
         );
+        if (!this.#isLatestCellCommit(key, columnName, revision)) {
+          throw new SupersededEditError(
+            `Edit response superseded for ${key}:${columnName}`,
+          );
+        }
+        const currentCellEdits = this.#getOrCreateRowEdits(key).cellEdits;
         if (isRpcError(response)) {
-          this.storeCellEdit(
-            cellEdits,
+          this.#storeCellEdit(
+            key,
+            currentCellEdits,
             columnName,
             cellEdit.originalValue,
             typedValue,
             false,
           );
-        } else if (cellEdits.size === 0) {
+        } else if (currentCellEdits.size === 0) {
           this.#rowEdits.delete(key);
         }
 
-        return {
-          editedDuringCurrentSession: cellEdit.originalValue !== typedValue,
-          ...response,
-        };
+        return response;
       }
       if (cellEdits.size === 0) {
         this.#rowEdits.delete(key);
       }
+      return { data: undefined, type: "SUCCESS_RESULT" };
     } else {
-      const { cellEdits } = rowEditDetails;
-      this.storeCellEdit(
+      this.#storeCellEdit(
+        key,
         cellEdits,
         columnName,
         originalValue,
         typedValue,
         isValid,
       );
-      return { editedDuringCurrentSession: false };
+      return { data: undefined, type: "SUCCESS_RESULT" };
     }
   }
 }

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -1,4 +1,5 @@
 export { DataEditingProvider, useEditSession } from "./DataEditingProvider";
+export { useCellEdited } from "./useCellEdited";
 export {
   getVuuEditMessage,
   isEditRowReadOnly,
@@ -13,6 +14,7 @@ export {
 export {
   EditError,
   EditSession,
+  SupersededEditError,
   type EditLifecycle,
   type NewRowState,
   type EditState,

--- a/vuu-ui/packages/vuu-data-editing/src/useCellEdited.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useCellEdited.ts
@@ -1,0 +1,34 @@
+import { useCallback, useSyncExternalStore } from "react";
+import type { EditSession } from "./EditSession";
+
+export const useCellEdited = (
+  editSession: EditSession | undefined,
+  key: string,
+  columnName: string,
+) => {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!editSession) {
+        return () => undefined;
+      }
+      const handleCellEditChanged = (
+        changedKey: string,
+        changedColumnName: string,
+      ) => {
+        if (changedKey === key && changedColumnName === columnName) {
+          onStoreChange();
+        }
+      };
+      editSession.on("cellEditChanged", handleCellEditChanged);
+      return () =>
+        editSession.removeListener("cellEditChanged", handleCellEditChanged);
+    },
+    [columnName, editSession, key],
+  );
+  const getSnapshot = useCallback(
+    () => editSession?.isCellEdited(key, columnName) ?? false,
+    [columnName, editSession, key],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+};

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -241,6 +241,55 @@ describe("EditSession lifecycle", () => {
     await editSession.begin();
     await expect(editSession.end()).rejects.toBe(staleUpdateError);
     expect(editStateListener).toHaveBeenCalledWith("stale");
+    expect(editSession.editState).toBe("stale");
+  });
+
+  it("keeps stale authoritative until a successful retry ends the session", async () => {
+    const staleUpdateError = new StaleUpdateError("stale update");
+    endEdit = vi
+      .fn()
+      .mockRejectedValueOnce(staleUpdateError)
+      .mockResolvedValueOnce(undefined);
+    let dataSource: MockDataSource;
+    createSession = vi.fn(
+      async () => dataSource as unknown as DataSource,
+    ) as CreateSession;
+    dataSource = new MockDataSource(endEdit, createSession);
+    editSession = new EditSession(dataSource);
+
+    await editSession.begin();
+    await editSession.commit("row-1", "price", 100, 101, true);
+    await expect(editSession.end(true)).rejects.toBe(staleUpdateError);
+    expect(editSession.editState).toBe("stale");
+
+    await editSession.end(true, true);
+    expect(editSession.editState).toBe("clean");
+
+    await editSession.begin();
+    expect(editSession.editState).toBe("clean");
+  });
+
+  it("prioritizes validation over stale and restores stale after correction", async () => {
+    const staleUpdateError = new StaleUpdateError("stale update");
+    endEdit = vi.fn().mockRejectedValue(staleUpdateError);
+    let dataSource: MockDataSource;
+    createSession = vi.fn(
+      async () => dataSource as unknown as DataSource,
+    ) as CreateSession;
+    dataSource = new MockDataSource(endEdit, createSession);
+    editSession = new EditSession(dataSource);
+
+    await editSession.begin();
+    await editSession.commit("row-1", "price", 100, 101, true);
+    await expect(editSession.end(true)).rejects.toBe(staleUpdateError);
+    await editSession.commit("row-1", "price", 100, "invalid", false);
+
+    expect(editSession.editState).toBe("invalid");
+    expect(editSession.invalidCount).toBe(1);
+
+    await editSession.commit("row-1", "price", 100, 102, true);
+    expect(editSession.editState).toBe("stale");
+    expect(editSession.invalidCount).toBe(0);
   });
 
   it("runs edits and end operations on the created session datasource", async () => {
@@ -390,6 +439,125 @@ describe("EditSession lifecycle", () => {
       editSession.invalidCount,
       editSession.editState,
     ]).toEqual([0, 0, "clean"]);
+  });
+
+  it("ignores superseded commit responses and keeps the newest cell state", async () => {
+    const first = deferred<RpcResultError>();
+    const second = deferred<RpcResultSuccess>();
+    editCell = vi
+      .fn<EditCell>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    let dataSource: MockDataSource;
+    createSession = vi.fn(
+      async () => dataSource as unknown as DataSource,
+    ) as CreateSession;
+    dataSource = new MockDataSource(endEdit, createSession, editCell);
+    editSession = new EditSession(dataSource);
+    await editSession.begin();
+
+    const firstCommit = editSession.commit("row-1", "price", 100, 101, true);
+    const secondCommit = editSession.commit("row-1", "price", 101, 102, true);
+
+    second.resolve(SUCCESS);
+    await secondCommit;
+    first.resolve(ERROR);
+    await expect(firstCommit).rejects.toThrow(
+      "Edit response superseded for row-1:price",
+    );
+
+    expect(editSession.isCellEdited("row-1", "price")).toBe(true);
+    expect([
+      editSession.editCount,
+      editSession.invalidCount,
+      editSession.editState,
+    ]).toEqual([1, 0, "dirty"]);
+  });
+
+  it("keeps concurrent cell responses attached to current row state", async () => {
+    const firstRevert = deferred<RpcResultSuccess>();
+    const secondRevert = deferred<RpcResultError>();
+    editCell = vi
+      .fn<EditCell>()
+      .mockResolvedValueOnce(SUCCESS)
+      .mockResolvedValueOnce(SUCCESS)
+      .mockReturnValueOnce(firstRevert.promise)
+      .mockReturnValueOnce(secondRevert.promise);
+    let dataSource: MockDataSource;
+    createSession = vi.fn(
+      async () => dataSource as unknown as DataSource,
+    ) as CreateSession;
+    dataSource = new MockDataSource(endEdit, createSession, editCell);
+    editSession = new EditSession(dataSource);
+    await editSession.begin();
+    await editSession.commit("row-1", "price", 100, 101, true);
+    await editSession.commit("row-1", "size", 10, 11, true);
+
+    const firstCommit = editSession.commit("row-1", "price", 101, 100, true);
+    const secondCommit = editSession.commit("row-1", "size", 11, 10, true);
+    firstRevert.resolve(SUCCESS);
+    await firstCommit;
+    secondRevert.resolve(ERROR);
+    await secondCommit;
+
+    expect([
+      editSession.editCount,
+      editSession.invalidCount,
+      editSession.editState,
+    ]).toEqual([0, 1, "invalid"]);
+  });
+
+  it("undoes only edits that existed when the undo request began", async () => {
+    const pendingUndo = deferred<RpcResultSuccess>();
+    let dataSource: EditApi;
+    dataSource = {
+      createSessionDataSource: vi.fn(
+        async () => dataSource as unknown as DataSource,
+      ),
+      editCell: vi.fn().mockResolvedValue(SUCCESS),
+      endEditSession: vi.fn(),
+      undoRowChange: vi.fn().mockReturnValue(pendingUndo.promise),
+    };
+    editSession = new EditSession(dataSource);
+    await editSession.begin();
+    await editSession.commit("row-1", "price", 100, 101, true);
+
+    const undo = editSession.undoRowChange("row-1");
+    await editSession.commit("row-1", "size", 10, 11, true);
+    pendingUndo.resolve(SUCCESS);
+    await undo;
+
+    expect(editSession.isCellEdited("row-1", "price")).toBe(false);
+    expect(editSession.isCellEdited("row-1", "size")).toBe(true);
+    expect([editSession.editCount, editSession.invalidCount]).toEqual([1, 0]);
+  });
+
+  it("does not let an older undo clear a newer row deletion", async () => {
+    const pendingUndo = deferred<RpcResultSuccess>();
+    const deleteSelectedRows = vi.fn().mockResolvedValue({
+      data: { deletedKeys: ["row-1"] },
+      type: "SUCCESS_RESULT",
+    });
+    let dataSource: EditApi;
+    dataSource = {
+      createSessionDataSource: vi.fn(
+        async () => dataSource as unknown as DataSource,
+      ),
+      deleteSelectedRows,
+      endEditSession: vi.fn(),
+      undoRowChange: vi.fn().mockReturnValue(pendingUndo.promise),
+    };
+    editSession = new EditSession(dataSource);
+    await editSession.begin();
+    await editSession.deleteSelectedRows();
+
+    const undo = editSession.undoRowChange("row-1");
+    await editSession.deleteSelectedRows();
+    pendingUndo.resolve(SUCCESS);
+    await undo;
+
+    expect(editSession.hasRowChanges("row-1")).toBe(true);
+    expect(editSession.deleteCount).toBe(1);
   });
 
   it("notifies delete count boundaries while cell edits keep the session dirty", async () => {

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.react.test.tsx
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.react.test.tsx
@@ -1,0 +1,205 @@
+import type { DataSource, EditApi } from "@vuu-ui/vuu-data-types";
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  EditButtons,
+  EditSession,
+  StaleUpdateError,
+  useCellEdited,
+} from "../src";
+
+const SUCCESS = { data: undefined, type: "SUCCESS_RESULT" as const };
+
+const createEditSession = () => {
+  let dataSource: EditApi;
+  dataSource = {
+    createSessionDataSource: vi.fn(
+      async () => dataSource as unknown as DataSource,
+    ),
+    editCell: vi.fn().mockResolvedValue(SUCCESS),
+    endEditSession: vi.fn(),
+    undoRowChange: vi.fn().mockResolvedValue(SUCCESS),
+  };
+  return new EditSession(dataSource);
+};
+
+const CellMarker = ({
+  columnName,
+  editSession,
+  rowKey,
+}: {
+  columnName: string;
+  editSession: EditSession;
+  rowKey: string;
+}) => (
+  <output data-edited={useCellEdited(editSession, rowKey, columnName)}>
+    {rowKey}:{columnName}
+  </output>
+);
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = false;
+});
+
+describe("EditSession React consumers", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("keeps markers through remounts and follows row and column identity", async () => {
+    const editSession = createEditSession();
+    await editSession.begin();
+    await editSession.commit("row-1", "price", 100, 101, true);
+
+    await act(async () => {
+      root.render(
+        <CellMarker
+          columnName="price"
+          editSession={editSession}
+          rowKey="row-1"
+        />,
+      );
+    });
+    expect(container.querySelector("output")?.dataset.edited).toBe("true");
+
+    await act(async () => root.render(<div />));
+    await act(async () => {
+      root.render(
+        <CellMarker
+          columnName="price"
+          editSession={editSession}
+          rowKey="row-1"
+        />,
+      );
+    });
+    expect(container.querySelector("output")?.dataset.edited).toBe("true");
+
+    await act(async () => {
+      root.render(
+        <CellMarker
+          columnName="price"
+          editSession={editSession}
+          rowKey="row-2"
+        />,
+      );
+    });
+    expect(container.querySelector("output")?.dataset.edited).toBe("false");
+
+    await act(async () => {
+      root.render(
+        <CellMarker
+          columnName="description"
+          editSession={editSession}
+          rowKey="row-1"
+        />,
+      );
+    });
+    expect(container.querySelector("output")?.dataset.edited).toBe("false");
+  });
+
+  it("updates a mounted marker when an edit is reverted or undone", async () => {
+    const editSession = createEditSession();
+    await editSession.begin();
+    await act(async () => {
+      root.render(
+        <CellMarker
+          columnName="price"
+          editSession={editSession}
+          rowKey="row-1"
+        />,
+      );
+    });
+
+    await act(() => editSession.commit("row-1", "price", 100, 101, true));
+    expect(container.querySelector("output")?.dataset.edited).toBe("true");
+
+    await act(() => editSession.commit("row-1", "price", 101, 100, true));
+    expect(container.querySelector("output")?.dataset.edited).toBe("false");
+
+    await act(() => editSession.commit("row-1", "price", 100, 102, true));
+    await act(() => editSession.undoRowChange("row-1"));
+    expect(container.querySelector("output")?.dataset.edited).toBe("false");
+  });
+
+  it("initializes remounted edit buttons from stale state and force saves", async () => {
+    const staleError = new StaleUpdateError("stale");
+    let dataSource: EditApi;
+    dataSource = {
+      createSessionDataSource: vi.fn(
+        async () => dataSource as unknown as DataSource,
+      ),
+      editCell: vi.fn().mockResolvedValue(SUCCESS),
+      endEditSession: vi.fn().mockRejectedValue(staleError),
+    };
+    const editSession = new EditSession(dataSource);
+    const onSave = vi.fn();
+    await editSession.begin();
+    await editSession.commit("row-1", "price", 100, 101, true);
+    await expect(editSession.end(true)).rejects.toBe(staleError);
+
+    const Fixture = () => {
+      const [mounted, setMounted] = useState(true);
+      return (
+        <>
+          <button onClick={() => setMounted((value) => !value)} type="button">
+            toggle
+          </button>
+          {mounted && (
+            <EditButtons
+              canCancel
+              canSave
+              editSession={editSession}
+              onSave={onSave}
+            />
+          )}
+        </>
+      );
+    };
+    await act(async () => root.render(<Fixture />));
+    expect(container.textContent).toContain("Save (force)");
+
+    await act(async () => {
+      (container.querySelector("button") as HTMLButtonElement).click();
+    });
+    await act(async () => {
+      (container.querySelector("button") as HTMLButtonElement).click();
+    });
+    expect(container.textContent).toContain("Save (force)");
+
+    const buttons = container.querySelectorAll("button");
+    await act(async () => buttons[1].click());
+    expect(onSave).toHaveBeenCalledWith(true);
+  });
+});

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
@@ -154,24 +154,10 @@ describe("EditSession", () => {
 
     await editSession.begin();
 
-    //prettier-ignore
-    let { editedDuringCurrentSession } = await editSession.commit(
-      "key-01",
-      "col-1",
-      100,
-      200,
-      true,
-    );
-    expect(editedDuringCurrentSession).toEqual(true);
-    //prettier-ignore
-    ({ editedDuringCurrentSession } = await editSession.commit(
-      "key-01",
-      "col-1",
-      200,
-      100,
-      true,
-    ));
-    expect(editedDuringCurrentSession).toEqual(false);
+    await editSession.commit("key-01", "col-1", 100, 200, true);
+    expect(editSession.isCellEdited("key-01", "col-1")).toEqual(true);
+    await editSession.commit("key-01", "col-1", 200, 100, true);
+    expect(editSession.isCellEdited("key-01", "col-1")).toEqual(false);
 
     await editSession.end();
   });
@@ -182,33 +168,12 @@ describe("EditSession", () => {
 
     await editSession.begin();
 
-    //prettier-ignore
-    let { editedDuringCurrentSession } = await editSession.commit(
-      "key-01",
-      "col-1",
-      100,
-      "abc",
-      false,
-    );
-    expect(editedDuringCurrentSession).toEqual(false);
-    //prettier-ignore
-    ({ editedDuringCurrentSession } = await editSession.commit(
-      "key-01",
-      "col-1",
-      "abc",
-      200,
-      true,
-    ));
-    expect(editedDuringCurrentSession).toEqual(true);
-    //prettier-ignore
-    ({ editedDuringCurrentSession } = await editSession.commit(
-      "key-01",
-      "col-1",
-      200,
-      100,
-      true,
-    ));
-    expect(editedDuringCurrentSession).toEqual(false);
+    await editSession.commit("key-01", "col-1", 100, "abc", false);
+    expect(editSession.isCellEdited("key-01", "col-1")).toEqual(false);
+    await editSession.commit("key-01", "col-1", "abc", 200, true);
+    expect(editSession.isCellEdited("key-01", "col-1")).toEqual(true);
+    await editSession.commit("key-01", "col-1", 200, 100, true);
+    expect(editSession.isCellEdited("key-01", "col-1")).toEqual(false);
 
     await editSession.end();
   });
@@ -240,7 +205,7 @@ describe("EditSession", () => {
     expect(insertedRowSession.addCount).toBe(0);
   });
 
-  it("emits the row key after undoing row changes", async () => {
+  it("clears cell markers after undoing row changes", async () => {
     const undoRowChange = vi.fn().mockResolvedValue({
       data: undefined,
       type: "SUCCESS_RESULT",
@@ -258,13 +223,15 @@ describe("EditSession", () => {
       undoRowChange,
     };
     const rowEditSession = new EditSession(editApi);
-    const rowChangeUndone = vi.fn();
-    rowEditSession.on("rowChangeUndone", rowChangeUndone);
+    const cellEditChanged = vi.fn();
+    rowEditSession.on("cellEditChanged", cellEditChanged);
     await rowEditSession.begin();
     await rowEditSession.commit("row-001", "name", "Alice", "Alicia", true);
+    cellEditChanged.mockClear();
 
     await rowEditSession.undoRowChange("row-001");
 
-    expect(rowChangeUndone).toHaveBeenCalledWith("row-001");
+    expect(rowEditSession.isCellEdited("row-001", "name")).toBe(false);
+    expect(cellEditChanged).toHaveBeenCalledWith("row-001", "name");
   });
 });

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -868,6 +868,44 @@ test.describe("Inline row editing (session)", () => {
     await expect(submitButton).toBeEnabled();
   });
 
+  test("edited markers survive virtualization without leaking to recycled rows", async ({
+    mount,
+    page,
+  }) => {
+    test.slow();
+    await mount(<EditableInstrumentsInlineEdit />);
+    await page.getByRole("radio", { name: "Edit" }).click();
+
+    const tableLocator = page.getByRole("table");
+    const table = new TableOM(tableLocator);
+    const editedCell = table.locateCell(2, 2);
+    await editedCell.dblclick();
+    await editedCell.pressSequentially("X");
+    await editedCell.press("Enter");
+    await expect(editedCell.locator(".vuuTableInputCell-edited")).toHaveCount(
+      1,
+    );
+
+    const contentContainer = page.locator(".vuuTable-contentContainer");
+    await contentContainer.evaluate((element) => {
+      element.scrollTop = 2_000;
+      element.dispatchEvent(new Event("scroll"));
+    });
+    await expect(table.row(2)).toHaveCount(0);
+    await expect(tableLocator.locator(".vuuTableInputCell-edited")).toHaveCount(
+      0,
+    );
+
+    await contentContainer.evaluate((element) => {
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event("scroll"));
+    });
+    await expect(table.row(2)).toBeVisible();
+    await expect(
+      table.locateCell(2, 2).locator(".vuuTableInputCell-edited"),
+    ).toHaveCount(1);
+  });
+
   test("soft-deleting a selected row marks it and shows the undo button", async ({
     browserName,
     mount,

--- a/vuu-ui/packages/vuu-table/src/table-cell/TableCell.tsx
+++ b/vuu-ui/packages/vuu-table/src/table-cell/TableCell.tsx
@@ -1,17 +1,12 @@
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
-import { useEditSession } from "@vuu-ui/vuu-data-editing";
+import { useCellEdited, useEditSession } from "@vuu-ui/vuu-data-editing";
 import type {
   TableCellEditHandler,
   TableCellProps,
 } from "@vuu-ui/vuu-table-types";
 import { isDataValueEditable } from "@vuu-ui/vuu-utils";
-import {
-  type MouseEventHandler,
-  useCallback,
-  useEffect,
-  useState,
-} from "react";
+import { type MouseEventHandler, useCallback } from "react";
 import { applyHighlighting } from "../applyHighlighting";
 import { useCell } from "../useCell";
 
@@ -37,21 +32,11 @@ export const TableCell = ({
 
   const { className, style } = useCell(column, classBase, false);
   const { ariaColIndex, CellRenderer, name, valueFormatter } = column;
-  const [editedDuringCurrentSession, setEditingDuringCurrentSession] = useState<
-    boolean | undefined
-  >(undefined);
-
-  useEffect(() => {
-    const handleRowChangeUndone = (key: string) => {
-      if (key === dataRow.key) {
-        setEditingDuringCurrentSession(false);
-      }
-    };
-    editSession?.on("rowChangeUndone", handleRowChangeUndone);
-    return () => {
-      editSession?.removeListener("rowChangeUndone", handleRowChangeUndone);
-    };
-  }, [dataRow.key, editSession]);
+  const editedDuringCurrentSession = useCellEdited(
+    editSession,
+    dataRow.key,
+    name,
+  );
 
   const handleDataItemEdited = useCallback<TableCellEditHandler>(
     async (editState, editPhase) => {
@@ -90,16 +75,13 @@ export const TableCell = ({
           return { data: undefined, type: "SUCCESS_RESULT" };
         }
 
-        const { editedDuringCurrentSession, ...response } =
-          await editSession.commit(
-            dataRow.key,
-            name,
-            previousValue,
-            value,
-            isValid,
-          );
-        setEditingDuringCurrentSession(editedDuringCurrentSession);
-        return response;
+        return editSession.commit(
+          dataRow.key,
+          name,
+          previousValue,
+          value,
+          isValid,
+        );
       }
     },
     [column, dataRow, editSession, name, onDataEdited],


### PR DESCRIPTION
## Summary
- make `EditSession` authoritative for identity-keyed per-cell edited status and expose it through a reusable `useSyncExternalStore` hook
- prevent superseded async commit and undo responses from corrupting current cell validity, counts, markers, or deletion state
- persist stale save state across remounts and failed retries while preserving validation priority and force-save behavior
- remove the obsolete `rowChangeUndone` event and local `TableCell` marker state

## Validation
- all 51 `vuu-data-editing` tests pass
- virtualization marker regression passes in Chromium, Firefox, and WebKit
- `@vuu-ui/vuu-data-editing` and `@vuu-ui/vuu-table` builds pass
- Biome passes with one pre-existing `TableCell` click/key accessibility warning

Repository-wide typecheck remains blocked by unrelated pre-existing errors outside these changes.