### PR TITLE
Fix user admin inline add key handling

### DIFF
--- a/vuu-ui/sample-apps/feature-user-admin/src/UserAdmin.tsx
+++ b/vuu-ui/sample-apps/feature-user-admin/src/UserAdmin.tsx
@@ -83,8 +83,6 @@ const EditableUsersTable = ({
     const visibleColumns = schema.columns.filter(
       ({ name }) => !INTERNAL_COLUMN_NAMES.has(name),
     );
-    const keyColumns = new Set(schema.key);
-
     return {
       columnLayout: "fit",
       columns:
@@ -93,9 +91,10 @@ const EditableUsersTable = ({
           : visibleColumns
               .map<ColumnDescriptor>((column) => ({
                 ...column,
-                editable: keyColumns.has(column.name)
-                  ? false
-                  : column.editable !== false,
+                editable:
+                  column.name === schema.key
+                    ? false
+                    : column.editable !== false,
               }))
               .concat({ hidden: true, name: "vuu_action" }, UNDO_DELETE_COLUMN),
       rowClassNameGenerators,


### PR DESCRIPTION
## Summary
- compare user table columns directly against the schema key
- keep the server-generated `id` read-only and out of inline add payloads

## Validation
- `npm run build --workspace=feature-user-admin`
- `biome format sample-apps/feature-user-admin/src/UserAdmin.tsx`
- `npm run lint -- sample-apps/feature-user-admin/src/UserAdmin.tsx`