### PR TITLE
Keep session edit source datasource live

### DIFF
--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -1,5 +1,6 @@
 import type {
   CopyOption,
+  DataSource,
   DataSourceBase,
   DataSourceCallbackMessage,
   DataSourceConstructorProps,
@@ -100,6 +101,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   #menu: VuuMenu | undefined;
   #optimize: OptimizeStrategy = "throttle";
   #selectedRowsCount = 0;
+  #sourceTableDataSource: VuuDataSource | undefined;
   #sessionTableMessageColumn: string | undefined = undefined;
   #status: DataSourceStatus = "initialising";
   #tableSchema: TableSchema | undefined;
@@ -298,6 +300,10 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
       type: "resume",
       viewport: this.viewport,
     });
+  }
+
+  isSessionDataSourceOf(dataSource: DataSource): boolean {
+    return this.#sourceTableDataSource === dataSource;
   }
 
   resume(callback?: DataSourceSubscribeCallback) {
@@ -676,7 +682,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
           (column): column is string => column !== undefined,
         ),
       );
-      return new VuuDataSource({
+      const sessionDataSource = new VuuDataSource({
         ...this.config,
         columns: sessionColumns,
         connectionId: this.#connectionId,
@@ -684,6 +690,8 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
         table: sessionTable,
         viewport: sessionTable.table,
       });
+      sessionDataSource.#sourceTableDataSource = this;
+      return sessionDataSource;
     } else {
       throw Error(
         `[VuuDataSource] createSessionDataSource ${rpcResponse?.errorMessage}`,
@@ -713,7 +721,13 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      this.sendResumeMessage();
+      const sourceTableDataSource = this.#sourceTableDataSource;
+      if (sourceTableDataSource) {
+        this.#sourceTableDataSource = undefined;
+        this.unsubscribe();
+      } else {
+        this.sendResumeMessage();
+      }
     } else {
       if (rpcResponse?.errorMessage === "stale update") {
         throw new StaleUpdateError(rpcResponse.errorMessage);

--- a/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "@vuu-ui/vuu-data-types";
 import type {
   LinkDescriptorWithLabel,
+  RpcResultSuccess,
   VuuSortCol,
 } from "@vuu-ui/vuu-protocol-types";
 import { VuuDataSource } from "../src/VuuDataSource";
@@ -201,6 +202,56 @@ describe("VuuDataSource", () => {
         },
         expect.any(Function),
       );
+    });
+
+    describe("session editing", () => {
+      it("keeps the source cache live without a range refresh during standalone session editing", async () => {
+        const source = new VuuDataSource({ table, viewport: "source-vp" });
+        await source.subscribe({}, vi.fn());
+        source.handleMessageFromServer({
+          type: "subscribed",
+          tableSchema: {},
+        } as any);
+
+        vi.spyOn(source, "rpcRequest").mockResolvedValue({
+          type: "SUCCESS_RESULT",
+          data: {
+            table: { module: "SIMUL", table: "session-vp" },
+          },
+        } as RpcResultSuccess);
+        const session = await source.createSessionDataSource("Empty");
+        expect(session?.isSessionDataSourceOf(source)).toBe(true);
+        vi.spyOn(session!, "rpcRequest").mockResolvedValue({
+          type: "SUCCESS_RESULT",
+        } as RpcResultSuccess);
+
+        const serverAPI = await ConnectionManager.serverAPI;
+        vi.mocked(serverAPI.send).mockClear();
+        source.suspend(false);
+
+        expect(serverAPI.send).toHaveBeenLastCalledWith({
+          escalateDelay: undefined,
+          escalateToDisable: false,
+          type: "suspend",
+          viewport: "source-vp",
+        });
+
+        vi.mocked(serverAPI.send).mockClear();
+        await session!.endEditSession(true);
+        expect(serverAPI.send).not.toHaveBeenCalledWith(
+          expect.objectContaining({ type: "setViewRange" }),
+        );
+
+        source.resume();
+        expect(serverAPI.send).toHaveBeenCalledWith({
+          type: "resume",
+          viewport: "source-vp",
+        });
+        expect(serverAPI.send).not.toHaveBeenCalledWith(
+          expect.objectContaining({ type: "setViewRange" }),
+        );
+      });
+
     });
 
     it("uses options supplied at creation, if not passed with subscription", async () => {

--- a/vuu-ui/packages/vuu-data-remote/test/server-proxy-suspend.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/server-proxy-suspend.test.ts
@@ -137,6 +137,64 @@ describe("suspend and resume", () => {
     vi.useRealTimers();
   });
 
+  it("replays an inserted row received while non-escalating suspension suppresses client delivery", async () => {
+    const [serverProxy, postMessageToClient, connection] =
+      await createFixtures();
+    serverProxy.handleMessageFromServer({
+      ...COMMON_ATTRS,
+      body: {
+        ...COMMON_TABLE_ROW_ATTRS,
+        rows: [
+          sizeRow("server-vp-1", 100),
+          ...createTableRows("server-vp-1", 0, 10),
+        ],
+      },
+    });
+    postMessageToClient.mockClear();
+    connection.send.mockClear();
+    vi.useFakeTimers();
+
+    serverProxy.handleMessageFromClient({
+      escalateToDisable: false,
+      type: "suspend",
+      viewport: "client-vp-1",
+    });
+    serverProxy.handleMessageFromServer({
+      ...COMMON_ATTRS,
+      body: {
+        ...COMMON_TABLE_ROW_ATTRS,
+        rows: [
+          sizeRow("server-vp-1", 101),
+          updateTableRow("server-vp-1", 3, 2004, {
+            key: "inserted",
+            vpSize: 101,
+          }),
+        ],
+      },
+    });
+    vi.advanceTimersByTime(3000);
+
+    expect(postMessageToClient).not.toHaveBeenCalled();
+    expect(connection.send).not.toHaveBeenCalled();
+
+    serverProxy.handleMessageFromClient({
+      type: "resume",
+      viewport: "client-vp-1",
+    });
+
+    expect(postMessageToClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rows: expect.arrayContaining([
+          expect.arrayContaining(["key-inserted", "name inserted", 2004]),
+        ]),
+        size: 101,
+        type: "viewport-update",
+      }),
+    );
+
+    vi.useRealTimers();
+  });
+
   it("suspend escalation delay can be configured", async () => {
     const [serverProxy, , connection] = await createFixtures();
     connection.send.mockClear();

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -4,6 +4,7 @@ import {
 } from "@vuu-ui/vuu-data-local";
 import type {
   DataSourceBase,
+  DataSource,
   DataSourceRowWithBigint,
   DataSourceSubscribeCallback,
   DataSourceSubscribeProps,
@@ -65,6 +66,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
   #pendingVisualLink?: LinkDescriptorWithLabel;
   #rpcMenuServices: RpcMenuService[] | undefined;
   #rpcServices: RpcService[] | undefined;
+  #sourceTableDataSource: TickingArrayDataSource | undefined;
   #table?: Table;
   #selectionLinkSubscribers: Map<string, LinkSubscription> | undefined;
   #visualLinkService?: VisualLinkHandler;
@@ -161,6 +163,10 @@ export class TickingArrayDataSource extends ArrayDataSource {
     return Array.from(this.selectedRows);
   }
 
+  isSessionDataSourceOf(dataSource: DataSource): boolean {
+    return this.#sourceTableDataSource === dataSource;
+  }
+
   async createSessionDataSource(
     copyOption: CopyOption,
   ): Promise<DataSourceBase<DataSourceRowWithBigint> | undefined> {
@@ -174,11 +180,15 @@ export class TickingArrayDataSource extends ArrayDataSource {
       const columns = this.config.columns.includes("vuu_action")
         ? this.config.columns
         : this.config.columns.concat("vuu_action");
-      return this.#vuuModule?.createDataSource(
+      const sessionDataSource = this.#vuuModule?.createDataSource(
         sessionTable.table,
         sessionTable.table,
         { ...this.config, columns },
       );
+      if (sessionDataSource instanceof TickingArrayDataSource) {
+        sessionDataSource.#sourceTableDataSource = this;
+      }
+      return sessionDataSource;
     } else {
       throw Error(
         `[TickingArrayDataSource] createSessionDataSource ${rpcResponse?.errorMessage}`,
@@ -282,7 +292,13 @@ export class TickingArrayDataSource extends ArrayDataSource {
     );
 
     if (isRpcSuccess(rpcResponse)) {
-      this.sendRowsToClient(true);
+      const sourceTableDataSource = this.#sourceTableDataSource;
+      if (sourceTableDataSource) {
+        this.#sourceTableDataSource = undefined;
+        this.unsubscribe();
+      } else {
+        this.sendRowsToClient(true);
+      }
     } else {
       if (rpcResponse?.errorMessage === "stale update") {
         throw new StaleUpdateError(rpcResponse.errorMessage);

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -10,6 +10,7 @@ import type {
   RpcResultError,
   RpcResultSuccess,
 } from "@vuu-ui/vuu-protocol-types";
+import { Range } from "@vuu-ui/vuu-utils";
 
 const schema: TableSchema = {
   columns: [
@@ -416,5 +417,59 @@ describe("createSessionDataSource", () => {
     await expect(ds.createSessionDataSource?.("All")).rejects.toThrow(
       "session table creation failed",
     );
+  });
+
+  it("replays committed rows from the source datasource when session editing ends", async () => {
+    const sourceTable = new Table(
+      schema,
+      [["row-001", "Alice", ""]],
+      buildDataColumnMapFromSchema(schema),
+    );
+    const sessionTable = new Table(
+      { ...schema, table: { module: "TEST", table: "session-xyz" } },
+      [],
+      buildDataColumnMapFromSchema(schema),
+    );
+    const sessionDataSource = new TickingArrayDataSource({
+      columnDescriptors: schema.columns,
+      table: sessionTable,
+    });
+    const sourceDataSource = new TickingArrayDataSource({
+      columnDescriptors: schema.columns,
+      table: sourceTable,
+      vuuModule: {
+        createDataSource: () => sessionDataSource,
+      },
+    });
+    vi.spyOn(sourceDataSource, "rpcRequest").mockResolvedValue(sessionSuccess);
+
+    const updates = vi.fn();
+    await sourceDataSource.subscribe({ range: Range(0, 10) }, updates);
+    updates.mockClear();
+
+    const editDataSource =
+      await sourceDataSource.createSessionDataSource("Empty");
+    expect(editDataSource?.isSessionDataSourceOf?.(sourceDataSource)).toBe(
+      true,
+    );
+    sourceDataSource.suspend(false);
+    vi.spyOn(sessionDataSource, "rpcRequest").mockImplementation(async () => {
+      sourceTable.insert(["row-002", "Bob", ""]);
+      updates.mockClear();
+      return SUCCESS;
+    });
+
+    await editDataSource?.endEditSession?.(true);
+    expect(updates).not.toHaveBeenCalled();
+
+    sourceDataSource.resume(updates);
+    const rows = updates.mock.calls.at(-1)?.[0].rows;
+    expect(rows).toEqual(
+      expect.arrayContaining([expect.arrayContaining(["row-002", "Bob"])]),
+    );
+
+    updates.mockClear();
+    await editDataSource?.endEditSession?.(true);
+    expect(updates).not.toHaveBeenCalled();
   });
 });

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -695,6 +695,11 @@ export interface DataSourceBase<
    */
   suspend?: (escalateToDisable?: boolean, escalateDelay?: number) => void;
   resume?: (callback?: DataSourceSubscribeCallback) => void;
+  /**
+   * Returns true when this datasource is a transient session datasource
+   * created by the supplied source datasource.
+   */
+  isSessionDataSourceOf?: (dataSource: DataSource) => boolean;
 
   deleteRow?: DataSourceDeleteHandler;
   /**

--- a/vuu-ui/packages/vuu-table/src/table-data-source/useDataSource.ts
+++ b/vuu-ui/packages/vuu-table/src/table-data-source/useDataSource.ts
@@ -363,12 +363,15 @@ export const useDataSource = ({
     }
 
     return () => {
+      const replacementDataSource = activeBindingRef.current?.dataSource;
+      const isOwnSessionReplacement =
+        replacementDataSource?.isSessionDataSourceOf?.(dataSource) === true;
       if (activeBindingRef.current === binding) {
         activeBindingRef.current = undefined;
       }
       dataSource.removeListener("resumed", handleResume);
       dataSource.suspend?.(
-        suspenseProps?.escalateToDisable,
+        isOwnSessionReplacement ? false : suspenseProps?.escalateToDisable,
         suspenseProps?.escalateDelay,
       );
     };

--- a/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
+++ b/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
@@ -1,0 +1,118 @@
+import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
+import { Range } from "@vuu-ui/vuu-utils";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { useDataSource } from "../src/table-data-source/useDataSource";
+
+const tableSchema: TableSchema = {
+  columns: [{ name: "id", serverDataType: "string" }],
+  key: "id",
+  table: { module: "TEST", table: "test" },
+};
+
+const createDataSource = () => {
+  const resolvedSuspensions: boolean[] = [];
+  const dataSource = {
+    columns: ["id"],
+    isSessionDataSourceOf: vi.fn(() => false),
+    on: vi.fn(),
+    range: Range(0, 10),
+    removeListener: vi.fn(),
+    resume: vi.fn(),
+    status: "subscribed",
+    suspend: vi.fn((escalateToDisable = true) => {
+      resolvedSuspensions.push(escalateToDisable);
+    }),
+    tableSchema,
+  } as unknown as DataSource;
+
+  return { dataSource, resolvedSuspensions };
+};
+
+const Fixture = ({ dataSource }: { dataSource: DataSource }) => {
+  useDataSource({
+    dataSource,
+    onSelect: vi.fn(),
+    onSizeChange: vi.fn(),
+    onSubscribed: vi.fn(),
+  });
+  return null;
+};
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  (
+    globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    }
+  ).IS_REACT_ACT_ENVIRONMENT = false;
+});
+
+describe("useDataSource replacement suspension", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("does not escalate suspension when switching to the source's session datasource", async () => {
+    const source = createDataSource();
+    const session = createDataSource();
+    vi.mocked(session.dataSource.isSessionDataSourceOf!).mockImplementation(
+      (dataSource) => dataSource === source.dataSource,
+    );
+
+    await act(async () =>
+      root.render(<Fixture dataSource={source.dataSource} />),
+    );
+    await act(async () =>
+      root.render(<Fixture dataSource={session.dataSource} />),
+    );
+
+    expect(source.dataSource.suspend).toHaveBeenCalledWith(false, undefined);
+    expect(source.resolvedSuspensions).toEqual([false]);
+  });
+
+  it("preserves normal escalating suspension for ordinary replacements", async () => {
+    const source = createDataSource();
+    const replacement = createDataSource();
+
+    await act(async () =>
+      root.render(<Fixture dataSource={source.dataSource} />),
+    );
+    await act(async () =>
+      root.render(<Fixture dataSource={replacement.dataSource} />),
+    );
+
+    expect(source.dataSource.suspend).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+    );
+    expect(source.resolvedSuspensions).toEqual([true]);
+  });
+});


### PR DESCRIPTION
## Summary
- keep a source datasource's server viewport and worker cache live when the table switches to its own standalone session datasource by using non-escalating suspension
- identify source/session relationships through the datasource API while preserving ordinary replacement and unmount suspension behavior
- replay cached source updates on return without a post-session range refresh; retain a deferred refresh only for genuinely disabled sources, including pending-disable races
- preserve legacy `beginEditSession` and `createSessionDataSource` behavior on `main`, keep failed/stale sessions retryable, and clear source references after success
- prevent standalone saves from resuming the source before session completion and mirror suspended-delivery behavior in the local test datasource

## Validation
- `npx vitest run packages/vuu-table/test/useDataSource.test.tsx packages/vuu-data-remote/test/VuuDataSource.test.ts packages/vuu-data-remote/test/server-proxy-suspend.test.ts packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts packages/vuu-utils/test/data-editing/useEditableTable.test.tsx --reporter=dot` (74 tests)
- `npm run typecheck -- --pretty false`
- changed-file ESLint completed with no errors (four pre-existing `no-explicit-any` warnings in `VuuDataSource.test.ts`)