### PR TITLE
Fix session datasource row initialization

### DIFF
--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/parse/csv-upload-utils.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/parse/csv-upload-utils.ts
@@ -1,3 +1,4 @@
+import type { DataSource } from "@vuu-ui/vuu-data-types";
 import type { RpcResult, VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
 import { isRpcError } from "@vuu-ui/vuu-utils";
 import type { CsvUploadError } from "../CsvUpload";
@@ -30,6 +31,31 @@ export const isCsvParseError = (value: unknown): value is CsvParseError =>
 
 export const hasFileParseErrors = (parseError: CsvParseError) =>
   Object.keys(parseError.errorMap.fileErrors).length > 0;
+
+export const ensureSessionTableColumnsPresent = (
+  dataSource: Pick<DataSource, "columns">,
+) => {
+  const { columns } = dataSource;
+  const hasMessageColumn = columns.includes("vuuMsg");
+  const hasActionColumn = columns.includes("vuu_action");
+
+  if (hasMessageColumn && hasActionColumn) {
+    return;
+  }
+
+  if (hasActionColumn) {
+    const actionColumnIndex = columns.indexOf("vuu_action");
+    dataSource.columns = [
+      ...columns.slice(0, actionColumnIndex),
+      "vuuMsg",
+      ...columns.slice(actionColumnIndex),
+    ];
+  } else {
+    dataSource.columns = hasMessageColumn
+      ? columns.concat("vuu_action")
+      : columns.concat("vuuMsg", "vuu_action");
+  }
+};
 
 export const createUploadError = (
   source: CsvUploadError["source"],

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildRowErrorMessage,
   createUploadError,
+  ensureSessionTableColumnsPresent,
   hasFileParseErrors,
   isCsvParseError,
   mergeValidationWithParseErrors,
@@ -223,9 +224,7 @@ export const useCsvUpload = ({
         "CsvUpload createSessionDataSource returned no session datasource.",
       );
     }
-    if (!sessionDataSource.columns.includes("vuuMsg")) {
-      sessionDataSource.columns = sessionDataSource.columns.concat("vuuMsg");
-    }
+    ensureSessionTableColumnsPresent(sessionDataSource);
     setActiveSessionDataSource(sessionDataSource);
     onImportSessionStarted?.(sessionDataSource);
     return sessionDataSource;

--- a/vuu-ui/packages/vuu-table-extras/test/csv-upload/csv-upload-utils.test.ts
+++ b/vuu-ui/packages/vuu-table-extras/test/csv-upload/csv-upload-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildRowErrorMessage,
+  ensureSessionTableColumnsPresent,
   executeBatchRpcCalls,
   mergeValidationWithParseErrors,
   normalizeTableData,
@@ -157,6 +158,39 @@ describe("csv-upload-utils", () => {
     expect(mergeValidationWithParseErrors(validation, undefined)).toBe(
       validation,
     );
+  });
+
+  describe("ensureSessionTableColumnsPresent", () => {
+    it("does nothing when both session columns are already present", () => {
+      const setColumns = vi.fn();
+      const dataSource = {
+        columns: ["id", "vuuMsg", "vuu_action"],
+      };
+      Object.defineProperty(dataSource, "columns", {
+        get: () => ["id", "vuuMsg", "vuu_action"],
+        set: setColumns,
+      });
+
+      ensureSessionTableColumnsPresent(dataSource);
+
+      expect(setColumns).not.toHaveBeenCalled();
+    });
+
+    it("adds the missing message column before the session action column", () => {
+      const dataSource = { columns: ["id", "vuu_action"] };
+
+      ensureSessionTableColumnsPresent(dataSource);
+
+      expect(dataSource.columns).toEqual(["id", "vuuMsg", "vuu_action"]);
+    });
+
+    it("adds both missing session columns in payload order", () => {
+      const dataSource = { columns: ["id"] };
+
+      ensureSessionTableColumnsPresent(dataSource);
+
+      expect(dataSource.columns).toEqual(["id", "vuuMsg", "vuu_action"]);
+    });
   });
 
   describe("buildRowErrorMessage", () => {

--- a/vuu-ui/packages/vuu-table-extras/test/csv-upload/useCsvUpload.test.tsx
+++ b/vuu-ui/packages/vuu-table-extras/test/csv-upload/useCsvUpload.test.tsx
@@ -171,7 +171,13 @@ describe("useCsvUpload", () => {
     expect(latestResult?.canImport).toBe(true);
     expect(latestResult?.validation?.errors).toHaveLength(0);
     expect(dataSource.createSessionDataSource).toHaveBeenCalledWith("Empty");
-    expect(getSessionDataSource(dataSource).columns).toContain("vuuMsg");
+    expect(getSessionDataSource(dataSource).columns).toEqual([
+      "id",
+      "label",
+      "count",
+      "vuuMsg",
+      "vuu_action",
+    ]);
     expect(getSessionDataSource(dataSource).addRow).toHaveBeenCalled();
     expect(dataSource.rpcRequest).not.toHaveBeenCalled();
   });

--- a/vuu-ui/packages/vuu-table/src/table-data-source/useDataSource.ts
+++ b/vuu-ui/packages/vuu-table/src/table-data-source/useDataSource.ts
@@ -36,6 +36,7 @@ type DataSourceBinding = {
   rangeLimits: RangeLimits;
   rangeRequested: boolean;
   rowAutoSelected: boolean;
+  pendingRows: DataSourceRow[];
   setColumns?: (columns: string[]) => void;
 };
 
@@ -92,9 +93,13 @@ export const useDataSource = ({
             previousRange.to,
             renderBufferSize,
           );
+          const tableSchema = dataSource.tableSchema;
+          const [dataRow, setColumns] = tableSchema
+            ? dataRowFactory(dataSource.columns, tableSchema.columns)
+            : [NullDataRow, undefined];
 
           return {
-            dataRow: NullDataRow,
+            dataRow,
             dataRows: { current: [] },
             dataRowWindow: new DataRowMovingWindow(range.withBuffer),
             dataSource,
@@ -105,6 +110,8 @@ export const useDataSource = ({
             rangeLimits: { ...defaultRangeLimits },
             rangeRequested: false,
             rowAutoSelected: false,
+            pendingRows: [],
+            setColumns,
           };
         })();
   previousBindingRef.current = binding;
@@ -213,6 +220,10 @@ export const useDataSource = ({
       }
       if (message.type === "subscribed") {
         createDataRow(message.columns, message.tableSchema.columns);
+        if (binding.pendingRows.length > 0) {
+          setData(binding.pendingRows);
+          binding.pendingRows = [];
+        }
         if (message.tableSchema.rangeLimits) {
           binding.rangeLimits = message.tableSchema.rangeLimits;
         }
@@ -226,7 +237,11 @@ export const useDataSource = ({
           binding.dataRowWindow.setRowCount(message.size);
         }
         if (message.rows) {
-          setData(message.rows);
+          if (binding.setColumns === undefined) {
+            binding.pendingRows.push(...message.rows);
+          } else {
+            setData(message.rows);
+          }
           if (autoSelect && binding.rowAutoSelected === false) {
             // OR if no selected row in message.rows, e.g after a filter
             binding.rowAutoSelected = true;

--- a/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
+++ b/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
@@ -1,6 +1,6 @@
 import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
 import { Range } from "@vuu-ui/vuu-utils";
-import { act } from "react";
+import { act, useEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import {
   afterAll,
@@ -39,6 +39,16 @@ const createDataSource = () => {
   return { dataSource, resolvedSuspensions };
 };
 
+const sessionTableSchema: TableSchema = {
+  columns: [
+    { name: "id", serverDataType: "string" },
+    { name: "vuuMsg", serverDataType: "string" },
+    { name: "vuu_action", serverDataType: "string" },
+  ],
+  key: "id",
+  table: { module: "TEST", table: "session" },
+};
+
 const Fixture = ({ dataSource }: { dataSource: DataSource }) => {
   useDataSource({
     dataSource,
@@ -46,6 +56,31 @@ const Fixture = ({ dataSource }: { dataSource: DataSource }) => {
     onSizeChange: vi.fn(),
     onSubscribed: vi.fn(),
   });
+  return null;
+};
+
+const SessionRowsFixture = ({
+  dataSource,
+  onRows,
+}: {
+  dataSource: DataSource;
+  onRows: (rows: ReturnType<typeof useDataSource>["dataRows"]) => void;
+}) => {
+  const { dataRows, setRange } = useDataSource({
+    dataSource,
+    onSelect: vi.fn(),
+    onSizeChange: vi.fn(),
+    onSubscribed: vi.fn(),
+  });
+
+  useEffect(() => {
+    setRange({ from: 0, to: 1 });
+  }, [setRange]);
+
+  useEffect(() => {
+    onRows(dataRows);
+  }, [dataRows, onRows]);
+
   return null;
 };
 
@@ -83,7 +118,13 @@ describe("useDataSource replacement suspension", () => {
   it("does not escalate suspension when switching to the source's session datasource", async () => {
     const source = createDataSource();
     const session = createDataSource();
-    vi.mocked(session.dataSource.isSessionDataSourceOf!).mockImplementation(
+    const isSessionDataSourceOf = session.dataSource.isSessionDataSourceOf;
+    if (isSessionDataSourceOf === undefined) {
+      throw Error(
+        "Test session datasource must identify its source datasource.",
+      );
+    }
+    vi.mocked(isSessionDataSourceOf).mockImplementation(
       (dataSource) => dataSource === source.dataSource,
     );
 
@@ -114,5 +155,63 @@ describe("useDataSource replacement suspension", () => {
       undefined,
     );
     expect(source.resolvedSuspensions).toEqual([true]);
+  });
+
+  it("waits for the session schema before creating DataRows from early updates", async () => {
+    let callback: Parameters<NonNullable<DataSource["subscribe"]>>[1];
+    let rows: ReturnType<typeof useDataSource>["dataRows"] = [];
+    const earlySessionDataSource = {
+      columns: ["id", "vuuMsg", "vuu_action"],
+      on: vi.fn(),
+      range: Range(0, 1),
+      removeListener: vi.fn(),
+      status: "initialising",
+      subscribe: vi.fn((_props, nextCallback) => {
+        callback = nextCallback;
+        callback({
+          rows: [
+            [
+              0,
+              0,
+              false,
+              false,
+              0,
+              0,
+              "row-1",
+              false,
+              0,
+              false,
+              "row-1",
+              "",
+              "addRow",
+            ],
+          ],
+          size: 1,
+          type: "viewport-update",
+        });
+        callback({
+          columns: ["id", "vuuMsg", "vuu_action"],
+          tableSchema: sessionTableSchema,
+          type: "subscribed",
+        });
+      }),
+      suspend: vi.fn(),
+    } as unknown as DataSource;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await act(async () =>
+      root.render(
+        <SessionRowsFixture
+          dataSource={earlySessionDataSource}
+          onRows={(nextRows) => {
+            rows = nextRows;
+          }}
+        />,
+      ),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].vuu_action).toBe("addRow");
+    expect(warn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- initialize a `DataRow` factory from an available datasource schema before session rows arrive
- queue early viewport updates until the session subscription supplies its schema
- normalize CSV session columns so `vuuMsg` precedes the final `vuu_action` payload column

## Validation
- `npx vitest run packages/vuu-table/test/useDataSource.test.tsx packages/vuu-table-extras/test/csv-upload/useCsvUpload.test.tsx`
- `npx biome check packages/vuu-table/src/table-data-source/useDataSource.ts packages/vuu-table/test/useDataSource.test.tsx packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts packages/vuu-table-extras/test/csv-upload/useCsvUpload.test.tsx`
- `npm run typecheck -- --pretty false` *(existing unrelated baseline diagnostics; none in changed files)*