### PR TITLE
Fix DataRow column synchronization during edit sessions

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -173,9 +173,10 @@ export const useEditableTable = ({
     onDelete: handleDelete,
     onSave: handleSave,
     onUndoRowChange: handleUndoRowChange,
-    rowClassNameGenerators: isEditMode
-      ? EDIT_ACTION_ROW_CLASS_NAME_GENERATORS
-      : undefined,
+    rowClassNameGenerators:
+      isEditMode && sessionDataSource !== undefined
+        ? EDIT_ACTION_ROW_CLASS_NAME_GENERATORS
+        : undefined,
     sessionDataSource,
     sourceDataSource,
   };

--- a/vuu-ui/packages/vuu-data-remote/src/inlined-worker.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/inlined-worker.ts
@@ -18,6 +18,10 @@ function partition(array, test, pass = [], fail = []) {
   return [pass, fail];
 }
 
+// ../vuu-utils/src/column-utils.ts
+var CalculatedColumnPattern = /.*:.*:.*/;
+var isCalculatedColumn = (columnName) => columnName !== void 0 && CalculatedColumnPattern.test(columnName);
+
 // ../vuu-utils/src/cookie-utils.ts
 var getCookieValue = (name) => {
   var _a, _b;
@@ -990,6 +994,13 @@ var Viewport = class {
     this.dataWindow.setRange(range.from, range.to);
     const tableSchema = table === baseTableSchema.table.table ? baseTableSchema : {
       ...baseTableSchema,
+      columns: baseTableSchema.columns.concat(
+        columns.filter(
+          (name) => !isCalculatedColumn(name) && !baseTableSchema.columns.some(
+            (column) => column.name === name
+          )
+        ).map((name) => ({ name, serverDataType: "string" }))
+      ),
       table: {
         ...baseTableSchema.table,
         session: table

--- a/vuu-ui/packages/vuu-data-remote/src/server-proxy/viewport.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/server-proxy/viewport.ts
@@ -44,7 +44,13 @@ import {
   FreezeViewportRequest,
   UnfreezeViewportRequest,
 } from "@vuu-ui/vuu-protocol-types";
-import { getFullRange, KeySet, logger, RangeMonitor } from "@vuu-ui/vuu-utils";
+import {
+  getFullRange,
+  isCalculatedColumn,
+  KeySet,
+  logger,
+  RangeMonitor,
+} from "@vuu-ui/vuu-utils";
 import { getFirstAndLastRows } from "../message-utils";
 import { ArrayBackedMovingWindow } from "./array-backed-moving-window";
 import * as Message from "./messages";
@@ -323,15 +329,26 @@ export class Viewport {
       table === baseTableSchema.table.table
         ? baseTableSchema
         : {
-          ...baseTableSchema,
-          table: {
-            ...baseTableSchema.table,
-            session: table,
-          },
-        };
+            ...baseTableSchema,
+            columns: baseTableSchema.columns.concat(
+              columns
+                .filter(
+                  (name) =>
+                    !isCalculatedColumn(name) &&
+                    !baseTableSchema.columns.some(
+                      (column) => column.name === name,
+                    ),
+                )
+                .map((name) => ({ name, serverDataType: "string" as const })),
+            ),
+            table: {
+              ...baseTableSchema.table,
+              session: table,
+            },
+          };
 
     if (tableSchema.rangeLimits) {
-      this.#maxRangeEnd = tableSchema.rangeLimits?.maxRangeEnd
+      this.#maxRangeEnd = tableSchema.rangeLimits?.maxRangeEnd;
     }
 
     return {

--- a/vuu-ui/packages/vuu-data-remote/test/viewport.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/viewport.test.ts
@@ -177,6 +177,27 @@ describe("Viewport", () => {
         type: "subscribed",
       });
     });
+
+    it("adds subscribed session columns to the session table schema", () => {
+      const vp = new Viewport(constructor_options, noop);
+      const message = vp.handleSubscribed(
+        {
+          ...vuu_config_options,
+          columns: ["col1", "session_status"],
+          range: { from: 0, to: 50 },
+          type: "CREATE_VP_SUCCESS",
+          table: "session-test-table",
+          viewPortId: "server-vp1",
+        },
+        testSchema,
+      );
+
+      expect(message.tableSchema.columns).toEqual([
+        ...testSchema.columns,
+        { name: "col1", serverDataType: "string" },
+        { name: "session_status", serverDataType: "string" },
+      ]);
+    });
   });
 
   describe("pending range requests", () => {

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -877,6 +877,15 @@ test.describe("Inline row editing (session)", () => {
     mount,
     page,
   }) => {
+    const dataRowWarnings: string[] = [];
+    page.on("console", (message) => {
+      if (
+        message.type() === "warning" &&
+        message.text().includes("[DataRow:Proxy] unknown column")
+      ) {
+        dataRowWarnings.push(message.text());
+      }
+    });
     await mount(<EditableInstrumentsInlineEdit />);
 
     // View mode: no Delete/Add Rows/Submit buttons visible
@@ -894,6 +903,8 @@ test.describe("Inline row editing (session)", () => {
     await expect(
       page.getByRole("columnheader", { name: "undo" }),
     ).toBeVisible();
+    await expect(page.getByRole("row").nth(1)).toBeVisible();
+    expect(dataRowWarnings).toEqual([]);
   });
 
   test("Submit is disabled until at least one row is changed", async ({

--- a/vuu-ui/packages/vuu-table/src/data-row/DataRow.ts
+++ b/vuu-ui/packages/vuu-table/src/data-row/DataRow.ts
@@ -6,6 +6,7 @@ import type {
   VuuRowDataItemType,
 } from "@vuu-ui/vuu-protocol-types";
 import type {
+  ColumnDescriptor,
   DataRow,
   DataRowIntrinsicAttribute,
   DataRowOperation,
@@ -19,9 +20,11 @@ import {
 } from "@vuu-ui/vuu-utils";
 
 type ColumnMapEntry = {
-  index: number;
+  index?: number;
   type: VuuColumnDataType;
 };
+
+type RenderedColumn = Pick<ColumnDescriptor, "name" | "source">;
 
 const dataRowSymbol = Symbol("DataRow");
 
@@ -127,27 +130,29 @@ const formatStringNumeric = (value: string, type: StringNumericType) => {
  * @param columnMap
  * @returns
  */
-function DataRowImpl(data: VuuDataRow, columnMap: DataRowColumnMap): DataRow {
+function DataRowImpl(
+  data: VuuDataRow,
+  columnMapRef: { current: DataRowColumnMap },
+): DataRow {
   const target: Record<string, VuuRowDataItemType> = {};
 
   const getPropertyNames = () => {
-    return Object.keys(columnMap);
+    return Object.keys(columnMapRef.current);
   };
 
   const jsonSerializer = () => {
-    return Object.entries(columnMap).reduce<Record<string, VuuRowDataItemType>>(
-      (json, [name, mapEntry]) => {
-        if (mapEntry) {
-          json[name] = data[mapEntry.index];
-        }
-        return json;
-      },
-      {},
-    );
+    return Object.entries(columnMapRef.current).reduce<
+      Record<string, VuuRowDataItemType>
+    >((json, [name, mapEntry]) => {
+      if (mapEntry?.index !== undefined) {
+        json[name] = data[mapEntry.index];
+      }
+      return json;
+    }, {});
   };
 
   const DataRowOperations: DataRowOperations = {
-    hasColumn: (name: string) => columnMap[name] !== undefined,
+    hasColumn: (name: string) => columnMapRef.current[name] !== undefined,
   };
 
   return new Proxy(target, {
@@ -168,13 +173,17 @@ function DataRowImpl(data: VuuDataRow, columnMap: DataRowColumnMap): DataRow {
       } else if (prop === "getPropertyNames") {
         return getPropertyNames;
       }
-      const columnMapEntry = columnMap[prop];
+      const columnMapEntry = columnMapRef.current[prop];
 
       if (columnMapEntry === undefined) {
         if (prop !== "") {
           // System columns like the selection checkbox column
           console.warn(`[DataRow:Proxy] unknown column ${prop}`);
         }
+        return undefined;
+      }
+
+      if (columnMapEntry.index === undefined) {
         return undefined;
       }
 
@@ -215,6 +224,7 @@ const ColumnMapIntrinsicColumns: DataRowColumnMap = {
 function createColumnMap(
   columns: string[],
   schemaColumns: readonly SchemaColumn[],
+  renderedColumns: readonly RenderedColumn[] = [],
 ) {
   const columnMap: DataRowColumnMap = {
     ...ColumnMapIntrinsicColumns,
@@ -244,13 +254,18 @@ function createColumnMap(
 
   if (columnMap.vuuMsg === undefined) {
     // We will always check for vuuMsg, even if it isn't explicitly included in the subscribed columns
-    return {
-      ...columnMap,
-      vuuMsg: { index: columns.length + 10, type: "string" },
-    } as DataRowColumnMap;
-  } else {
-    return columnMap;
+    columnMap.vuuMsg = { index: columns.length + 10, type: "string" };
   }
+
+  for (const { name } of renderedColumns) {
+    if (columnMap[name] === undefined) {
+      // Client columns and temporarily unsubscribed rendered columns have no
+      // backing value in the row array, but are valid Table columns.
+      columnMap[name] = { type: "string" };
+    }
+  }
+
+  return columnMap;
 }
 
 /**
@@ -261,22 +276,43 @@ function createColumnMap(
  * @returns a tuple containing:
  * - factory function that will create a DataRow instance from a DataSourceRow
  * array.
- * - a function that can be used to reset the columns, which will be used for all
- * subsequently created DataRows. Used by Table when user adds or removes columns
- * at runtime.
+ * - a function that resets the shared column map used by existing and subsequently
+ * created DataRows. Used by Table when user adds or removes columns at runtime.
  */
 export const dataRowFactory = (
   columns: string[],
   schemaColumns: readonly SchemaColumn[],
-): [DataRowFunc, (columns: string[]) => void] => {
-  let columnMap = createColumnMap(columns, schemaColumns);
+  renderedColumns: readonly RenderedColumn[] = [],
+): [
+  DataRowFunc,
+  (columns: string[], renderedColumns?: readonly RenderedColumn[]) => void,
+] => {
+  const columnMapRef = {
+    current: createColumnMap(columns, schemaColumns, renderedColumns),
+  };
+  let currentColumns = columns;
+  let currentRenderedColumns = renderedColumns;
 
-  const setColumns = (columns: string[]) => {
-    // new columnMap will be used for all subsequently created DataRows
-    columnMap = createColumnMap(columns, schemaColumns);
+  const setColumns = (
+    columns: string[],
+    nextRenderedColumns: readonly RenderedColumn[] = [],
+  ) => {
+    if (
+      columns === currentColumns &&
+      nextRenderedColumns === currentRenderedColumns
+    ) {
+      return;
+    }
+    currentColumns = columns;
+    currentRenderedColumns = nextRenderedColumns;
+    columnMapRef.current = createColumnMap(
+      columns,
+      schemaColumns,
+      nextRenderedColumns,
+    );
   };
 
-  const DataRow = (data: DataSourceRow) => DataRowImpl(data, columnMap);
+  const DataRow = (data: DataSourceRow) => DataRowImpl(data, columnMapRef);
 
   return [DataRow, setColumns];
 };

--- a/vuu-ui/packages/vuu-table/src/data-row/DataRow.ts
+++ b/vuu-ui/packages/vuu-table/src/data-row/DataRow.ts
@@ -171,8 +171,8 @@ function DataRowImpl(data: VuuDataRow, columnMap: DataRowColumnMap): DataRow {
       const columnMapEntry = columnMap[prop];
 
       if (columnMapEntry === undefined) {
-        if (prop !== "" && prop !== "undo" && prop !== "vuu_action") {
-          // System columns like the selection checkbox column or client/session action columns
+        if (prop !== "") {
+          // System columns like the selection checkbox column
           console.warn(`[DataRow:Proxy] unknown column ${prop}`);
         }
         return undefined;
@@ -234,9 +234,6 @@ function createColumnMap(
           `[DataRow] calculated column with invalid serverDataType ${name}`,
         );
       }
-    } else if (name === "vuu_action") {
-      // column on a session table
-      columnMap[name] = { index: i + 10, type: "string" };
     } else {
       throw Error(`[DataRow] dataRowFactory column not in schema ${name}`);
     }

--- a/vuu-ui/packages/vuu-table/src/data-row/DataRow.ts
+++ b/vuu-ui/packages/vuu-table/src/data-row/DataRow.ts
@@ -6,7 +6,6 @@ import type {
   VuuRowDataItemType,
 } from "@vuu-ui/vuu-protocol-types";
 import type {
-  ColumnDescriptor,
   DataRow,
   DataRowIntrinsicAttribute,
   DataRowOperation,
@@ -20,11 +19,9 @@ import {
 } from "@vuu-ui/vuu-utils";
 
 type ColumnMapEntry = {
-  index?: number;
+  index: number;
   type: VuuColumnDataType;
 };
-
-type RenderedColumn = Pick<ColumnDescriptor, "name" | "source">;
 
 const dataRowSymbol = Symbol("DataRow");
 
@@ -130,29 +127,27 @@ const formatStringNumeric = (value: string, type: StringNumericType) => {
  * @param columnMap
  * @returns
  */
-function DataRowImpl(
-  data: VuuDataRow,
-  columnMapRef: { current: DataRowColumnMap },
-): DataRow {
+function DataRowImpl(data: VuuDataRow, columnMap: DataRowColumnMap): DataRow {
   const target: Record<string, VuuRowDataItemType> = {};
 
   const getPropertyNames = () => {
-    return Object.keys(columnMapRef.current);
+    return Object.keys(columnMap);
   };
 
   const jsonSerializer = () => {
-    return Object.entries(columnMapRef.current).reduce<
-      Record<string, VuuRowDataItemType>
-    >((json, [name, mapEntry]) => {
-      if (mapEntry?.index !== undefined) {
-        json[name] = data[mapEntry.index];
-      }
-      return json;
-    }, {});
+    return Object.entries(columnMap).reduce<Record<string, VuuRowDataItemType>>(
+      (json, [name, mapEntry]) => {
+        if (mapEntry) {
+          json[name] = data[mapEntry.index];
+        }
+        return json;
+      },
+      {},
+    );
   };
 
   const DataRowOperations: DataRowOperations = {
-    hasColumn: (name: string) => columnMapRef.current[name] !== undefined,
+    hasColumn: (name: string) => columnMap[name] !== undefined,
   };
 
   return new Proxy(target, {
@@ -173,17 +168,13 @@ function DataRowImpl(
       } else if (prop === "getPropertyNames") {
         return getPropertyNames;
       }
-      const columnMapEntry = columnMapRef.current[prop];
+      const columnMapEntry = columnMap[prop];
 
       if (columnMapEntry === undefined) {
-        if (prop !== "") {
-          // System columns like the selection checkbox column
+        if (prop !== "" && prop !== "undo" && prop !== "vuu_action") {
+          // System columns like the selection checkbox column or client/session action columns
           console.warn(`[DataRow:Proxy] unknown column ${prop}`);
         }
-        return undefined;
-      }
-
-      if (columnMapEntry.index === undefined) {
         return undefined;
       }
 
@@ -224,13 +215,12 @@ const ColumnMapIntrinsicColumns: DataRowColumnMap = {
 function createColumnMap(
   columns: string[],
   schemaColumns: readonly SchemaColumn[],
-  renderedColumns: readonly RenderedColumn[] = [],
 ) {
   const columnMap: DataRowColumnMap = {
     ...ColumnMapIntrinsicColumns,
   };
 
-  columns.forEach((name, i, cols) => {
+  columns.forEach((name, i) => {
     const schemaColumn = schemaColumns.find((col) => col.name === name);
     if (schemaColumn) {
       const serverDataType = getServerDataType(schemaColumn, true);
@@ -244,8 +234,8 @@ function createColumnMap(
           `[DataRow] calculated column with invalid serverDataType ${name}`,
         );
       }
-    } else if (name === "vuu_action" && i === cols.length - 1) {
-      // column on a session table, always in last place
+    } else if (name === "vuu_action") {
+      // column on a session table
       columnMap[name] = { index: i + 10, type: "string" };
     } else {
       throw Error(`[DataRow] dataRowFactory column not in schema ${name}`);
@@ -254,18 +244,13 @@ function createColumnMap(
 
   if (columnMap.vuuMsg === undefined) {
     // We will always check for vuuMsg, even if it isn't explicitly included in the subscribed columns
-    columnMap.vuuMsg = { index: columns.length + 10, type: "string" };
+    return {
+      ...columnMap,
+      vuuMsg: { index: columns.length + 10, type: "string" },
+    } as DataRowColumnMap;
+  } else {
+    return columnMap;
   }
-
-  for (const { name } of renderedColumns) {
-    if (columnMap[name] === undefined) {
-      // Client columns and temporarily unsubscribed rendered columns have no
-      // backing value in the row array, but are valid Table columns.
-      columnMap[name] = { type: "string" };
-    }
-  }
-
-  return columnMap;
 }
 
 /**
@@ -276,43 +261,22 @@ function createColumnMap(
  * @returns a tuple containing:
  * - factory function that will create a DataRow instance from a DataSourceRow
  * array.
- * - a function that resets the shared column map used by existing and subsequently
- * created DataRows. Used by Table when user adds or removes columns at runtime.
+ * - a function that can be used to reset the columns, which will be used for all
+ * subsequently created DataRows. Used by Table when user adds or removes columns
+ * at runtime.
  */
 export const dataRowFactory = (
   columns: string[],
   schemaColumns: readonly SchemaColumn[],
-  renderedColumns: readonly RenderedColumn[] = [],
-): [
-  DataRowFunc,
-  (columns: string[], renderedColumns?: readonly RenderedColumn[]) => void,
-] => {
-  const columnMapRef = {
-    current: createColumnMap(columns, schemaColumns, renderedColumns),
-  };
-  let currentColumns = columns;
-  let currentRenderedColumns = renderedColumns;
+): [DataRowFunc, (columns: string[]) => void] => {
+  let columnMap = createColumnMap(columns, schemaColumns);
 
-  const setColumns = (
-    columns: string[],
-    nextRenderedColumns: readonly RenderedColumn[] = [],
-  ) => {
-    if (
-      columns === currentColumns &&
-      nextRenderedColumns === currentRenderedColumns
-    ) {
-      return;
-    }
-    currentColumns = columns;
-    currentRenderedColumns = nextRenderedColumns;
-    columnMapRef.current = createColumnMap(
-      columns,
-      schemaColumns,
-      nextRenderedColumns,
-    );
+  const setColumns = (columns: string[]) => {
+    // new columnMap will be used for all subsequently created DataRows
+    columnMap = createColumnMap(columns, schemaColumns);
   };
 
-  const DataRow = (data: DataSourceRow) => DataRowImpl(data, columnMapRef);
+  const DataRow = (data: DataSourceRow) => DataRowImpl(data, columnMap);
 
   return [DataRow, setColumns];
 };

--- a/vuu-ui/packages/vuu-table/src/table-cell/TableCell.tsx
+++ b/vuu-ui/packages/vuu-table/src/table-cell/TableCell.tsx
@@ -14,6 +14,11 @@ import tableCellCss from "./TableCell.css";
 
 const classBase = "vuuTableCell";
 
+export const getCellValue = (
+  column: Pick<TableCellProps["column"], "name" | "source">,
+  dataRow: TableCellProps["dataRow"],
+) => (column.source === "client" ? undefined : dataRow[column.name]);
+
 export const TableCell = ({
   column,
   dataRow,
@@ -112,7 +117,10 @@ export const TableCell = ({
           searchPattern={searchPattern}
         />
       ) : (
-        applyHighlighting(valueFormatter(dataRow[column.name]), searchPattern)
+        applyHighlighting(
+          valueFormatter(getCellValue(column, dataRow)),
+          searchPattern,
+        )
       )}
     </div>
   );

--- a/vuu-ui/packages/vuu-table/src/table-data-source/useDataSource.ts
+++ b/vuu-ui/packages/vuu-table/src/table-data-source/useDataSource.ts
@@ -13,6 +13,7 @@ import { Range } from "@vuu-ui/vuu-utils";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { TableProps } from "../Table";
 import type {
+  ColumnDescriptor,
   DataRow,
   TableRowSelectHandlerInternal,
 } from "@vuu-ui/vuu-table-types";
@@ -36,7 +37,10 @@ type DataSourceBinding = {
   rangeLimits: RangeLimits;
   rangeRequested: boolean;
   rowAutoSelected: boolean;
-  setColumns?: (columns: string[]) => void;
+  setColumns?: (
+    columns: string[],
+    renderedColumns?: readonly ColumnDescriptor[],
+  ) => void;
 };
 
 export interface DataSourceHookProps
@@ -50,6 +54,7 @@ export interface DataSourceHookProps
     | "selectionModel"
   > {
   suspenseProps?: DataSourceSuspenseProps;
+  columns: readonly ColumnDescriptor[];
   onSelect: TableRowSelectHandlerInternal;
   /**
    * Invoked whenever rowCount changes. For example when rows are added
@@ -67,6 +72,7 @@ export interface DataSourceHookProps
 export const useDataSource = ({
   autoSelectFirstRow,
   autoSelectRowKey,
+  columns,
   dataSource,
   onSizeChange,
   onSubscribed,
@@ -111,6 +117,12 @@ export const useDataSource = ({
 
   const activeBindingRef = useRef<DataSourceBinding | undefined>(binding);
   activeBindingRef.current = binding;
+  const renderedColumnsRef = useRef(columns);
+  renderedColumnsRef.current = columns;
+
+  // Rows already in the moving window retain their DataRow proxies, so update
+  // their shared map before Table can process an incoming column configuration.
+  binding.setColumns?.(dataSource.columns, columns);
 
   useEffect(() => {
     isMounted.current = true;
@@ -199,7 +211,11 @@ export const useDataSource = ({
    */
   const createDataRow = useCallback(
     (columns: string[], schemaColumns: readonly SchemaColumn[]) => {
-      const [DataRow, setColumns] = dataRowFactory(columns, schemaColumns);
+      const [DataRow, setColumns] = dataRowFactory(
+        columns,
+        schemaColumns,
+        renderedColumnsRef.current,
+      );
       binding.dataRow = DataRow;
       binding.setColumns = setColumns;
     },
@@ -270,10 +286,6 @@ export const useDataSource = ({
   const getSelectedRows = useCallback(() => {
     return binding.dataRowWindow.getSelectedRows();
   }, [binding]);
-
-  useEffect(() => {
-    binding.setColumns?.(dataSource.columns);
-  }, [binding, dataSource.columns]);
 
   const setRange = useCallback(
     (viewportRange: VuuRange) => {

--- a/vuu-ui/packages/vuu-table/src/table-data-source/useDataSource.ts
+++ b/vuu-ui/packages/vuu-table/src/table-data-source/useDataSource.ts
@@ -13,7 +13,6 @@ import { Range } from "@vuu-ui/vuu-utils";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { TableProps } from "../Table";
 import type {
-  ColumnDescriptor,
   DataRow,
   TableRowSelectHandlerInternal,
 } from "@vuu-ui/vuu-table-types";
@@ -33,14 +32,12 @@ type DataSourceBinding = {
   dataRowWindow: DataRowMovingWindow;
   dataSource: DataSource;
   isReplacement: boolean;
+  pendingRows: DataSourceRow[];
   range: Range;
   rangeLimits: RangeLimits;
   rangeRequested: boolean;
   rowAutoSelected: boolean;
-  setColumns?: (
-    columns: string[],
-    renderedColumns?: readonly ColumnDescriptor[],
-  ) => void;
+  setColumns?: (columns: string[]) => void;
 };
 
 export interface DataSourceHookProps
@@ -54,7 +51,6 @@ export interface DataSourceHookProps
     | "selectionModel"
   > {
   suspenseProps?: DataSourceSuspenseProps;
-  columns: readonly ColumnDescriptor[];
   onSelect: TableRowSelectHandlerInternal;
   /**
    * Invoked whenever rowCount changes. For example when rows are added
@@ -72,7 +68,6 @@ export interface DataSourceHookProps
 export const useDataSource = ({
   autoSelectFirstRow,
   autoSelectRowKey,
-  columns,
   dataSource,
   onSizeChange,
   onSubscribed,
@@ -98,31 +93,31 @@ export const useDataSource = ({
             previousRange.to,
             renderBufferSize,
           );
+          const tableSchema = dataSource.tableSchema;
+          const [dataRow, setColumns] = tableSchema
+            ? dataRowFactory(dataSource.columns, tableSchema.columns)
+            : [NullDataRow, undefined];
 
           return {
-            dataRow: NullDataRow,
+            dataRow,
             dataRows: { current: [] },
             dataRowWindow: new DataRowMovingWindow(range.withBuffer),
             dataSource,
             isReplacement:
               previousBinding !== undefined &&
               previousBinding.dataSource !== dataSource,
+            pendingRows: [],
             range,
             rangeLimits: { ...defaultRangeLimits },
             rangeRequested: false,
             rowAutoSelected: false,
+            setColumns,
           };
         })();
   previousBindingRef.current = binding;
 
   const activeBindingRef = useRef<DataSourceBinding | undefined>(binding);
   activeBindingRef.current = binding;
-  const renderedColumnsRef = useRef(columns);
-  renderedColumnsRef.current = columns;
-
-  // Rows already in the moving window retain their DataRow proxies, so update
-  // their shared map before Table can process an incoming column configuration.
-  binding.setColumns?.(dataSource.columns, columns);
 
   useEffect(() => {
     isMounted.current = true;
@@ -211,11 +206,7 @@ export const useDataSource = ({
    */
   const createDataRow = useCallback(
     (columns: string[], schemaColumns: readonly SchemaColumn[]) => {
-      const [DataRow, setColumns] = dataRowFactory(
-        columns,
-        schemaColumns,
-        renderedColumnsRef.current,
-      );
+      const [DataRow, setColumns] = dataRowFactory(columns, schemaColumns);
       binding.dataRow = DataRow;
       binding.setColumns = setColumns;
     },
@@ -229,6 +220,10 @@ export const useDataSource = ({
       }
       if (message.type === "subscribed") {
         createDataRow(message.columns, message.tableSchema.columns);
+        if (binding.pendingRows.length > 0) {
+          setData(binding.pendingRows);
+          binding.pendingRows = [];
+        }
         if (message.tableSchema.rangeLimits) {
           binding.rangeLimits = message.tableSchema.rangeLimits;
         }
@@ -242,7 +237,11 @@ export const useDataSource = ({
           binding.dataRowWindow.setRowCount(message.size);
         }
         if (message.rows) {
-          setData(message.rows);
+          if (binding.setColumns === undefined) {
+            binding.pendingRows.push(...message.rows);
+          } else {
+            setData(message.rows);
+          }
           if (autoSelect && binding.rowAutoSelected === false) {
             // OR if no selected row in message.rows, e.g after a filter
             binding.rowAutoSelected = true;
@@ -286,6 +285,10 @@ export const useDataSource = ({
   const getSelectedRows = useCallback(() => {
     return binding.dataRowWindow.getSelectedRows();
   }, [binding]);
+
+  useEffect(() => {
+    binding.setColumns?.(dataSource.columns);
+  }, [binding, dataSource.columns]);
 
   const setRange = useCallback(
     (viewportRange: VuuRange) => {

--- a/vuu-ui/packages/vuu-table/src/useTable.ts
+++ b/vuu-ui/packages/vuu-table/src/useTable.ts
@@ -327,6 +327,7 @@ export const useTable = ({
   } = useDataSource({
     autoSelectFirstRow,
     autoSelectRowKey,
+    columns: config.columns,
     dataSource,
     renderBufferSize,
     revealSelected,

--- a/vuu-ui/packages/vuu-table/src/useTable.ts
+++ b/vuu-ui/packages/vuu-table/src/useTable.ts
@@ -327,7 +327,6 @@ export const useTable = ({
   } = useDataSource({
     autoSelectFirstRow,
     autoSelectRowKey,
-    columns: config.columns,
     dataSource,
     renderBufferSize,
     revealSelected,

--- a/vuu-ui/packages/vuu-table/test/DataRow.test.ts
+++ b/vuu-ui/packages/vuu-table/test/DataRow.test.ts
@@ -26,20 +26,21 @@ describe("DataRow", () => {
     expect(dataRow.bbg).toEqual("AAO L");
   });
 
-  it("maps session column vuu_action", () => {
+  it("maps a session column from the authoritative schema", () => {
     const [DataRow] = dataRowFactory(
-      ["id", "description", "vuu_action"],
+      ["id", "description", "session_status"],
       [
         { name: "id", serverDataType: "string" },
         { name: "description", serverDataType: "string" },
+        { name: "session_status", serverDataType: "string" },
       ],
     );
     // prettier-ignore
     const dataRow = DataRow([0, 0, false, false, 1, 0, "key-0", 0, 0, false, "1", "Test", "addRow"]);
-    expect(dataRow.vuu_action).toEqual("addRow");
+    expect(dataRow.session_status).toEqual("addRow");
   });
 
-  it("does not warn when accessing client column undo", () => {
+  it("warns when an unknown server column is accessed", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const [DataRow] = dataRowFactory(
       ["id"],
@@ -47,8 +48,11 @@ describe("DataRow", () => {
     );
     // prettier-ignore
     const dataRow = DataRow([0, 0, false, false, 1, 0, "key-0", 0, 0, false, "1"]);
-    expect(dataRow.undo).toBeUndefined();
-    expect(warn).not.toHaveBeenCalled();
+
+    expect(dataRow.unresolved_server_value).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      "[DataRow:Proxy] unknown column unresolved_server_value",
+    );
     warn.mockRestore();
   });
 

--- a/vuu-ui/packages/vuu-table/test/DataRow.test.ts
+++ b/vuu-ui/packages/vuu-table/test/DataRow.test.ts
@@ -26,31 +26,30 @@ describe("DataRow", () => {
     expect(dataRow.bbg).toEqual("AAO L");
   });
 
-  it("keeps buffered and new rows synchronized with rendered columns", () => {
+  it("maps session column vuu_action", () => {
+    const [DataRow] = dataRowFactory(
+      ["id", "description", "vuu_action"],
+      [
+        { name: "id", serverDataType: "string" },
+        { name: "description", serverDataType: "string" },
+      ],
+    );
+    // prettier-ignore
+    const dataRow = DataRow([0, 0, false, false, 1, 0, "key-0", 0, 0, false, "1", "Test", "addRow"]);
+    expect(dataRow.vuu_action).toEqual("addRow");
+  });
+
+  it("does not warn when accessing client column undo", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const schemaColumns = [
-      { name: "bbg", serverDataType: "string" as const },
-      { name: "vuu_action", serverDataType: "string" as const },
-    ];
-    const [DataRow, setColumns] = dataRowFactory(["bbg"], schemaColumns, [
-      { name: "bbg" },
-    ]);
+    const [DataRow] = dataRowFactory(
+      ["id"],
+      [{ name: "id", serverDataType: "string" }],
+    );
     // prettier-ignore
-    const bufferedRow = DataRow([0, 0, false, false, 1, 0, "key-0", 0, 0, false, "AAO L"]);
-
-    setColumns(["bbg", "vuu_action"], [
-      { name: "bbg" },
-      { name: "vuu_action" },
-      { name: "undo", source: "client" },
-    ]);
-    // prettier-ignore
-    const newRow = DataRow([1, 1, false, false, 1, 0, "key-1", 0, 0, false, "AAPL", "deleteRow"]);
-
-    expect(bufferedRow.vuu_action).toBeUndefined();
-    expect(bufferedRow.undo).toBeUndefined();
-    expect(newRow.vuu_action).toEqual("deleteRow");
-    expect(newRow.undo).toBeUndefined();
+    const dataRow = DataRow([0, 0, false, false, 1, 0, "key-0", 0, 0, false, "1"]);
+    expect(dataRow.undo).toBeUndefined();
     expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it("Factory supports calculated columns", () => {

--- a/vuu-ui/packages/vuu-table/test/DataRow.test.ts
+++ b/vuu-ui/packages/vuu-table/test/DataRow.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { dataRowFactory } from "../src/data-row/DataRow";
 
 describe("DataRow", () => {
@@ -24,6 +24,33 @@ describe("DataRow", () => {
     // prettier-ignore
     const dataRow = DataRow([0, 0, false, false, 1, 0, "key-0", 0, 0, false, "AAO L"]);
     expect(dataRow.bbg).toEqual("AAO L");
+  });
+
+  it("keeps buffered and new rows synchronized with rendered columns", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const schemaColumns = [
+      { name: "bbg", serverDataType: "string" as const },
+      { name: "vuu_action", serverDataType: "string" as const },
+    ];
+    const [DataRow, setColumns] = dataRowFactory(["bbg"], schemaColumns, [
+      { name: "bbg" },
+    ]);
+    // prettier-ignore
+    const bufferedRow = DataRow([0, 0, false, false, 1, 0, "key-0", 0, 0, false, "AAO L"]);
+
+    setColumns(["bbg", "vuu_action"], [
+      { name: "bbg" },
+      { name: "vuu_action" },
+      { name: "undo", source: "client" },
+    ]);
+    // prettier-ignore
+    const newRow = DataRow([1, 1, false, false, 1, 0, "key-1", 0, 0, false, "AAPL", "deleteRow"]);
+
+    expect(bufferedRow.vuu_action).toBeUndefined();
+    expect(bufferedRow.undo).toBeUndefined();
+    expect(newRow.vuu_action).toEqual("deleteRow");
+    expect(newRow.undo).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("Factory supports calculated columns", () => {

--- a/vuu-ui/packages/vuu-table/test/TableCell.test.ts
+++ b/vuu-ui/packages/vuu-table/test/TableCell.test.ts
@@ -1,0 +1,34 @@
+import type { DataRow } from "@vuu-ui/vuu-table-types";
+import { describe, expect, it, vi } from "vitest";
+import { getCellValue } from "../src/table-cell/TableCell";
+
+describe("TableCell", () => {
+  it("does not read a client column from the DataRow", () => {
+    const dataRow = new Proxy(
+      {},
+      {
+        get: vi.fn(() => {
+          throw Error("client column accessed DataRow");
+        }),
+      },
+    ) as DataRow;
+
+    expect(
+      getCellValue(
+        { name: "arbitrary-client-action", source: "client" },
+        dataRow,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("reads a server column from the DataRow", () => {
+    const dataRow = { arbitrary_server_value: "value" } as DataRow;
+
+    expect(
+      getCellValue(
+        { name: "arbitrary_server_value", source: "server" },
+        dataRow,
+      ),
+    ).toBe("value");
+  });
+});

--- a/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
+++ b/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
@@ -1,6 +1,6 @@
 import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
 import { Range } from "@vuu-ui/vuu-utils";
-import { act } from "react";
+import { act, useEffect } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import {
   afterAll,
@@ -18,6 +18,16 @@ const tableSchema: TableSchema = {
   columns: [{ name: "id", serverDataType: "string" }],
   key: "id",
   table: { module: "TEST", table: "test" },
+};
+
+const sessionTableSchema: TableSchema = {
+  columns: [
+    { name: "id", serverDataType: "string" },
+    { name: "vuuMsg", serverDataType: "string" },
+    { name: "vuu_action", serverDataType: "string" },
+  ],
+  key: "id",
+  table: { module: "TEST", table: "session" },
 };
 
 const createDataSource = () => {
@@ -41,12 +51,36 @@ const createDataSource = () => {
 
 const Fixture = ({ dataSource }: { dataSource: DataSource }) => {
   useDataSource({
-    columns: [],
     dataSource,
     onSelect: vi.fn(),
     onSizeChange: vi.fn(),
     onSubscribed: vi.fn(),
   });
+  return null;
+};
+
+const SessionRowsFixture = ({
+  dataSource,
+  onRows,
+}: {
+  dataSource: DataSource;
+  onRows: (rows: ReturnType<typeof useDataSource>["dataRows"]) => void;
+}) => {
+  const { dataRows, setRange } = useDataSource({
+    dataSource,
+    onSelect: vi.fn(),
+    onSizeChange: vi.fn(),
+    onSubscribed: vi.fn(),
+  });
+
+  useEffect(() => {
+    setRange({ from: 0, to: 1 });
+  }, [setRange]);
+
+  useEffect(() => {
+    onRows(dataRows);
+  }, [dataRows, onRows]);
+
   return null;
 };
 
@@ -115,5 +149,64 @@ describe("useDataSource replacement suspension", () => {
       undefined,
     );
     expect(source.resolvedSuspensions).toEqual([true]);
+  });
+
+  it("waits for the session schema before creating DataRows from early updates", async () => {
+    let callback: Parameters<NonNullable<DataSource["subscribe"]>>[1];
+    let rows: ReturnType<typeof useDataSource>["dataRows"] = [];
+    const earlySessionDataSource = {
+      columns: ["id", "vuuMsg", "vuu_action"],
+      on: vi.fn(),
+      range: Range(0, 1),
+      removeListener: vi.fn(),
+      status: "initialising",
+      subscribe: vi.fn((_props, nextCallback) => {
+        callback = nextCallback;
+        callback({
+          rows: [
+            [
+              0,
+              0,
+              false,
+              false,
+              0,
+              0,
+              "row-1",
+              false,
+              0,
+              false,
+              "row-1",
+              "",
+              "addRow",
+            ],
+          ],
+          size: 1,
+          type: "viewport-update",
+        });
+        callback({
+          columns: ["id", "vuuMsg", "vuu_action"],
+          tableSchema: sessionTableSchema,
+          type: "subscribed",
+        });
+      }),
+      suspend: vi.fn(),
+    } as unknown as DataSource;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await act(async () =>
+      root.render(
+        <SessionRowsFixture
+          dataSource={earlySessionDataSource}
+          onRows={(nextRows) => {
+            rows = nextRows;
+          }}
+        />,
+      ),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].vuu_action).toBe("addRow");
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
+++ b/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
@@ -41,6 +41,7 @@ const createDataSource = () => {
 
 const Fixture = ({ dataSource }: { dataSource: DataSource }) => {
   useDataSource({
+    columns: [],
     dataSource,
     onSelect: vi.fn(),
     onSizeChange: vi.fn(),

--- a/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
+++ b/vuu-ui/packages/vuu-table/test/useDataSource.test.tsx
@@ -24,7 +24,7 @@ const sessionTableSchema: TableSchema = {
   columns: [
     { name: "id", serverDataType: "string" },
     { name: "vuuMsg", serverDataType: "string" },
-    { name: "vuu_action", serverDataType: "string" },
+    { name: "session_status", serverDataType: "string" },
   ],
   key: "id",
   table: { module: "TEST", table: "session" },
@@ -155,7 +155,7 @@ describe("useDataSource replacement suspension", () => {
     let callback: Parameters<NonNullable<DataSource["subscribe"]>>[1];
     let rows: ReturnType<typeof useDataSource>["dataRows"] = [];
     const earlySessionDataSource = {
-      columns: ["id", "vuuMsg", "vuu_action"],
+      columns: ["id", "vuuMsg", "session_status"],
       on: vi.fn(),
       range: Range(0, 1),
       removeListener: vi.fn(),
@@ -184,7 +184,7 @@ describe("useDataSource replacement suspension", () => {
           type: "viewport-update",
         });
         callback({
-          columns: ["id", "vuuMsg", "vuu_action"],
+          columns: ["id", "vuuMsg", "session_status"],
           tableSchema: sessionTableSchema,
           type: "subscribed",
         });
@@ -205,7 +205,7 @@ describe("useDataSource replacement suspension", () => {
     );
 
     expect(rows).toHaveLength(1);
-    expect(rows[0].vuu_action).toBe("addRow");
+    expect(rows[0].session_status).toBe("addRow");
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });

--- a/vuu-ui/packages/vuu-utils/src/column-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/column-utils.ts
@@ -1116,8 +1116,7 @@ export const assertAllColumnsAreIncludedInSubscription = (
 ) => {
   const unsubscribedColumns: string[] = [];
   for (const column of columns) {
-    // temp exclusion for vuu_action, this will be removed later
-    if (column.source !== "client" && column.name !== 'vuu_action' && !columnNames?.includes(column.name)) {
+    if (column.source !== "client" && !columnNames?.includes(column.name)) {
       unsubscribedColumns.push(column.name);
     }
   }

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -391,6 +391,7 @@ const EditableInstrumentsTemplate = ({
     onDelete,
     onSave,
     rowClassNameGenerators,
+    sessionDataSource,
     sourceDataSource,
   } = useEditableTable({
     dataSource: sourceTableDataSource,
@@ -418,7 +419,7 @@ const EditableInstrumentsTemplate = ({
 
       return {
         columns:
-          editMode === "view"
+          editMode === "view" || sessionDataSource === undefined
             ? InstrumentColumns
             :
             InstrumentColumns.map((col) =>
@@ -441,7 +442,7 @@ const EditableInstrumentsTemplate = ({
         zebraStripes: true,
       };
     },
-    [editMode, rowClassNameGenerators],
+    [editMode, rowClassNameGenerators, sessionDataSource],
   );
 
   return (
@@ -462,7 +463,9 @@ const EditableInstrumentsTemplate = ({
               editMode === "edit" && showInlineAddRow ? InlineAddRow : undefined
             }
             renderBufferSize={10}
-            isRowSelectable={editMode === "edit" ? isRowSelectable : undefined}
+            isRowSelectable={
+              sessionDataSource === undefined ? undefined : isRowSelectable
+            }
             selectionModel={editMode === "edit" ? "checkbox" : "none"}
           />
         </DataEditingProvider>


### PR DESCRIPTION
## Summary

Fix DataRow initialization and column handling when entering table edit sessions without column-name exceptions.

A session datasource can emit viewport rows before its authoritative subscription schema arrives. Creating DataRows before that metadata is available leaves their raw array layout unknown. Session-only UI behavior can also start while source-table rows are still rendered.

This change:
- initializes the DataRow factory immediately only when a new datasource already has a table schema;
- otherwise buffers viewport rows until authoritative subscribed columns/schema arrive, then creates the factory and flushes the rows;
- enriches session table schemas generically with subscribed session-only columns missing from the base table schema (excluding calculated columns), and regenerates the inlined worker;
- keeps DataRow strict and maps every server-backed column only through subscription columns plus schema—there are no `undo` or `vuu_action` warning/schema exceptions;
- handles no-value client columns structurally at the cell boundary through `ColumnDescriptor.source === "client"`, avoiding DataRow lookup for arbitrary client column names;
- removes the former session-column subscription-validation bypass;
- gates session-only column configuration, row selection, and edit row-class processing until the session datasource exists.

## Validation

- Targeted Vitest suites for DataRow, TableCell, useDataSource, and remote Viewport: 29 passed
- Playwright component tests for inline edit-session entry and `createSessionTable` entry: 2 passed in Chromium with no DataRow unknown-column warnings
- Biome lint with error diagnostics: passed
- `@vuu-ui/vuu-table` rslib build: passed
- Remote inlined worker regenerated successfully

Full-workspace typecheck and package type generation remain blocked by unrelated pre-existing errors on `vuu-ui-rslib` in data-local, data-test, table-extras, utils, and showcase code.