### PR TITLE
Fix consecutive inline row additions

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -12,6 +12,7 @@ import { EventEmitter, isRpcError, StaleUpdateError } from "@vuu-ui/vuu-utils";
 export type EditState = "clean" | "dirty" | "invalid" | "stale";
 export type NewRowState = {
   columns: readonly string[];
+  draftRevision: number;
   errors: Readonly<Record<string, string>>;
   submitting: boolean;
   values: Readonly<Record<string, VuuRowDataItemType>>;
@@ -73,6 +74,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   #sessionDataSource?: DataSource;
   #newRowState: NewRowState = {
     columns: [],
+    draftRevision: 0,
     errors: {},
     submitting: false,
     values: {},
@@ -277,6 +279,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
 
       this.#setNewRowState({
         columns: this.#newRowState.columns,
+        draftRevision: this.#newRowState.draftRevision + 1,
         errors: {},
         submitting: false,
         values: {},
@@ -440,6 +443,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     this.#isStale = false;
     this.#setNewRowState({
       columns: this.#newRowState.columns,
+      draftRevision: this.#newRowState.draftRevision + 1,
       errors: {},
       submitting: false,
       values: {},

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -130,6 +130,7 @@ describe("EditSession lifecycle", () => {
     await expect(editSession.addNewRow()).resolves.toEqual(SUCCESS);
     expect(addRow).toHaveBeenCalledWith({ id: 7, name: "Alice" });
     expect(editSession.newRowState).toMatchObject({
+      draftRevision: 1,
       errors: {},
       values: {},
     });

--- a/vuu-ui/packages/vuu-table-extras/src/inline-add-row/InlineAddRow.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/inline-add-row/InlineAddRow.tsx
@@ -24,9 +24,10 @@ export const InlineAddRow = ({
     window: targetWindow,
   });
 
-  const { containerRef, dataRow, inlineAddColumns } = useInlineAddRow({
-    columns,
-  });
+  const { containerRef, dataRow, draftRevision, inlineAddColumns } =
+    useInlineAddRow({
+      columns,
+    });
 
   return (
     <div className={cx(classBase, className)} ref={containerRef}>
@@ -34,6 +35,7 @@ export const InlineAddRow = ({
         ariaRowIndex={ariaRowIndex}
         columns={inlineAddColumns}
         dataRow={dataRow}
+        key={draftRevision}
         offset={0}
         searchPattern=""
         showBookends={false}

--- a/vuu-ui/packages/vuu-table-extras/src/inline-add-row/useInlineAddRow.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/inline-add-row/useInlineAddRow.ts
@@ -88,7 +88,7 @@ export const useInlineAddRow = ({ columns }: UseInlineAddRowProps) => {
   const focusEditor = useCallback((index: number) => {
     const cell =
       containerRef.current?.querySelectorAll<HTMLElement>("[data-field]")[
-      index
+        index
       ];
     cell?.querySelector<HTMLElement>("input, button, [tabindex]")?.focus();
   }, []);
@@ -175,6 +175,7 @@ export const useInlineAddRow = ({ columns }: UseInlineAddRowProps) => {
   return {
     containerRef,
     dataRow,
+    draftRevision: newRowState.draftRevision,
     inlineAddColumns,
   };
 };

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -141,6 +141,54 @@ test.describe("Test table editing", () => {
     ).toHaveValue("TEST-006");
   });
 
+  test("inserts two consecutive rows in the same edit session", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestTableEmpty />);
+    await page.getByRole("radio", { name: "Edit" }).click();
+
+    const inlineAddRow = page.locator(".vuuInlineAddRow");
+    const id = inlineAddRow.getByRole("textbox", { name: "id", exact: true });
+    const description = inlineAddRow.getByRole("textbox", {
+      name: "description",
+    });
+    const quantity = inlineAddRow.getByRole("textbox", { name: "quantity" });
+    const price = inlineAddRow.getByRole("textbox", { name: "price" });
+    const externalId = inlineAddRow.getByRole("textbox", {
+      name: "externalId",
+    });
+
+    const addRow = async (
+      values: readonly [string, string, string, string, string],
+    ) => {
+      const editors = [id, description, quantity, price, externalId];
+      for (const [index, editor] of editors.entries()) {
+        await editor.fill(values[index]);
+        await editor.press("Enter");
+      }
+    };
+
+    await addRow(["TEST-006", "Foxtrot", "72", "607.5", "1006"]);
+    await expect(id).toBeFocused();
+    await expect(id).toHaveValue("");
+
+    await addRow(["TEST-007", "Golf", "84", "708.5", "1006"]);
+
+    await expect(id).toBeFocused();
+    await expect(id).toHaveValue("");
+    await expect(description).toHaveValue("");
+    await expect(quantity).toHaveValue("");
+    await expect(price).toHaveValue("");
+    await expect(externalId).toHaveValue("");
+    await expect(
+      page.getByRole("textbox", { name: "id", exact: true }).nth(1),
+    ).toHaveValue("TEST-006");
+    await expect(
+      page.getByRole("textbox", { name: "id", exact: true }).nth(2),
+    ).toHaveValue("TEST-007");
+  });
+
   test("marks only omitted cells as invalid when the final cell is committed", async ({
     mount,
     page,


### PR DESCRIPTION
## Summary
- give each successful inline-add draft a new editor revision while preserving the synthetic edit-session row key
- remount inline row cells after insertion so stale local editor state cannot suppress an identical value in the next row
- cover two consecutive additions where the second row repeats the first row's final value and assert row insertion, draft clearing, and focus reset

## Validation
- `npm run test:playwright:ct -- packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx -g "inserts two consecutive rows" --project=chromium`
- `npx vitest run packages/vuu-data-editing/test/EditSession.lifecycle.test.ts --reporter=dot`
- `npm run build --workspace=feature-user-admin`
- changed-file Biome format and lint

## Typecheck
`npm run typecheck` still reports pre-existing errors outside this change in vuu-data-local, vuu-data-test, vuu-table-extras CSV preview, feature descriptors, sample apps, and showcase modules.