### PR TITLE
Fix session edit source refresh

### DIFF
--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -100,6 +100,8 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   #menu: VuuMenu | undefined;
   #optimize: OptimizeStrategy = "throttle";
   #selectedRowsCount = 0;
+  #editSourceDataSource: VuuDataSource | undefined;
+  #refreshOnEnable = false;
   #sessionTableMessageColumn: string | undefined = undefined;
   #status: DataSourceStatus = "initialising";
   #tableSchema: TableSchema | undefined;
@@ -208,6 +210,10 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     } else if (message.type === "enabled") {
       this.#status = "subscribed";
       this.emit("enabled", this.viewport);
+      if (this.#refreshOnEnable) {
+        this.#refreshOnEnable = false;
+        this.rawRangeRequest(this._range.withBuffer);
+      }
     } else if (isDataSourceConfigMessage(message)) {
       // This is an ACK for a CHANGE_VP message. Nothing to do here. We need
       // to wait for data to be returned before we can consider the change
@@ -298,6 +304,18 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
       type: "resume",
       viewport: this.viewport,
     });
+  }
+
+  private refreshAfterEdit() {
+    if (
+      this.#status === "disabled" ||
+      this.#status === "disabling" ||
+      this.#status === "enabling"
+    ) {
+      this.#refreshOnEnable = true;
+    } else {
+      this.rawRangeRequest(this._range.withBuffer);
+    }
   }
 
   resume(callback?: DataSourceSubscribeCallback) {
@@ -676,7 +694,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
           (column): column is string => column !== undefined,
         ),
       );
-      return new VuuDataSource({
+      const sessionDataSource = new VuuDataSource({
         ...this.config,
         columns: sessionColumns,
         connectionId: this.#connectionId,
@@ -684,6 +702,8 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
         table: sessionTable,
         viewport: sessionTable.table,
       });
+      sessionDataSource.#editSourceDataSource = this;
+      return sessionDataSource;
     } else {
       throw Error(
         `[VuuDataSource] createSessionDataSource ${rpcResponse?.errorMessage}`,
@@ -713,13 +733,20 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      this.sendResumeMessage();
+      if (this.#editSourceDataSource) {
+        this.unsubscribe();
+      }
     } else {
       if (rpcResponse?.errorMessage === "stale update") {
         throw new StaleUpdateError(rpcResponse.errorMessage);
       } else {
         throw Error(rpcResponse?.errorMessage ?? "endEditSession failed");
       }
+    }
+    if (this.#editSourceDataSource) {
+      this.#editSourceDataSource.refreshAfterEdit();
+    } else {
+      this.sendResumeMessage();
     }
   }
 

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -733,8 +733,13 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      if (this.#sourceTableDataSource) {
+      const sourceTableDataSource = this.#sourceTableDataSource;
+      if (sourceTableDataSource) {
+        this.#sourceTableDataSource = undefined;
         this.unsubscribe();
+        sourceTableDataSource.refreshAfterEdit();
+      } else {
+        this.sendResumeMessage();
       }
     } else {
       if (rpcResponse?.errorMessage === "stale update") {
@@ -742,11 +747,6 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
       } else {
         throw Error(rpcResponse?.errorMessage ?? "endEditSession failed");
       }
-    }
-    if (this.#sourceTableDataSource) {
-      this.#sourceTableDataSource.refreshAfterEdit();
-    } else {
-      this.sendResumeMessage();
     }
   }
 

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -100,7 +100,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   #menu: VuuMenu | undefined;
   #optimize: OptimizeStrategy = "throttle";
   #selectedRowsCount = 0;
-  #editSourceDataSource: VuuDataSource | undefined;
+  #sourceTableDataSource: VuuDataSource | undefined;
   #refreshOnEnable = false;
   #sessionTableMessageColumn: string | undefined = undefined;
   #status: DataSourceStatus = "initialising";
@@ -702,7 +702,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
         table: sessionTable,
         viewport: sessionTable.table,
       });
-      sessionDataSource.#editSourceDataSource = this;
+      sessionDataSource.#sourceTableDataSource = this;
       return sessionDataSource;
     } else {
       throw Error(
@@ -733,7 +733,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      if (this.#editSourceDataSource) {
+      if (this.#sourceTableDataSource) {
         this.unsubscribe();
       }
     } else {
@@ -743,8 +743,8 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
         throw Error(rpcResponse?.errorMessage ?? "endEditSession failed");
       }
     }
-    if (this.#editSourceDataSource) {
-      this.#editSourceDataSource.refreshAfterEdit();
+    if (this.#sourceTableDataSource) {
+      this.#sourceTableDataSource.refreshAfterEdit();
     } else {
       this.sendResumeMessage();
     }

--- a/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "@vuu-ui/vuu-data-types";
 import type {
   LinkDescriptorWithLabel,
+  RpcResultSuccess,
   VuuSortCol,
 } from "@vuu-ui/vuu-protocol-types";
 import { VuuDataSource } from "../src/VuuDataSource";
@@ -201,6 +202,54 @@ describe("VuuDataSource", () => {
         },
         expect.any(Function),
       );
+    });
+
+    describe("session editing", () => {
+      it("refreshes a disabled source range after a standalone session is saved and the source is enabled", async () => {
+        const source = new VuuDataSource({ table, viewport: "source-vp" });
+        await source.subscribe({}, vi.fn());
+        source.handleMessageFromServer({
+          type: "subscribed",
+          tableSchema: {},
+        } as any);
+        source.range = Range(0, 20);
+
+        vi.spyOn(source, "rpcRequest").mockResolvedValue({
+          type: "SUCCESS_RESULT",
+          data: {
+            table: { module: "SIMUL", table: "session-vp" },
+          },
+        } as RpcResultSuccess);
+        const session = await source.createSessionDataSource("Empty");
+        expect(session).toBeDefined();
+        vi.spyOn(session!, "rpcRequest").mockResolvedValue({
+          type: "SUCCESS_RESULT",
+        } as RpcResultSuccess);
+
+        source.disable();
+        source.handleMessageFromServer({ type: "disabled" } as any);
+        const serverAPI = await ConnectionManager.serverAPI;
+        vi.mocked(serverAPI.send).mockClear();
+
+        await session!.endEditSession(true);
+
+        expect(serverAPI.send).not.toHaveBeenCalledWith(
+          expect.objectContaining({ type: "setViewRange" }),
+        );
+
+        source.resume();
+        source.handleMessageFromServer({ type: "enabled" } as any);
+
+        expect(serverAPI.send).toHaveBeenNthCalledWith(1, {
+          type: "enable",
+          viewport: "source-vp",
+        });
+        expect(serverAPI.send).toHaveBeenNthCalledWith(2, {
+          type: "setViewRange",
+          range: Range(0, 20),
+          viewport: "source-vp",
+        });
+      });
     });
 
     it("uses options supplied at creation, if not passed with subscription", async () => {

--- a/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
@@ -249,6 +249,15 @@ describe("VuuDataSource", () => {
           range: Range(0, 20),
           viewport: "source-vp",
         });
+
+        vi.mocked(serverAPI.send).mockClear();
+        await session!.endEditSession(true);
+        expect(serverAPI.send).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "setViewRange",
+            viewport: "source-vp",
+          }),
+        );
       });
     });
 

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -65,7 +65,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
   #pendingVisualLink?: LinkDescriptorWithLabel;
   #rpcMenuServices: RpcMenuService[] | undefined;
   #rpcServices: RpcService[] | undefined;
-  #editSourceDataSource: TickingArrayDataSource | undefined;
+  #sourceTableDataSource: TickingArrayDataSource | undefined;
   #table?: Table;
   #selectionLinkSubscribers: Map<string, LinkSubscription> | undefined;
   #visualLinkService?: VisualLinkHandler;
@@ -181,7 +181,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
         { ...this.config, columns },
       );
       if (sessionDataSource instanceof TickingArrayDataSource) {
-        sessionDataSource.#editSourceDataSource = this;
+        sessionDataSource.#sourceTableDataSource = this;
       }
       return sessionDataSource;
     } else {
@@ -287,10 +287,10 @@ export class TickingArrayDataSource extends ArrayDataSource {
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      if (this.#editSourceDataSource) {
+      if (this.#sourceTableDataSource) {
         this.unsubscribe();
       }
-      (this.#editSourceDataSource ?? this).sendRowsToClient(true);
+      (this.#sourceTableDataSource ?? this).sendRowsToClient(true);
     } else {
       if (rpcResponse?.errorMessage === "stale update") {
         throw new StaleUpdateError(rpcResponse.errorMessage);

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -65,6 +65,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
   #pendingVisualLink?: LinkDescriptorWithLabel;
   #rpcMenuServices: RpcMenuService[] | undefined;
   #rpcServices: RpcService[] | undefined;
+  #editSourceDataSource: TickingArrayDataSource | undefined;
   #table?: Table;
   #selectionLinkSubscribers: Map<string, LinkSubscription> | undefined;
   #visualLinkService?: VisualLinkHandler;
@@ -174,11 +175,15 @@ export class TickingArrayDataSource extends ArrayDataSource {
       const columns = this.config.columns.includes("vuu_action")
         ? this.config.columns
         : this.config.columns.concat("vuu_action");
-      return this.#vuuModule?.createDataSource(
+      const sessionDataSource = this.#vuuModule?.createDataSource(
         sessionTable.table,
         sessionTable.table,
         { ...this.config, columns },
       );
+      if (sessionDataSource instanceof TickingArrayDataSource) {
+        sessionDataSource.#editSourceDataSource = this;
+      }
+      return sessionDataSource;
     } else {
       throw Error(
         `[TickingArrayDataSource] createSessionDataSource ${rpcResponse?.errorMessage}`,
@@ -282,7 +287,10 @@ export class TickingArrayDataSource extends ArrayDataSource {
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      this.sendRowsToClient(true);
+      if (this.#editSourceDataSource) {
+        this.unsubscribe();
+      }
+      (this.#editSourceDataSource ?? this).sendRowsToClient(true);
     } else {
       if (rpcResponse?.errorMessage === "stale update") {
         throw new StaleUpdateError(rpcResponse.errorMessage);

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -287,10 +287,12 @@ export class TickingArrayDataSource extends ArrayDataSource {
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      if (this.#sourceTableDataSource) {
+      const sourceTableDataSource = this.#sourceTableDataSource;
+      if (sourceTableDataSource) {
+        this.#sourceTableDataSource = undefined;
         this.unsubscribe();
       }
-      (this.#sourceTableDataSource ?? this).sendRowsToClient(true);
+      (sourceTableDataSource ?? this).sendRowsToClient(true);
     } else {
       if (rpcResponse?.errorMessage === "stale update") {
         throw new StaleUpdateError(rpcResponse.errorMessage);

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -463,5 +463,9 @@ describe("createSessionDataSource", () => {
         expect.arrayContaining(["row-002", "Bob"]),
       ]),
     );
+
+    updates.mockClear();
+    await editDataSource?.endEditSession?.(true);
+    expect(updates).not.toHaveBeenCalled();
   });
 });

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -10,6 +10,7 @@ import type {
   RpcResultError,
   RpcResultSuccess,
 } from "@vuu-ui/vuu-protocol-types";
+import { Range } from "@vuu-ui/vuu-utils";
 
 const schema: TableSchema = {
   columns: [
@@ -415,6 +416,52 @@ describe("createSessionDataSource", () => {
     );
     await expect(ds.createSessionDataSource?.("All")).rejects.toThrow(
       "session table creation failed",
+    );
+  });
+
+  it("reconciles committed rows into the source datasource when the session ends", async () => {
+    const sourceTable = new Table(
+      schema,
+      [["row-001", "Alice", ""]],
+      buildDataColumnMapFromSchema(schema),
+    );
+    const sessionTable = new Table(
+      { ...schema, table: { module: "TEST", table: "session-xyz" } },
+      [],
+      buildDataColumnMapFromSchema(schema),
+    );
+    const sessionDataSource = new TickingArrayDataSource({
+      columnDescriptors: schema.columns,
+      table: sessionTable,
+    });
+    const sourceDataSource = new TickingArrayDataSource({
+      columnDescriptors: schema.columns,
+      table: sourceTable,
+      vuuModule: {
+        createDataSource: () => sessionDataSource,
+      },
+    });
+    vi.spyOn(sourceDataSource, "rpcRequest").mockResolvedValue(sessionSuccess);
+
+    const updates = vi.fn();
+    await sourceDataSource.subscribe({ range: Range(0, 10) }, updates);
+    updates.mockClear();
+
+    const editDataSource =
+      await sourceDataSource.createSessionDataSource("Empty");
+    vi.spyOn(sessionDataSource, "rpcRequest").mockImplementation(async () => {
+      sourceTable.insert(["row-002", "Bob", ""]);
+      updates.mockClear();
+      return SUCCESS;
+    });
+
+    await editDataSource?.endEditSession?.(true);
+
+    const rows = updates.mock.calls.at(-1)?.[0].rows;
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining(["row-002", "Bob"]),
+      ]),
     );
   });
 });


### PR DESCRIPTION
## Summary

- link standalone session datasources created by `createSessionDataSource` back to their source datasource
- refresh the source viewport range after `endEditSession` succeeds
- defer refresh until enable completes when the source was disabled during the commit
- mirror source reconciliation in `TickingArrayDataSource`
- preserve `vuu-ui-rslib`'s standalone session lifecycle and server enable semantics

## Testing

- `npx vitest run packages/vuu-data-remote/test/VuuDataSource.test.ts packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts` (59 tests passed)
- changed datasource and regression-test files report no TypeScript diagnostics
- `git diff --check`

The repository-wide `npm run typecheck` still reports existing errors elsewhere on `vuu-ui-rslib`. No Scala server behavior is changed.