### PR TITLE
Add user admin table editing

### DIFF
--- a/vuu-ui/package-lock.json
+++ b/vuu-ui/package-lock.json
@@ -15696,10 +15696,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@salt-ds/core": "1.67.0",
+        "@vuu-ui/vuu-data-editing": "2.2.1",
         "@vuu-ui/vuu-data-react": "2.2.1",
         "@vuu-ui/vuu-layout": "2.2.1",
         "@vuu-ui/vuu-shell": "2.2.1",
         "@vuu-ui/vuu-table": "2.2.1",
+        "@vuu-ui/vuu-table-extras": "2.2.1",
         "@vuu-ui/vuu-utils2": "2.2.1"
       },
       "devDependencies": {

--- a/vuu-ui/sample-apps/feature-user-admin/package.json
+++ b/vuu-ui/sample-apps/feature-user-admin/package.json
@@ -21,10 +21,12 @@
     "@vuu-ui/vuu-table-types": "2.2.1"
   },
   "dependencies": {
+    "@vuu-ui/vuu-data-editing": "2.2.1",
     "@vuu-ui/vuu-data-react": "2.2.1",
     "@vuu-ui/vuu-layout": "2.2.1",
     "@vuu-ui/vuu-shell": "2.2.1",
     "@vuu-ui/vuu-table": "2.2.1",
+    "@vuu-ui/vuu-table-extras": "2.2.1",
     "@vuu-ui/vuu-utils2": "2.2.1",
     "@salt-ds/core": "1.67.0"
   },

--- a/vuu-ui/sample-apps/feature-user-admin/src/UserAdmin.css
+++ b/vuu-ui/sample-apps/feature-user-admin/src/UserAdmin.css
@@ -1,9 +1,15 @@
 .vuuUserAdmin {
   display: flex;
+  flex-direction: column;
   height: 100%;
   width: 100%;
 
+  .vuuUserAdmin-toolbar {
+    flex: 0 0 auto;
+  }
+
   .vuuUserAdmin-tableContainer {
     flex: 1 1 0%;
+    min-height: 0;
   }
 }

--- a/vuu-ui/sample-apps/feature-user-admin/src/UserAdmin.tsx
+++ b/vuu-ui/sample-apps/feature-user-admin/src/UserAdmin.tsx
@@ -1,35 +1,178 @@
+import { ToggleButton, ToggleButtonGroup, Toolbar } from "@salt-ds/core";
+import {
+  DataEditingProvider,
+  EditButtons,
+  type EditMode,
+  UNDO_CELL_RENDERER,
+  useEditableTable,
+} from "@vuu-ui/vuu-data-editing";
+import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
 import { Table } from "@vuu-ui/vuu-table";
-import { useUserAdmin } from "./useUserAdmin";
+import {
+  DataSourceStats,
+  InlineAddRow,
+  TableFooter,
+  TableFooterTray,
+} from "@vuu-ui/vuu-table-extras";
+import type {
+  ColumnDescriptor,
+  DataRow,
+  SelectionChangeHandler,
+  TableConfig,
+} from "@vuu-ui/vuu-table-types";
+import { type SyntheticEvent, useCallback, useMemo, useState } from "react";
+import { INTERNAL_COLUMN_NAMES, useUserAdmin } from "./useUserAdmin";
 
 import "./UserAdmin.css";
+
+const UNDO_DELETE_COLUMN: ColumnDescriptor = {
+  name: "undo",
+  source: "client",
+  width: 80,
+  type: {
+    name: "string",
+    renderer: {
+      name: UNDO_CELL_RENDERER,
+    },
+  },
+};
+
+const EditableUsersTable = ({
+  dataSource: sourceTableDataSource,
+  onSelectionChange,
+  schema,
+}: {
+  dataSource: DataSource;
+  onSelectionChange: SelectionChangeHandler;
+  schema: TableSchema;
+}) => {
+  const [editMode, setEditMode] = useState<EditMode>("view");
+  const exitEditMode = useCallback(() => setEditMode("view"), []);
+  const {
+    canCancel,
+    canSave,
+    dataSource,
+    editSession,
+    hasSelection,
+    onCancel,
+    onDelete,
+    onSave,
+    rowClassNameGenerators,
+  } = useEditableTable({
+    dataSource: sourceTableDataSource,
+    copyOption: "All",
+    deleteMode: "soft",
+    isEditMode: editMode === "edit",
+    onCancel: exitEditMode,
+    onSave: exitEditMode,
+  });
+
+  const onToggleEditMode = useCallback(
+    (event: SyntheticEvent<HTMLButtonElement>) => {
+      setEditMode((event.target as HTMLButtonElement).value as EditMode);
+    },
+    [],
+  );
+
+  const isRowSelectable = useCallback(
+    (dataRow: DataRow) => dataRow.vuu_action !== "deleteRow",
+    [],
+  );
+
+  const config = useMemo<TableConfig>(() => {
+    const visibleColumns = schema.columns.filter(
+      ({ name }) => !INTERNAL_COLUMN_NAMES.has(name),
+    );
+    const keyColumns = new Set(schema.key);
+
+    return {
+      columnLayout: "fit",
+      columns:
+        editMode === "view"
+          ? visibleColumns.map((column) => ({ ...column, editable: false }))
+          : visibleColumns
+              .map<ColumnDescriptor>((column) => ({
+                ...column,
+                editable: keyColumns.has(column.name)
+                  ? false
+                  : column.editable !== false,
+              }))
+              .concat({ hidden: true, name: "vuu_action" }, UNDO_DELETE_COLUMN),
+      rowClassNameGenerators,
+      rowSeparators: true,
+      zebraStripes: true,
+    };
+  }, [editMode, rowClassNameGenerators, schema]);
+
+  return (
+    <>
+      <Toolbar className="vuuUserAdmin-toolbar">
+        <ToggleButtonGroup onChange={onToggleEditMode} value={editMode}>
+          <ToggleButton value="view">View</ToggleButton>
+          <ToggleButton value="edit">Edit</ToggleButton>
+        </ToggleButtonGroup>
+      </Toolbar>
+      <div className="vuuUserAdmin-tableContainer">
+        <DataEditingProvider editSession={editSession}>
+          <Table
+            config={config}
+            customHeader={editMode === "edit" ? InlineAddRow : undefined}
+            dataSource={dataSource}
+            height="100%"
+            isRowSelectable={editMode === "edit" ? isRowSelectable : undefined}
+            navigationStyle="row"
+            onSelectionChange={
+              editMode === "view" ? onSelectionChange : undefined
+            }
+            renderBufferSize={20}
+            rowHeight={21}
+            selectionModel={editMode === "edit" ? "checkbox" : "single"}
+            width="100%"
+          />
+        </DataEditingProvider>
+      </div>
+      <TableFooter>
+        {editMode === "view" ? (
+          <DataSourceStats dataSource={sourceTableDataSource} />
+        ) : (
+          <TableFooterTray position="center">
+            <EditButtons
+              canCancel={canCancel}
+              canSave={canSave}
+              editSession={editSession}
+              hasSelection={hasSelection}
+              onCancel={onCancel}
+              onDelete={onDelete}
+              onSave={onSave}
+            />
+          </TableFooterTray>
+        )}
+      </TableFooter>
+    </>
+  );
+};
 
 const UserAdmin = () => {
   const hookResult = useUserAdmin();
 
   if (!hookResult) {
-    return <div className="vuuUserAdmin-loading">Loading keycloak admin tables...</div>;
+    return (
+      <div className="vuuUserAdmin-loading">
+        Loading keycloak admin tables...
+      </div>
+    );
   }
 
-  const { dataSources, drawerOpen, groupsConfig, handleUserSelectionChange, rolesConfig, usersConfig } = hookResult;
+  const { dataSources, handleUserSelectionChange, schemas } = hookResult;
 
   return (
     <div className="vuuUserAdmin">
-
-      <div className="vuuUserAdmin-tableContainer">
-        <Table
-          config={usersConfig}
-          dataSource={dataSources.users}
-          height="100%"
-          navigationStyle="row"
-          onSelectionChange={handleUserSelectionChange}
-          renderBufferSize={20}
-          rowHeight={21}
-          width="100%"
-        />
-      </div>
-
-
-    </div >
+      <EditableUsersTable
+        dataSource={dataSources.users}
+        onSelectionChange={handleUserSelectionChange}
+        schema={schemas.users}
+      />
+    </div>
   );
 };
 

--- a/vuu-ui/sample-apps/feature-user-admin/src/useUserAdmin.ts
+++ b/vuu-ui/sample-apps/feature-user-admin/src/useUserAdmin.ts
@@ -8,7 +8,7 @@ import { useData } from "@vuu-ui/vuu-utils2";
 
 const KEYCLOAK_ADMIN_MODULE = "KEYCLOAK_ADMIN";
 
-const INTERNAL_COLUMN_NAMES = new Set([
+export const INTERNAL_COLUMN_NAMES = new Set([
   "vuuCreatedTimestamp",
   "vuuUpdatedTimestamp",
   "vuuMsg",
@@ -32,6 +32,7 @@ export type UserAdminHookResult = {
   groupsConfig: TableConfig;
   handleUserSelectionChange: SelectionChangeHandler;
   rolesConfig: TableConfig;
+  schemas: KeycloakAdminSchemas;
   usersConfig: TableConfig;
 };
 
@@ -85,6 +86,7 @@ export const useUserAdmin = (): UserAdminHookResult | undefined => {
       users: getDataSource(`${sessionPrefix}-users`, {
         bufferSize: 200,
         columns: getColumns(schemas.users),
+        sessionTableMessageColumn: "vuuMsg",
         table: schemas.users.table,
         title,
         viewport: `${sessionPrefix}-users`,
@@ -151,9 +153,23 @@ export const useUserAdmin = (): UserAdminHookResult | undefined => {
     [],
   );
 
-  if (!dataSources || !usersConfig || !groupsConfig || !rolesConfig) {
+  if (
+    !schemas ||
+    !dataSources ||
+    !usersConfig ||
+    !groupsConfig ||
+    !rolesConfig
+  ) {
     return undefined;
   }
 
-  return { dataSources, drawerOpen, groupsConfig, handleUserSelectionChange, rolesConfig, usersConfig };
+  return {
+    dataSources,
+    drawerOpen,
+    groupsConfig,
+    handleUserSelectionChange,
+    rolesConfig,
+    schemas,
+    usersConfig,
+  };
 };


### PR DESCRIPTION
## Summary
- add edit mode to the user admin users table
- support inline row creation and editable cells
- support checkbox row deletion with save, cancel, and undo controls

## Validation
- `npm run build --workspace feature-user-admin`