### PR TITLE
Handle conditional React children

### DIFF
--- a/vuu-ui/packages/vuu-utils/src/react-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/react-utils.ts
@@ -1,9 +1,9 @@
 import {
   Children,
   isValidElement,
-  ReactElement,
-  ReactNode,
-  SetStateAction,
+  type ReactElement,
+  type ReactNode,
+  type SetStateAction,
   useEffect,
   useMemo,
   useRef,
@@ -12,17 +12,8 @@ import {
 const EMPTY_ARRAY: ReactElement[] = [];
 
 export const asReactElements = (children: ReactNode): ReactElement[] => {
-  const isArray = Array.isArray(children);
-  const count = isArray ? children.length : Children.count(children);
-  if (isArray && children.every(isValidElement)) {
-    return children;
-  } else if (count === 1 && !isArray && isValidElement(children)) {
-    return [children];
-  } else if (count > 1) {
-    return children as ReactElement[];
-  } else {
-    return EMPTY_ARRAY;
-  }
+  const elements = Children.toArray(children).filter(isValidElement);
+  return elements.length === 0 ? EMPTY_ARRAY : elements;
 };
 
 export const useIsMounted = (id = "") => {

--- a/vuu-ui/packages/vuu-utils/test/react-utils.test.tsx
+++ b/vuu-ui/packages/vuu-utils/test/react-utils.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { asReactElements } from "../src/react-utils";
+
+describe("asReactElements", () => {
+  it("filters non-element values from mixed children", () => {
+    const elements = asReactElements([
+      <button key="first" type="button">
+        First
+      </button>,
+      null,
+      false,
+      undefined,
+      <button key="second" type="button">
+        Second
+      </button>,
+    ]);
+
+    expect(elements).toHaveLength(2);
+    expect(elements.map(({ props }) => props.children)).toEqual([
+      "First",
+      "Second",
+    ]);
+  });
+
+  it("returns an empty array when there are no element children", () => {
+    expect(asReactElements([null, false, undefined])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- make `asReactElements` filter `null`, boolean, and `undefined` conditional children instead of casting mixed child arrays to `ReactElement[]`
- prevent `Toolbar` and other element-only consumers from reading `.props` on non-elements
- add regression coverage for mixed and entirely empty conditional child collections

## Validation
- focused `asReactElements` tests pass
- affected Editing showcase component test passes in Chromium
- `@vuu-ui/vuu-utils` and `@vuu-ui/vuu-ui-controls` builds pass
- Biome passes