### PR TITLE
Clickhouse plugin should use parameterized queries

### DIFF
--- a/plugin/clickhouse-plugin/pom.xml
+++ b/plugin/clickhouse-plugin/pom.xml
@@ -199,6 +199,39 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check-coverage</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/client/ClickHouseClient.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/client/ClickHouseClient.scala
@@ -6,8 +6,8 @@ import com.typesafe.scalalogging.StrictLogging
 import org.finos.toolbox.lifecycle.{LifecycleContainer, LifecycleEnabled}
 import org.finos.vuu.plugin.clickhouse.client.options.ClickHouseClientOptions
 
-import java.util
 import java.util.concurrent.ExecutionException
+import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.util.Using
 
 class ClickHouseClient(val options: ClickHouseClientOptions)
@@ -18,12 +18,12 @@ class ClickHouseClient(val options: ClickHouseClientOptions)
 
   lifecycle(this)
 
-  def executeQuery[T](sql: String, params: util.Map[String, Object] = util.Map.of())(action: Records => T): T = {
+  def executeQuery[T](sql: String, params: Map[String, Any] = Map.empty)(action: Records => T): T = {
     client match {
       case Some(c) =>
         val response = try {
           logger.debug(s"Executing query \"$sql\" with params $params")
-          c.queryRecords(sql, params).get()
+          c.queryRecords(sql, params.asJava).get()
         } catch {
           case e: ExecutionException =>
             throw new RuntimeException(s"ClickHouse query execution failed for SQL: $sql", e.getCause)
@@ -41,12 +41,12 @@ class ClickHouseClient(val options: ClickHouseClientOptions)
     }
   }
 
-  def executeUpdate(sql: String, params: util.Map[String, Object] = util.Map.of()): Int = {
+  def executeUpdate(sql: String, params: Map[String, Any] = Map.empty): Int = {
     client match {
       case Some(c) =>
         val response = try {
           logger.debug(s"Executing update \"$sql\" with params $params")
-          c.query(sql, params).get()
+          c.query(sql, params.asJava).get()
         } catch {
           case e: ExecutionException =>
             throw new RuntimeException(s"ClickHouse update/DDL execution failed for SQL: $sql", e.getCause)

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/ClickHouseVirtualizedDataProvider.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/ClickHouseVirtualizedDataProvider.scala
@@ -28,16 +28,16 @@ class ClickHouseVirtualizedDataProvider(tableDef: VirtualizedSessionTableDef, cl
   override def runOnce(viewPort: ViewPort): Unit = {
     logger.trace("[ClickHouseVirtualizedDataProvider] Starting runOnce")
 
-    val (whereClause, params) = filterFactory.build(viewPort.filterSpec, permissionFunction.apply(viewPort))
+    val clauseWithParams = filterFactory.build(viewPort.filterSpec, permissionFunction.apply(viewPort))
     val orderBy = sortFactory.build(viewPort.sortSpec)
     val offset = viewPort.getRange.from
     val limit = viewPort.getRange.to - offset
 
-    logger.trace(s"[ClickHouseVirtualizedDataProvider] Loading rows from ClickHouse range ${viewPort.getRange.from} to ${viewPort.getRange.to} filter=$whereClause sort=$orderBy")
+    logger.trace(s"[ClickHouseVirtualizedDataProvider] Loading rows from ClickHouse range ${viewPort.getRange.from} to ${viewPort.getRange.to} filter=$clauseWithParams sort=$orderBy")
 
     val queryStart = clock.now()
-    val tableSize = tableSizeProvider.getTableSize(whereClause, params)
-    val rowsWithData = rowDataProvider.queryForRowData(viewPort.getColumns, whereClause, params, orderBy, offset, limit)
+    val tableSize = tableSizeProvider.getTableSize(clauseWithParams)
+    val rowsWithData = rowDataProvider.queryForRowData(viewPort.getColumns, clauseWithParams, orderBy, offset, limit)
     val dataQueryMillis = clock.now() - queryStart
 
     logger.trace(s"[ClickHouseVirtualizedDataProvider] Updating session table")

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataProvider.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataProvider.scala
@@ -2,6 +2,7 @@ package org.finos.vuu.plugin.clickhouse.provider.data
 
 import org.finos.vuu.core.table.RowWithData
 import org.finos.vuu.plugin.clickhouse.client.ClickHouseClient
+import org.finos.vuu.plugin.clickhouse.provider.filter.ClauseWithParams
 import org.finos.vuu.plugin.virtualized.api.{VirtualizedSessionTableColumn, VirtualizedSessionTableDef}
 import org.finos.vuu.viewport.ViewPortColumns
 
@@ -14,15 +15,14 @@ class ClickHouseRowDataProvider(client: ClickHouseClient,
   private val rowDataMapper = ClickHouseRowDataMapper(tableDef)
   
   def queryForRowData(viewPortColumns: ViewPortColumns,
-                      whereClause: String,
-                      params: util.Map[String, Object],
+                      clauseWithParams: ClauseWithParams,
                       orderBy: String,
                       offset: Int,
                       limit: Int): IndexedSeq[RowWithData] = {
 
-    val query = buildQuery(viewPortColumns, whereClause, orderBy, offset, limit)
+    val query = buildQuery(viewPortColumns, clauseWithParams.clause, orderBy, offset, limit)
 
-    client.executeQuery(query, params) { records =>
+    client.executeQuery(query, clauseWithParams.params) { records =>
       val buf = new ArrayBuffer[RowWithData](records.getResultRows.toInt)
       val it = records.iterator()
       while (it.hasNext) {
@@ -59,12 +59,12 @@ class ClickHouseRowDataProvider(client: ClickHouseClient,
 
     //Where
     if (whereClause != null && whereClause.nonEmpty) {
-      sb.append(" ").append(whereClause)
+      sb.append(" WHERE ").append(whereClause)
     }
 
     //Order By
     if (orderBy != null && orderBy.nonEmpty) {
-      sb.append(" ").append(orderBy)
+      sb.append(" ORDER BY ").append(orderBy)
     }
 
     //Limit

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseTableSizeProvider.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseTableSizeProvider.scala
@@ -1,6 +1,7 @@
 package org.finos.vuu.plugin.clickhouse.provider.data
 
 import org.finos.vuu.plugin.clickhouse.client.ClickHouseClient
+import org.finos.vuu.plugin.clickhouse.provider.filter.ClauseWithParams
 
 import java.util
 
@@ -8,19 +9,15 @@ class ClickHouseTableSizeProvider(client: ClickHouseClient, remoteTableName: Str
 
   private val defaultQuery = s"SELECT count() as cnt FROM $remoteTableName"
 
-  def getTableSize(whereClause: String, params: util.Map[String, Object]): Int = {
-    val query = if (whereClause == null || whereClause.isEmpty) defaultQuery
-    else s"$defaultQuery $whereClause"
-
-    client.executeQuery(query, params) {
-      records =>
-        val it = records.iterator()
-        if (it.hasNext) {
-          it.next().getLong("cnt").toInt
-        } else {
-          0
-        }
+  def getTableSize(clauseWithParams: ClauseWithParams): Int =
+    clauseWithParams.clause match {
+      case null | "" => executeQuery(defaultQuery, Map.empty)
+      case clause => executeQuery(s"$defaultQuery WHERE $clause", clauseWithParams.params)
     }
-  }
 
+  private def executeQuery(query: String, params: Map[String, Any]): Int =
+    client.executeQuery(query, params) { records =>
+      val it = records.iterator()
+      if (it.hasNext) it.next().getLong("cnt").toInt else 0
+    }
 }

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClauseWithParams.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClauseWithParams.scala
@@ -1,0 +1,21 @@
+package org.finos.vuu.plugin.clickhouse.provider.filter
+
+case class ClauseWithParams(clause: String,
+                            params: Map[String, Any]) {
+
+  def and(other: ClauseWithParams): ClauseWithParams = (this, other) match {
+    case (NoResults, _) | (_, NoResults) => NoResults
+    case (NoFilter, _) => other
+    case (_, NoFilter) => this
+    case (c1, c2) =>
+      ClauseWithParams(s"(${c1.clause}) AND (${c2.clause})", c1.params ++ c2.params)
+  }
+
+}
+
+object NoFilter extends ClauseWithParams("", Map.empty)
+
+object NoResults extends ClauseWithParams("1 = 0", Map.empty)
+
+
+

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClauseWithParams.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClauseWithParams.scala
@@ -1,21 +1,42 @@
 package org.finos.vuu.plugin.clickhouse.provider.filter
 
-case class ClauseWithParams(clause: String,
-                            params: Map[String, Any]) {
+sealed trait ClauseWithParams {
+  def clause: String
 
-  def and(other: ClauseWithParams): ClauseWithParams = (this, other) match {
-    case (NoResults, _) | (_, NoResults) => NoResults
-    case (NoFilter, _) => other
-    case (_, NoFilter) => this
-    case (c1, c2) =>
-      ClauseWithParams(s"(${c1.clause}) AND (${c2.clause})", c1.params ++ c2.params)
-  }
+  def params: Map[String, Any]
 
+  def and(other: ClauseWithParams): ClauseWithParams
 }
 
-object NoFilter extends ClauseWithParams("", Map.empty)
+object ClauseWithParams {
+  def apply(clause: String, params: Map[String, Any] = Map.empty): ClauseWithParams =
+    ClauseWithParamsImpl(clause, params)
+}
 
-object NoResults extends ClauseWithParams("1 = 0", Map.empty)
+case object NoFilter extends ClauseWithParams {
+  override val clause: String = ""
+  override val params: Map[String, Any] = Map.empty
 
+  override def and(other: ClauseWithParams): ClauseWithParams = other
+}
 
+case object NoResults extends ClauseWithParams {
+  override val clause: String = "1 = 0"
+  override val params: Map[String, Any] = Map.empty
 
+  override def and(other: ClauseWithParams): ClauseWithParams = NoResults
+}
+
+private case class ClauseWithParamsImpl(clause: String, params: Map[String, Any]) extends ClauseWithParams {
+  override def and(other: ClauseWithParams): ClauseWithParams = other match {
+    case NoFilter => this
+    case NoResults => NoResults
+    case sc: ClauseWithParamsImpl =>
+      val combinedParams =
+        if (params.isEmpty) sc.params
+        else if (sc.params.isEmpty) params
+        else params ++ sc.params
+
+      ClauseWithParamsImpl(s"($clause) AND (${sc.clause})", combinedParams)
+  }
+}

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterFactory.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterFactory.scala
@@ -1,30 +1,26 @@
 package org.finos.vuu.plugin.clickhouse.provider.filter
 
-import java.util
-import java.util.HashMap as JHashMap
 import com.typesafe.scalalogging.StrictLogging
 import org.finos.vuu.core.filter.FilterSpecParser
 import org.finos.vuu.net.FilterSpec
 import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableDef
 
+import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
-object ClickHouseFilterFactory {
-  private val NoFilter = ""
-  private val NoResults = "WHERE 1 = 0"
-  private val WherePrefix = "WHERE "
-}
-
 class ClickHouseFilterFactory(tableDef: VirtualizedSessionTableDef) extends StrictLogging {
-  import ClickHouseFilterFactory.*
 
-  def build(userSpec: FilterSpec, permissionSpec: FilterSpec): (String, util.Map[String, Object]) = {
-    val params = new JHashMap[String, Object]()
+  def build(filterSpec: FilterSpec): ClauseWithParams = {
+    val safeFilter = safeFilterString(filterSpec)
+    parseFilter(safeFilter)
+  }
+
+  def build(userSpec: FilterSpec, permissionSpec: FilterSpec): ClauseWithParams = {
     val userFilterStr = safeFilterString(userSpec)
     val permFilterStr = safeFilterString(permissionSpec)
 
     if (userFilterStr.isEmpty && permFilterStr.isEmpty) {
-      (NoFilter, params)
+      NoFilter
     } else {
       val combined =
         if (userFilterStr.nonEmpty && permFilterStr.nonEmpty) {
@@ -35,28 +31,33 @@ class ClickHouseFilterFactory(tableDef: VirtualizedSessionTableDef) extends Stri
           permFilterStr
         }
 
-      (parseFilter(combined), params)
+      parseFilter(combined)
     }
   }
 
-  private def parseFilter(filterSpec: String): String = {
+  private def parseFilter(filterSpec: String): ClauseWithParams = {
     if (filterSpec.isBlank) {
       logger.trace("Filter spec is blank, returning no filter")
       return NoFilter
     }
 
-    val filterVisitor = new ClickHouseFilterVisitor(tableDef.getRemoteColumnMapping)
+    val stringBuilder = new java.lang.StringBuilder(256)
+    val params = new mutable.HashMap[String, Any]()
+    val filterVisitor = ClickHouseFilterVisitor(
+      remoteNameMapping = tableDef.getRemoteColumnMapping,
+      stringBuilder = stringBuilder,
+      params = params
+    )
 
     Try(FilterSpecParser.parse(filterSpec, filterVisitor)) match {
       case Success(_) =>
-        val buffer = filterVisitor.getBuffer
-        if (buffer.length == 0) {
+        if (stringBuilder.length == 0) {
           logger.warn("Parsed filter was empty")
           NoResults
         } else {
-          val whereClause = s"$WherePrefix${buffer.toString}"
-          logger.trace(s"Parsed filter: $whereClause")
-          whereClause
+          val whereClause = stringBuilder.toString
+          logger.trace(s"Parsed filter: $whereClause with params $params")
+          ClauseWithParams(whereClause, params.toMap)
         }
 
       case Failure(err) =>

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterFactory.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterFactory.scala
@@ -10,11 +10,6 @@ import scala.util.{Failure, Success, Try}
 
 class ClickHouseFilterFactory(tableDef: VirtualizedSessionTableDef) extends StrictLogging {
 
-  def build(filterSpec: FilterSpec): ClauseWithParams = {
-    val safeFilter = safeFilterString(filterSpec)
-    parseFilter(safeFilter)
-  }
-
   def build(userSpec: FilterSpec, permissionSpec: FilterSpec): ClauseWithParams = {
     val userFilterStr = safeFilterString(userSpec)
     val permFilterStr = safeFilterString(permissionSpec)

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
@@ -32,33 +32,37 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSes
   override def visitOperationEq(ctx: OperationEqContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" = ")
-    appendScalarParam(remoteColumn, ctx.scalar())
+    appendParam(remoteColumn, ctx.scalar().getText)
   }
 
   override def visitOperationNeq(ctx: OperationNeqContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" != ")
-    appendScalarParam(remoteColumn, ctx.scalar())
+    appendParam(remoteColumn, ctx.scalar().getText)
   }
 
   override def visitOperationGt(ctx: OperationGtContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" > ").append(ctx.NUMBER().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" > ")
+    appendParam(remoteColumn, ctx.NUMBER().getText)
   }
 
   override def visitOperationGte(ctx: OperationGteContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" >= ").append(ctx.NUMBER().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" >= ")
+    appendParam(remoteColumn, ctx.NUMBER().getText)
   }
 
   override def visitOperationLt(ctx: OperationLtContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" < ").append(ctx.NUMBER().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" < ")
+    appendParam(remoteColumn, ctx.NUMBER().getText)
   }
 
   override def visitOperationLte(ctx: OperationLteContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" <= ").append(ctx.NUMBER().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" <= ")
+    appendParam(remoteColumn, ctx.NUMBER().getText)
   }
 
   override def visitOperationStarts(ctx: OperationStartsContext): Unit = {
@@ -130,10 +134,9 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSes
     stringBuilder.append('\'')
   }
 
-  private def appendScalarParam(column: VirtualizedSessionTableColumn,
-                                scalarContext: ScalarContext): Unit = {
+  private def appendParam(column: VirtualizedSessionTableColumn,
+                          paramValue: String): Unit = {
     val paramName = s"p_${params.size}"
-    val paramValue = scalarContext.getText
 
     stringBuilder.append("{")
     stringBuilder.append(paramName)

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
@@ -1,9 +1,14 @@
 package org.finos.vuu.plugin.clickhouse.provider.filter
 
+import org.finos.toolbox.time.TimeUtils.ofEpochNanosecond
+import org.finos.vuu.core.table.DataType
+import org.finos.vuu.core.table.datatype.Scale.{Eight, Four, Six, Two}
+import org.finos.vuu.core.table.datatype.ScaledDecimal
 import org.finos.vuu.grammar.FilterBaseVisitor
 import org.finos.vuu.grammar.FilterParser.*
 import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumn
 
+import java.time.Instant.ofEpochMilli
 import scala.collection.mutable
 
 case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSessionTableColumn],
@@ -25,80 +30,63 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSes
     visit(ctx.orExpression())
 
   override def visitOperationEq(ctx: OperationEqContext): Unit = {
-    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" = ")
-    appendScalar(ctx.scalar())
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" = ")
+    appendScalarParam(remoteColumn, ctx.scalar())
   }
 
   override def visitOperationNeq(ctx: OperationNeqContext): Unit = {
-    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" != ")
-    appendScalar(ctx.scalar())
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" != ")
+    appendScalarParam(remoteColumn, ctx.scalar())
   }
 
-  override def visitOperationGt(ctx: OperationGtContext): Unit =
-    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" > ").append(ctx.NUMBER().getText)
+  override def visitOperationGt(ctx: OperationGtContext): Unit = {
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" > ").append(ctx.NUMBER().getText)
+  }
 
-  override def visitOperationGte(ctx: OperationGteContext): Unit =
-    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" >= ").append(ctx.NUMBER().getText)
+  override def visitOperationGte(ctx: OperationGteContext): Unit = {
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" >= ").append(ctx.NUMBER().getText)
+  }
 
-  override def visitOperationLt(ctx: OperationLtContext): Unit =
-    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" < ").append(ctx.NUMBER().getText)
+  override def visitOperationLt(ctx: OperationLtContext): Unit = {
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" < ").append(ctx.NUMBER().getText)
+  }
 
-  override def visitOperationLte(ctx: OperationLteContext): Unit =
-    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" <= ").append(ctx.NUMBER().getText)
+  override def visitOperationLte(ctx: OperationLteContext): Unit = {
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" <= ").append(ctx.NUMBER().getText)
+  }
 
-  override def visitOperationStarts(ctx: OperationStartsContext): Unit =
-    like(getRemoteId(ctx.ID().getText), ctx.STRING().getText, prefix = false, suffix = true)
+  override def visitOperationStarts(ctx: OperationStartsContext): Unit = {
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    like(remoteColumn.remoteName, ctx.STRING().getText, prefix = false, suffix = true)
+  }
 
-  override def visitOperationEnds(ctx: OperationEndsContext): Unit =
-    like(getRemoteId(ctx.ID().getText), ctx.STRING().getText, prefix = true, suffix = false)
+  override def visitOperationEnds(ctx: OperationEndsContext): Unit = {
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    like(remoteColumn.remoteName, ctx.STRING().getText, prefix = true, suffix = false)
+  }
 
-  override def visitOperationContains(ctx: OperationContainsContext): Unit =
-    like(getRemoteId(ctx.ID().getText), ctx.STRING().getText, prefix = true, suffix = true)
+  override def visitOperationContains(ctx: OperationContainsContext): Unit = {
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    like(remoteColumn.remoteName, ctx.STRING().getText, prefix = true, suffix = true)
+  }
 
   override def visitOperationIn(ctx: OperationInContext): Unit = {
-    val id = getRemoteId(ctx.ID().getText)
-    val setCtx = ctx.set()
-
-    val nums = setCtx.NUMBER()
-    if (nums != null && !nums.isEmpty) {
-      stringBuilder.append(id).append(" IN (")
-      val it = nums.iterator()
-      if (it.hasNext) stringBuilder.append(it.next().getText)
-      while (it.hasNext) {
-        stringBuilder.append(", ").append(it.next().getText)
-      }
-      stringBuilder.append(")")
-      return
-    }
-
-    val strings = setCtx.STRING()
-    if (strings != null && !strings.isEmpty) {
-      stringBuilder.append(id).append(" IN (")
-      val it = strings.iterator()
-      if (it.hasNext) {
-        stringBuilder.append('\'')
-        appendEscaped(it.next().getText)
-        stringBuilder.append('\'')
-      }
-      while (it.hasNext) {
-        stringBuilder.append(", '")
-        appendEscaped(it.next().getText)
-        stringBuilder.append('\'')
-      }
-      stringBuilder.append(")")
-      return
-    }
-
-    stringBuilder.append("1 = 0")
+    //TODO
   }
 
   // ------------------------------------------------------------
   // Helpers
   // ------------------------------------------------------------
 
-  private def getRemoteId(id: String): String = {
+  private def getRemoteColumn(id: String): VirtualizedSessionTableColumn = {
     remoteNameMapping.getOrElse(id,
-      throw new IllegalArgumentException(s"Mapping missing for filter column: '$id'")).remoteName
+      throw new IllegalArgumentException(s"Mapping missing for filter column: '$id'"))
   }
 
   private def joinChildren(children: java.util.List[_ <: org.antlr.v4.runtime.tree.ParseTree], op: String): Unit = {
@@ -137,32 +125,62 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSes
   private def like(id: String, lit: String, prefix: Boolean, suffix: Boolean): Unit = {
     stringBuilder.append(id).append(" LIKE '")
     if (prefix) stringBuilder.append('%')
-    appendEscaped(lit)
+    //TODO
     if (suffix) stringBuilder.append('%')
     stringBuilder.append('\'')
   }
 
-  private def appendScalar(scalar: ScalarContext): Unit = {
-    val s = scalar.STRING()
-    if (s != null) {
-      stringBuilder.append('\'')
-      appendEscaped(s.getText)
-      stringBuilder.append('\'')
-    } else {
-      stringBuilder.append(scalar.getText)
+  private def appendScalarParam(column: VirtualizedSessionTableColumn,
+                                scalarContext: ScalarContext): Unit = {
+    val paramName = s"p_${params.size}"
+    val paramValue = scalarContext.getText
+
+    stringBuilder.append("{")
+    stringBuilder.append(paramName)
+    stringBuilder.append(":")
+
+    column.dataType match {
+      case DataType.StringDataType =>
+        params.put(paramName, paramValue)
+        stringBuilder.append("String")
+      case DataType.CharDataType =>
+        params.put(paramName, paramValue.charAt(0))
+        stringBuilder.append("String")
+      case DataType.IntegerDataType =>
+        params.put(paramName, paramValue.toInt)
+        stringBuilder.append("Int32")
+      case DataType.LongDataType =>
+        params.put(paramName, paramValue.toLong)
+        stringBuilder.append("Int64")
+      case DataType.DoubleDataType =>
+        params.put(paramName, paramValue.toDouble)
+        stringBuilder.append("Float64")
+      case DataType.BooleanDataType =>
+        params.put(paramName, paramValue.toBoolean)
+        stringBuilder.append("Bool")
+      case DataType.EpochTimestampType =>
+        params.put(paramName, ofEpochMilli(paramValue.toLong))
+        stringBuilder.append("DateTime64")
+      case DataType.EpochTimestampNanoType =>
+        params.put(paramName, ofEpochNanosecond(paramValue.toLong))
+        stringBuilder.append("DateTime64")
+      case DataType.ScaledDecimal2Type =>
+        params.put(paramName, ScaledDecimal(paramValue, Two).scaledValue)
+        stringBuilder.append("Int64")
+      case DataType.ScaledDecimal4Type =>
+        params.put(paramName, ScaledDecimal(paramValue, Four).scaledValue)
+        stringBuilder.append("Int64")
+      case DataType.ScaledDecimal6Type =>
+        params.put(paramName, ScaledDecimal(paramValue, Six).scaledValue)
+        stringBuilder.append("Int64")
+      case DataType.ScaledDecimal8Type =>
+        params.put(paramName, ScaledDecimal(paramValue, Eight).scaledValue)
+        stringBuilder.append("Int64")
+      case _ =>
+        throw new IllegalArgumentException(s"Unable to handle column dataType: '${column.dataType}'")
     }
+
+    stringBuilder.append("}")
   }
 
-  private def appendEscaped(s: String): Unit = {
-    if (s != null) {
-      var i = 0
-      val len = s.length
-      while (i < len) {
-        val c = s.charAt(i)
-        if (c == '\'') stringBuilder.append("''")
-        else stringBuilder.append(c)
-        i += 1
-      }
-    }
-  }
 }

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
@@ -6,7 +6,7 @@ import org.finos.vuu.core.table.datatype.Scale.{Eight, Four, Six, Two}
 import org.finos.vuu.core.table.datatype.ScaledDecimal
 import org.finos.vuu.grammar.FilterBaseVisitor
 import org.finos.vuu.grammar.FilterParser.*
-import org.finos.vuu.plugin.clickhouse.provider.filter.ClickHouseFilterVisitor.DATE_TIME_FORMATTER
+import org.finos.vuu.plugin.clickhouse.provider.filter.ClickHouseFilterVisitor.{MILLI_DATE_TIME_FORMATTER, NANO_DATE_TIME_FORMATTER}
 import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumn
 
 import java.time.Instant.ofEpochMilli
@@ -16,21 +16,23 @@ import java.util
 import scala.collection.mutable
 
 object ClickHouseFilterVisitor {
-
-  val DATE_TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter
-    .ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS")
+  val MILLI_DATE_TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter
+    .ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
     .withZone(ZoneOffset.UTC)
 
+  val NANO_DATE_TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter
+    .ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS")
+    .withZone(ZoneOffset.UTC)
 }
 
-case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSessionTableColumn],
-                                   stringBuilder: java.lang.StringBuilder,
-                                   params: mutable.Map[String, Any]
+case class ClickHouseFilterVisitor(
+                                    remoteNameMapping: Map[String, VirtualizedSessionTableColumn],
+                                    stringBuilder: java.lang.StringBuilder,
+                                    params: mutable.Map[String, Any]
                                   ) extends FilterBaseVisitor[Unit] {
 
-  override def visitStart(ctx: StartContext): Unit = {
+  override def visitStart(ctx: StartContext): Unit =
     visit(ctx.orExpression())
-  }
 
   override def visitOrExpression(ctx: OrExpressionContext): Unit =
     joinChildren(ctx.andExpression(), " OR ")
@@ -41,252 +43,166 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSes
   override def visitSubexpression(ctx: SubexpressionContext): Unit =
     visit(ctx.orExpression())
 
-  override def visitOperationEq(ctx: OperationEqContext): Unit = {
-    val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" = ")
-    appendScalarParam(remoteColumn, ctx.scalar().getText)
-  }
+  override def visitOperationEq(ctx: OperationEqContext): Unit =
+    visitBinary(ctx.ID().getText, " = ", ctx.scalar().getText)
 
-  override def visitOperationNeq(ctx: OperationNeqContext): Unit = {
-    val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" != ")
-    appendScalarParam(remoteColumn, ctx.scalar().getText)
-  }
+  override def visitOperationNeq(ctx: OperationNeqContext): Unit =
+    visitBinary(ctx.ID().getText, " != ", ctx.scalar().getText)
 
-  override def visitOperationGt(ctx: OperationGtContext): Unit = {
-    val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" > ")
-    appendScalarParam(remoteColumn, ctx.NUMBER().getText)
-  }
+  override def visitOperationGt(ctx: OperationGtContext): Unit =
+    visitBinary(ctx.ID().getText, " > ", ctx.NUMBER().getText)
 
-  override def visitOperationGte(ctx: OperationGteContext): Unit = {
-    val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" >= ")
-    appendScalarParam(remoteColumn, ctx.NUMBER().getText)
-  }
+  override def visitOperationGte(ctx: OperationGteContext): Unit =
+    visitBinary(ctx.ID().getText, " >= ", ctx.NUMBER().getText)
 
-  override def visitOperationLt(ctx: OperationLtContext): Unit = {
-    val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" < ")
-    appendScalarParam(remoteColumn, ctx.NUMBER().getText)
-  }
+  override def visitOperationLt(ctx: OperationLtContext): Unit =
+    visitBinary(ctx.ID().getText, " < ", ctx.NUMBER().getText)
 
-  override def visitOperationLte(ctx: OperationLteContext): Unit = {
-    val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    stringBuilder.append(remoteColumn.remoteName).append(" <= ")
-    appendScalarParam(remoteColumn, ctx.NUMBER().getText)
-  }
+  override def visitOperationLte(ctx: OperationLteContext): Unit =
+    visitBinary(ctx.ID().getText, " <= ", ctx.NUMBER().getText)
 
   override def visitOperationStarts(ctx: OperationStartsContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append("startsWith(").append(remoteColumn.remoteName).append(", ")
     appendScalarParam(remoteColumn, ctx.STRING().getText)
-    stringBuilder.append(")")
+    stringBuilder.append(')')
   }
 
   override def visitOperationEnds(ctx: OperationEndsContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append("endsWith(").append(remoteColumn.remoteName).append(", ")
     appendScalarParam(remoteColumn, ctx.STRING().getText)
-    stringBuilder.append(")")
+    stringBuilder.append(')')
   }
 
   override def visitOperationContains(ctx: OperationContainsContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" LIKE ")
-    appendScalarParam(remoteColumn, s"%${ctx.STRING().getText}%")
+    val rawText = ctx.STRING().getText
+    val containsVal = new java.lang.StringBuilder(rawText.length + 2).append('%').append(rawText).append('%').toString
+    appendScalarParam(remoteColumn, containsVal)
   }
 
   override def visitOperationIn(ctx: OperationInContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" IN ")
 
-    val stringTokens = ctx.set().STRING()
-    val tokens = if (stringTokens != null && !stringTokens.isEmpty) {
-      stringTokens
-    } else {
-      ctx.set().NUMBER()
-    }
+    val setCtx = ctx.set()
+    val stringTokens = setCtx.STRING()
+    val tokens = if (stringTokens != null && !stringTokens.isEmpty) stringTokens else setCtx.NUMBER()
 
     val n = tokens.size()
-    val params = new util.ArrayList[String](n)
+    val paramValues = new util.ArrayList[Any](n)
     var i = 0
     while (i < n) {
-      params.add(tokens.get(i).getText)
+      paramValues.add(parseArrayElement(remoteColumn.dataType, tokens.get(i).getText))
       i += 1
     }
 
-    appendParamArray(remoteColumn, params)
+    val paramName = s"p_${params.size}"
+    params.put(paramName, paramValues)
+
+    stringBuilder
+      .append("{")
+      .append(paramName)
+      .append(":Array(")
+      .append(getClickHouseType(remoteColumn.dataType))
+      .append(")}")
   }
 
   // ------------------------------------------------------------
   // Helpers
   // ------------------------------------------------------------
 
-  private def getRemoteColumn(id: String): VirtualizedSessionTableColumn = {
-    remoteNameMapping.getOrElse(id,
-      throw new IllegalArgumentException(s"Mapping missing for filter column: '$id'"))
+  private inline def visitBinary(id: String, op: String, value: String): Unit = {
+    val remoteColumn = getRemoteColumn(id)
+    stringBuilder.append(remoteColumn.remoteName).append(op)
+    appendScalarParam(remoteColumn, value)
   }
 
-  private def joinChildren(children: java.util.List[_ <: org.antlr.v4.runtime.tree.ParseTree], op: String): Unit = {
+  private inline def getRemoteColumn(id: String): VirtualizedSessionTableColumn =
+    remoteNameMapping.getOrElse(id,
+      throw new IllegalArgumentException(s"Mapping missing for filter column: '$id'"))
+
+  private def joinChildren(children: java.util.List[? <: org.antlr.v4.runtime.tree.ParseTree], op: String): Unit = {
     val startLen = stringBuilder.length()
     val it = children.iterator()
     var writtenCount = 0
 
     while (it.hasNext) {
       val marker = stringBuilder.length()
-
-      // Speculatively append the operator if this isn't the first confirmed element
-      if (writtenCount > 0) {
-        stringBuilder.append(op)
-      }
+      if (writtenCount > 0) stringBuilder.append(op)
 
       val childStart = stringBuilder.length()
       visit(it.next())
 
       if (stringBuilder.length() == childStart) {
-        // The child didn't write anything (empty node), roll back the appended operator
-        if (writtenCount > 0) {
-          stringBuilder.setLength(marker)
-        }
+        if (writtenCount > 0) stringBuilder.setLength(marker)
       } else {
         writtenCount += 1
       }
     }
 
-    // Wrap in parentheses only if we combined multiple distinct valid criteria
     if (writtenCount > 1) {
       stringBuilder.insert(startLen, '(')
       stringBuilder.append(')')
     }
   }
 
-  private def appendScalarParam(column: VirtualizedSessionTableColumn,
-                          paramValue: String): Unit = {
+  private def appendScalarParam(column: VirtualizedSessionTableColumn, paramValue: String): Unit = {
     val paramName = s"p_${params.size}"
+    params.put(paramName, parseScalarValue(column.dataType, paramValue))
 
-    stringBuilder.append("{")
-    stringBuilder.append(paramName)
-    stringBuilder.append(":")
-
-    column.dataType match {
-      case DataType.StringDataType =>
-        params.put(paramName, paramValue)
-        stringBuilder.append("String")
-      case DataType.CharDataType =>
-        params.put(paramName, String.valueOf(paramValue.charAt(0)))
-        stringBuilder.append("String")
-      case DataType.IntegerDataType =>
-        params.put(paramName, paramValue.toInt)
-        stringBuilder.append("Int32")
-      case DataType.LongDataType =>
-        params.put(paramName, paramValue.toLong)
-        stringBuilder.append("Int64")
-      case DataType.DoubleDataType =>
-        params.put(paramName, paramValue.toDouble)
-        stringBuilder.append("Float64")
-      case DataType.BooleanDataType =>
-        params.put(paramName, paramValue.toBoolean)
-        stringBuilder.append("Bool")
-      case DataType.EpochTimestampType =>
-        params.put(paramName, ofEpochMilli(paramValue.toLong))
-        stringBuilder.append("DateTime64")
-      case DataType.EpochTimestampNanoType =>
-        params.put(paramName, ofEpochNanosecond(paramValue.toLong))
-        stringBuilder.append("DateTime64")
-      case DataType.ScaledDecimal2Type =>
-        params.put(paramName, ScaledDecimal(paramValue, Two).scaledValue)
-        stringBuilder.append("Int64")
-      case DataType.ScaledDecimal4Type =>
-        params.put(paramName, ScaledDecimal(paramValue, Four).scaledValue)
-        stringBuilder.append("Int64")
-      case DataType.ScaledDecimal6Type =>
-        params.put(paramName, ScaledDecimal(paramValue, Six).scaledValue)
-        stringBuilder.append("Int64")
-      case DataType.ScaledDecimal8Type =>
-        params.put(paramName, ScaledDecimal(paramValue, Eight).scaledValue)
-        stringBuilder.append("Int64")
-      case _ =>
-        throw new IllegalArgumentException(s"Unable to handle column dataType: '${column.dataType}'")
-    }
-
-    stringBuilder.append("}")
+    stringBuilder
+      .append('{')
+      .append(paramName)
+      .append(':')
+      .append(getClickHouseType(column.dataType))
+      .append('}')
   }
 
-  private def appendParamArray(column: VirtualizedSessionTableColumn,
-                               paramValues: java.util.List[String]): Unit = {
-    val paramName = s"p_${params.size}"
-
-    stringBuilder.append("{")
-    stringBuilder.append(paramName)
-    stringBuilder.append(":Array(")
-
-    column.dataType match {
-      case DataType.StringDataType =>
-        params.put(paramName, paramValues.stream()
-          .map(f => s"'$f'")
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("String")
-      case DataType.CharDataType =>
-        params.put(paramName, paramValues.stream()
-          .map(f => s"'${f.charAt(0)}'")
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("String")
-      case DataType.IntegerDataType =>
-        params.put(paramName, paramValues.stream()
-          .map(f => f.toInt)
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("Int32")
-      case DataType.LongDataType =>
-        params.put(paramName, paramValues.stream()
-          .map(f => f.toLong)
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("Int64")
-      case DataType.DoubleDataType =>
-        params.put(paramName, paramValues.stream()
-          .map(f => f.toDouble)
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("Float64")
-      case DataType.BooleanDataType =>
-        params.put(paramName, paramValues.stream()
-          .map(f => f.toBoolean)
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("Bool")
-      case DataType.EpochTimestampType =>
-        params.put(paramName, paramValues.stream()
-          .map(f => s"'${DATE_TIME_FORMATTER.format(ofEpochMilli(f.toLong))}'")
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("DateTime64")
-      case DataType.EpochTimestampNanoType =>
-        params.put(paramName, paramValues.stream()
-          .map(f => s"'${DATE_TIME_FORMATTER.format(ofEpochNanosecond(f.toLong))}'")
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("DateTime64")
-      case DataType.ScaledDecimal2Type =>
-        params.put(paramName, paramValues.stream()
-          .map(f => ScaledDecimal(f, Two).scaledValue)
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("Int64")
-      case DataType.ScaledDecimal4Type =>
-        params.put(paramName, paramValues.stream()
-          .map(f => ScaledDecimal(f, Four).scaledValue)
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("Int64")
-      case DataType.ScaledDecimal6Type =>
-        params.put(paramName, paramValues.stream()
-          .map(f => ScaledDecimal(f, Six).scaledValue)
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("Int64")
-      case DataType.ScaledDecimal8Type =>
-        params.put(paramName, paramValues.stream()
-          .map(f => ScaledDecimal(f, Eight).scaledValue)
-          .collect(java.util.stream.Collectors.toList()))
-        stringBuilder.append("Int64")
-      case _ =>
-        throw new IllegalArgumentException(s"Unable to handle column dataType: '${column.dataType}'")
-    }
-
-    stringBuilder.append(")}")
+  private def getClickHouseType(dataType: Class[?]): String = dataType match {
+    case DataType.StringDataType | DataType.CharDataType => "String"
+    case DataType.IntegerDataType => "Int32"
+    case DataType.LongDataType |
+         DataType.ScaledDecimal2Type | DataType.ScaledDecimal4Type |
+         DataType.ScaledDecimal6Type | DataType.ScaledDecimal8Type => "Int64"
+    case DataType.DoubleDataType => "Float64"
+    case DataType.BooleanDataType => "Bool"
+    case DataType.EpochTimestampType |
+         DataType.EpochTimestampNanoType => "DateTime64"
+    case _ => throw new IllegalArgumentException(s"Unable to handle column dataType: '$dataType'")
   }
 
+  private def parseScalarValue(dataType: Class[?], value: String): Any = dataType match {
+    case DataType.StringDataType => value
+    case DataType.CharDataType => java.lang.String.valueOf(value.charAt(0))
+    case DataType.IntegerDataType => value.toInt
+    case DataType.LongDataType => value.toLong
+    case DataType.DoubleDataType => value.toDouble
+    case DataType.BooleanDataType => value.toBoolean
+    case DataType.EpochTimestampType => ofEpochMilli(value.toLong)
+    case DataType.EpochTimestampNanoType => ofEpochNanosecond(value.toLong)
+    case DataType.ScaledDecimal2Type => ScaledDecimal(value, Two).scaledValue
+    case DataType.ScaledDecimal4Type => ScaledDecimal(value, Four).scaledValue
+    case DataType.ScaledDecimal6Type => ScaledDecimal(value, Six).scaledValue
+    case DataType.ScaledDecimal8Type => ScaledDecimal(value, Eight).scaledValue
+    case _ => throw new IllegalArgumentException(s"Unable to handle column dataType: '$dataType'")
+  }
+
+  private def parseArrayElement(dataType: Class[?], value: String): Any = dataType match {
+    case DataType.StringDataType => s"'$value'"
+    case DataType.CharDataType => s"'${value.charAt(0)}'"
+    case DataType.IntegerDataType => value.toInt
+    case DataType.LongDataType => value.toLong
+    case DataType.DoubleDataType => value.toDouble
+    case DataType.BooleanDataType => value.toBoolean
+    case DataType.EpochTimestampType => s"'${MILLI_DATE_TIME_FORMATTER.format(ofEpochMilli(value.toLong))}'"
+    case DataType.EpochTimestampNanoType => s"'${NANO_DATE_TIME_FORMATTER.format(ofEpochNanosecond(value.toLong))}'"
+    case DataType.ScaledDecimal2Type => ScaledDecimal(value, Two).scaledValue
+    case DataType.ScaledDecimal4Type => ScaledDecimal(value, Four).scaledValue
+    case DataType.ScaledDecimal6Type => ScaledDecimal(value, Six).scaledValue
+    case DataType.ScaledDecimal8Type => ScaledDecimal(value, Eight).scaledValue
+    case _ => throw new IllegalArgumentException(s"Unable to handle column dataType: '$dataType'")
+  }
 }

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
@@ -6,10 +6,22 @@ import org.finos.vuu.core.table.datatype.Scale.{Eight, Four, Six, Two}
 import org.finos.vuu.core.table.datatype.ScaledDecimal
 import org.finos.vuu.grammar.FilterBaseVisitor
 import org.finos.vuu.grammar.FilterParser.*
+import org.finos.vuu.plugin.clickhouse.provider.filter.ClickHouseFilterVisitor.DATE_TIME_FORMATTER
 import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumn
 
 import java.time.Instant.ofEpochMilli
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util
 import scala.collection.mutable
+
+object ClickHouseFilterVisitor {
+
+  val DATE_TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter
+    .ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS")
+    .withZone(ZoneOffset.UTC)
+
+}
 
 case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSessionTableColumn],
                                    stringBuilder: java.lang.StringBuilder,
@@ -32,56 +44,79 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSes
   override def visitOperationEq(ctx: OperationEqContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" = ")
-    appendParam(remoteColumn, ctx.scalar().getText)
+    appendScalarParam(remoteColumn, ctx.scalar().getText)
   }
 
   override def visitOperationNeq(ctx: OperationNeqContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" != ")
-    appendParam(remoteColumn, ctx.scalar().getText)
+    appendScalarParam(remoteColumn, ctx.scalar().getText)
   }
 
   override def visitOperationGt(ctx: OperationGtContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" > ")
-    appendParam(remoteColumn, ctx.NUMBER().getText)
+    appendScalarParam(remoteColumn, ctx.NUMBER().getText)
   }
 
   override def visitOperationGte(ctx: OperationGteContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" >= ")
-    appendParam(remoteColumn, ctx.NUMBER().getText)
+    appendScalarParam(remoteColumn, ctx.NUMBER().getText)
   }
 
   override def visitOperationLt(ctx: OperationLtContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" < ")
-    appendParam(remoteColumn, ctx.NUMBER().getText)
+    appendScalarParam(remoteColumn, ctx.NUMBER().getText)
   }
 
   override def visitOperationLte(ctx: OperationLteContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
     stringBuilder.append(remoteColumn.remoteName).append(" <= ")
-    appendParam(remoteColumn, ctx.NUMBER().getText)
+    appendScalarParam(remoteColumn, ctx.NUMBER().getText)
   }
 
   override def visitOperationStarts(ctx: OperationStartsContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    like(remoteColumn.remoteName, ctx.STRING().getText, prefix = false, suffix = true)
+    stringBuilder.append("startsWith(").append(remoteColumn.remoteName).append(", ")
+    appendScalarParam(remoteColumn, ctx.STRING().getText)
+    stringBuilder.append(")")
   }
 
   override def visitOperationEnds(ctx: OperationEndsContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    like(remoteColumn.remoteName, ctx.STRING().getText, prefix = true, suffix = false)
+    stringBuilder.append("endsWith(").append(remoteColumn.remoteName).append(", ")
+    appendScalarParam(remoteColumn, ctx.STRING().getText)
+    stringBuilder.append(")")
   }
 
   override def visitOperationContains(ctx: OperationContainsContext): Unit = {
     val remoteColumn = getRemoteColumn(ctx.ID().getText)
-    like(remoteColumn.remoteName, ctx.STRING().getText, prefix = true, suffix = true)
+    stringBuilder.append(remoteColumn.remoteName).append(" LIKE ")
+    appendScalarParam(remoteColumn, s"%${ctx.STRING().getText}%")
   }
 
   override def visitOperationIn(ctx: OperationInContext): Unit = {
-    //TODO
+    val remoteColumn = getRemoteColumn(ctx.ID().getText)
+    stringBuilder.append(remoteColumn.remoteName).append(" IN ")
+
+    val stringTokens = ctx.set().STRING()
+    val tokens = if (stringTokens != null && !stringTokens.isEmpty) {
+      stringTokens
+    } else {
+      ctx.set().NUMBER()
+    }
+
+    val n = tokens.size()
+    val params = new util.ArrayList[String](n)
+    var i = 0
+    while (i < n) {
+      params.add(tokens.get(i).getText)
+      i += 1
+    }
+
+    appendParamArray(remoteColumn, params)
   }
 
   // ------------------------------------------------------------
@@ -126,15 +161,7 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSes
     }
   }
 
-  private def like(id: String, lit: String, prefix: Boolean, suffix: Boolean): Unit = {
-    stringBuilder.append(id).append(" LIKE '")
-    if (prefix) stringBuilder.append('%')
-    //TODO
-    if (suffix) stringBuilder.append('%')
-    stringBuilder.append('\'')
-  }
-
-  private def appendParam(column: VirtualizedSessionTableColumn,
+  private def appendScalarParam(column: VirtualizedSessionTableColumn,
                           paramValue: String): Unit = {
     val paramName = s"p_${params.size}"
 
@@ -184,6 +211,82 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSes
     }
 
     stringBuilder.append("}")
+  }
+
+  private def appendParamArray(column: VirtualizedSessionTableColumn,
+                               paramValues: java.util.List[String]): Unit = {
+    val paramName = s"p_${params.size}"
+
+    stringBuilder.append("{")
+    stringBuilder.append(paramName)
+    stringBuilder.append(":Array(")
+
+    column.dataType match {
+      case DataType.StringDataType =>
+        params.put(paramName, paramValues.stream()
+          .map(f => s"'$f'")
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("String")
+      case DataType.CharDataType =>
+        params.put(paramName, paramValues.stream()
+          .map(f => s"'${f.charAt(0)}'")
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("String")
+      case DataType.IntegerDataType =>
+        params.put(paramName, paramValues.stream()
+          .map(f => f.toInt)
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("Int32")
+      case DataType.LongDataType =>
+        params.put(paramName, paramValues.stream()
+          .map(f => f.toLong)
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("Int64")
+      case DataType.DoubleDataType =>
+        params.put(paramName, paramValues.stream()
+          .map(f => f.toDouble)
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("Float64")
+      case DataType.BooleanDataType =>
+        params.put(paramName, paramValues.stream()
+          .map(f => f.toBoolean)
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("Bool")
+      case DataType.EpochTimestampType =>
+        params.put(paramName, paramValues.stream()
+          .map(f => s"'${DATE_TIME_FORMATTER.format(ofEpochMilli(f.toLong))}'")
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("DateTime64")
+      case DataType.EpochTimestampNanoType =>
+        params.put(paramName, paramValues.stream()
+          .map(f => s"'${DATE_TIME_FORMATTER.format(ofEpochNanosecond(f.toLong))}'")
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("DateTime64")
+      case DataType.ScaledDecimal2Type =>
+        params.put(paramName, paramValues.stream()
+          .map(f => ScaledDecimal(f, Two).scaledValue)
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("Int64")
+      case DataType.ScaledDecimal4Type =>
+        params.put(paramName, paramValues.stream()
+          .map(f => ScaledDecimal(f, Four).scaledValue)
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("Int64")
+      case DataType.ScaledDecimal6Type =>
+        params.put(paramName, paramValues.stream()
+          .map(f => ScaledDecimal(f, Six).scaledValue)
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("Int64")
+      case DataType.ScaledDecimal8Type =>
+        params.put(paramName, paramValues.stream()
+          .map(f => ScaledDecimal(f, Eight).scaledValue)
+          .collect(java.util.stream.Collectors.toList()))
+        stringBuilder.append("Int64")
+      case _ =>
+        throw new IllegalArgumentException(s"Unable to handle column dataType: '${column.dataType}'")
+    }
+
+    stringBuilder.append(")}")
   }
 
 }

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
@@ -2,13 +2,13 @@ package org.finos.vuu.plugin.clickhouse.provider.filter
 
 import org.finos.vuu.grammar.FilterBaseVisitor
 import org.finos.vuu.grammar.FilterParser.*
-import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumn
 
-class ClickHouseFilterVisitor(remoteNameMapping: Map[String, String]) extends FilterBaseVisitor[Unit] {
+import scala.collection.mutable
 
-  private val sb = new java.lang.StringBuilder(256)
-
-  def getBuffer: java.lang.StringBuilder = sb
+case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, String],
+                                   stringBuilder: java.lang.StringBuilder,
+                                   params: mutable.Map[String, Any]
+                                  ) extends FilterBaseVisitor[Unit] {
 
   override def visitStart(ctx: StartContext): Unit = {
     visit(ctx.orExpression())
@@ -24,26 +24,26 @@ class ClickHouseFilterVisitor(remoteNameMapping: Map[String, String]) extends Fi
     visit(ctx.orExpression())
 
   override def visitOperationEq(ctx: OperationEqContext): Unit = {
-    sb.append(getRemoteId(ctx.ID().getText)).append(" = ")
+    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" = ")
     appendScalar(ctx.scalar())
   }
 
   override def visitOperationNeq(ctx: OperationNeqContext): Unit = {
-    sb.append(getRemoteId(ctx.ID().getText)).append(" != ")
+    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" != ")
     appendScalar(ctx.scalar())
   }
 
   override def visitOperationGt(ctx: OperationGtContext): Unit =
-    sb.append(getRemoteId(ctx.ID().getText)).append(" > ").append(ctx.NUMBER().getText)
+    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" > ").append(ctx.NUMBER().getText)
 
   override def visitOperationGte(ctx: OperationGteContext): Unit =
-    sb.append(getRemoteId(ctx.ID().getText)).append(" >= ").append(ctx.NUMBER().getText)
+    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" >= ").append(ctx.NUMBER().getText)
 
   override def visitOperationLt(ctx: OperationLtContext): Unit =
-    sb.append(getRemoteId(ctx.ID().getText)).append(" < ").append(ctx.NUMBER().getText)
+    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" < ").append(ctx.NUMBER().getText)
 
   override def visitOperationLte(ctx: OperationLteContext): Unit =
-    sb.append(getRemoteId(ctx.ID().getText)).append(" <= ").append(ctx.NUMBER().getText)
+    stringBuilder.append(getRemoteId(ctx.ID().getText)).append(" <= ").append(ctx.NUMBER().getText)
 
   override def visitOperationStarts(ctx: OperationStartsContext): Unit =
     like(getRemoteId(ctx.ID().getText), ctx.STRING().getText, prefix = false, suffix = true)
@@ -60,35 +60,35 @@ class ClickHouseFilterVisitor(remoteNameMapping: Map[String, String]) extends Fi
 
     val nums = setCtx.NUMBER()
     if (nums != null && !nums.isEmpty) {
-      sb.append(id).append(" IN (")
+      stringBuilder.append(id).append(" IN (")
       val it = nums.iterator()
-      if (it.hasNext) sb.append(it.next().getText)
+      if (it.hasNext) stringBuilder.append(it.next().getText)
       while (it.hasNext) {
-        sb.append(", ").append(it.next().getText)
+        stringBuilder.append(", ").append(it.next().getText)
       }
-      sb.append(")")
+      stringBuilder.append(")")
       return
     }
 
     val strings = setCtx.STRING()
     if (strings != null && !strings.isEmpty) {
-      sb.append(id).append(" IN (")
+      stringBuilder.append(id).append(" IN (")
       val it = strings.iterator()
       if (it.hasNext) {
-        sb.append('\'')
+        stringBuilder.append('\'')
         appendEscaped(it.next().getText)
-        sb.append('\'')
+        stringBuilder.append('\'')
       }
       while (it.hasNext) {
-        sb.append(", '")
+        stringBuilder.append(", '")
         appendEscaped(it.next().getText)
-        sb.append('\'')
+        stringBuilder.append('\'')
       }
-      sb.append(")")
+      stringBuilder.append(")")
       return
     }
 
-    sb.append("1 = 0")
+    stringBuilder.append("1 = 0")
   }
 
   // ------------------------------------------------------------
@@ -101,25 +101,25 @@ class ClickHouseFilterVisitor(remoteNameMapping: Map[String, String]) extends Fi
   }
 
   private def joinChildren(children: java.util.List[_ <: org.antlr.v4.runtime.tree.ParseTree], op: String): Unit = {
-    val startLen = sb.length()
+    val startLen = stringBuilder.length()
     val it = children.iterator()
     var writtenCount = 0
 
     while (it.hasNext) {
-      val marker = sb.length()
+      val marker = stringBuilder.length()
 
       // Speculatively append the operator if this isn't the first confirmed element
       if (writtenCount > 0) {
-        sb.append(op)
+        stringBuilder.append(op)
       }
 
-      val childStart = sb.length()
+      val childStart = stringBuilder.length()
       visit(it.next())
 
-      if (sb.length() == childStart) {
+      if (stringBuilder.length() == childStart) {
         // The child didn't write anything (empty node), roll back the appended operator
         if (writtenCount > 0) {
-          sb.setLength(marker)
+          stringBuilder.setLength(marker)
         }
       } else {
         writtenCount += 1
@@ -128,27 +128,27 @@ class ClickHouseFilterVisitor(remoteNameMapping: Map[String, String]) extends Fi
 
     // Wrap in parentheses only if we combined multiple distinct valid criteria
     if (writtenCount > 1) {
-      sb.insert(startLen, '(')
-      sb.append(')')
+      stringBuilder.insert(startLen, '(')
+      stringBuilder.append(')')
     }
   }
 
   private def like(id: String, lit: String, prefix: Boolean, suffix: Boolean): Unit = {
-    sb.append(id).append(" LIKE '")
-    if (prefix) sb.append('%')
+    stringBuilder.append(id).append(" LIKE '")
+    if (prefix) stringBuilder.append('%')
     appendEscaped(lit)
-    if (suffix) sb.append('%')
-    sb.append('\'')
+    if (suffix) stringBuilder.append('%')
+    stringBuilder.append('\'')
   }
 
   private def appendScalar(scalar: ScalarContext): Unit = {
     val s = scalar.STRING()
     if (s != null) {
-      sb.append('\'')
+      stringBuilder.append('\'')
       appendEscaped(s.getText)
-      sb.append('\'')
+      stringBuilder.append('\'')
     } else {
-      sb.append(scalar.getText)
+      stringBuilder.append(scalar.getText)
     }
   }
 
@@ -158,8 +158,8 @@ class ClickHouseFilterVisitor(remoteNameMapping: Map[String, String]) extends Fi
       val len = s.length
       while (i < len) {
         val c = s.charAt(i)
-        if (c == '\'') sb.append("''")
-        else sb.append(c)
+        if (c == '\'') stringBuilder.append("''")
+        else stringBuilder.append(c)
         i += 1
       }
     }

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
@@ -144,7 +144,7 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSes
         params.put(paramName, paramValue)
         stringBuilder.append("String")
       case DataType.CharDataType =>
-        params.put(paramName, paramValue.charAt(0))
+        params.put(paramName, String.valueOf(paramValue.charAt(0)))
         stringBuilder.append("String")
       case DataType.IntegerDataType =>
         params.put(paramName, paramValue.toInt)

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitor.scala
@@ -2,10 +2,11 @@ package org.finos.vuu.plugin.clickhouse.provider.filter
 
 import org.finos.vuu.grammar.FilterBaseVisitor
 import org.finos.vuu.grammar.FilterParser.*
+import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumn
 
 import scala.collection.mutable
 
-case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, String],
+case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, VirtualizedSessionTableColumn],
                                    stringBuilder: java.lang.StringBuilder,
                                    params: mutable.Map[String, Any]
                                   ) extends FilterBaseVisitor[Unit] {
@@ -97,7 +98,7 @@ case class ClickHouseFilterVisitor(remoteNameMapping: Map[String, String],
 
   private def getRemoteId(id: String): String = {
     remoteNameMapping.getOrElse(id,
-      throw new IllegalArgumentException(s"Mapping missing for filter column: '$id'"))
+      throw new IllegalArgumentException(s"Mapping missing for filter column: '$id'")).remoteName
   }
 
   private def joinChildren(children: java.util.List[_ <: org.antlr.v4.runtime.tree.ParseTree], op: String): Unit = {

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/sort/ClickHouseSortFactory.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/sort/ClickHouseSortFactory.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success, Try}
 
 class ClickHouseSortFactory(tableDef: VirtualizedSessionTableDef) extends StrictLogging {
 
-  private val DEFAULT_SORT = s"ORDER BY ${tableDef.getRemoteKeyField} ASC"
+  private val DEFAULT_SORT = s"${tableDef.getRemoteKeyField} ASC"
 
   def build(sortSpec: SortSpec): String = {
     if (sortSpec != null && sortSpec.sortDefs != null && sortSpec.sortDefs.nonEmpty) {
@@ -21,20 +21,19 @@ class ClickHouseSortFactory(tableDef: VirtualizedSessionTableDef) extends Strict
   }
 
   private def parseSort(sortSpec: SortSpec): String = {
-    val primaryKeyInSort: Boolean = sortSpec.sortDefs.exists(f => f.column == tableDef.keyField)
-
     Try(parseSortItems(sortSpec)) match {
       case Success(sortItems) =>
+        val primaryKeyInSort = sortSpec.sortDefs.exists(f => f.column == tableDef.keyField)
         val orderBy = if (primaryKeyInSort) {
-          s"ORDER BY ${sortItems.mkString(", ")}"
+          sortItems.mkString(", ")
         } else {
-          s"ORDER BY ${sortItems.mkString(", ")}, ${tableDef.getRemoteKeyField} ASC"
+          s"${sortItems.mkString(", ")}, $DEFAULT_SORT"
         }
         logger.trace(s"Parsed sort \"$orderBy\"")
         orderBy
       case Failure(err) =>
         logger.error(s"Could not parse sort $sortSpec", err)
-        s"ORDER BY ${tableDef.getRemoteKeyField} ASC"
+        DEFAULT_SORT
     }
   }
 

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/sort/ClickHouseSortFactory.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/sort/ClickHouseSortFactory.scala
@@ -39,11 +39,11 @@ class ClickHouseSortFactory(tableDef: VirtualizedSessionTableDef) extends Strict
 
   private def parseSortItems(sortSpec: SortSpec): List[String] = {
     val remoteMapping = tableDef.getRemoteColumnMapping
-    sortSpec.sortDefs.map { sd =>
-      val direction = if (sd.sortType == SortDirection.DESCENDING.external) "DESC" else "ASC"
-      val remoteColumnName = remoteMapping.getOrElse(sd.column,
+    sortSpec.sortDefs.map { sd =>      
+      val remoteColumn = remoteMapping.getOrElse(sd.column,
         throw new IllegalArgumentException(s"Mapping missing for sort column: '${sd.column}'"))
-      s"$remoteColumnName $direction"
+      val direction = if (sd.sortType == SortDirection.DESCENDING.external) "DESC" else "ASC"
+      s"${remoteColumn.remoteName} $direction"
     }
   }
 

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/typeahead/ClickHouseTypeAheadProvider.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/typeahead/ClickHouseTypeAheadProvider.scala
@@ -8,7 +8,6 @@ import org.finos.vuu.plugin.clickhouse.provider.filter.{ClauseWithParams, ClickH
 import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableDef
 import org.finos.vuu.viewport.ViewPort
 
-import java.util.HashMap as JHashMap
 import scala.collection.mutable.ArrayBuffer
 
 class ClickHouseTypeAheadProvider(client: ClickHouseClient,
@@ -39,8 +38,12 @@ class ClickHouseTypeAheadProvider(client: ClickHouseClient,
 
   private def fetchUniqueStringValues(remoteColumnName: String, starts: String, viewPort: ViewPort): Array[String] = {
     val clauseWithParams = buildWhereClauseAndParams(remoteColumnName, starts, viewPort)
-    val query =
-      s"SELECT DISTINCT $remoteColumnName FROM ${tableDef.getRemoteTableName} ${clauseWithParams.clause} ORDER BY $remoteColumnName LIMIT 10"
+
+    val query = if (clauseWithParams.clause.isBlank) {
+      s"SELECT DISTINCT $remoteColumnName FROM ${tableDef.getRemoteTableName} ORDER BY $remoteColumnName LIMIT 10"
+    } else {
+      s"SELECT DISTINCT $remoteColumnName FROM ${tableDef.getRemoteTableName} WHERE ${clauseWithParams.clause} ORDER BY $remoteColumnName LIMIT 10"
+    }
 
     client.executeQuery(query, clauseWithParams.params) { records =>
      recordsToArray(records, remoteColumnName)
@@ -48,7 +51,10 @@ class ClickHouseTypeAheadProvider(client: ClickHouseClient,
   }
 
   private def buildWhereClauseAndParams(remoteColumnName: String, starts: String, viewPort: ViewPort): ClauseWithParams = {
-    val permissionClauseWithParams = filterFactory.build(tableDef.getRemotePermissionFilterSpecFunction.apply(viewPort))
+    val initialClauseWithParams = filterFactory.build(
+      viewPort.filterSpec,
+      tableDef.getRemotePermissionFilterSpecFunction.apply(viewPort)
+    )
 
     val typeAheadClauseWithParams =
       if (starts != null && !starts.isBlank) {
@@ -59,7 +65,7 @@ class ClickHouseTypeAheadProvider(client: ClickHouseClient,
         NoFilter
       }
 
-    permissionClauseWithParams.and(typeAheadClauseWithParams)
+    initialClauseWithParams.and(typeAheadClauseWithParams)
   }
 
   private def recordsToArray(records: Records, column: String): Array[String] = {

--- a/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/typeahead/ClickHouseTypeAheadProvider.scala
+++ b/plugin/clickhouse-plugin/src/main/scala/org/finos/vuu/plugin/clickhouse/provider/typeahead/ClickHouseTypeAheadProvider.scala
@@ -4,7 +4,7 @@ import com.clickhouse.client.api.query.Records
 import com.typesafe.scalalogging.StrictLogging
 import org.finos.vuu.core.table.{ColumnValueProvider, DataType}
 import org.finos.vuu.plugin.clickhouse.client.ClickHouseClient
-import org.finos.vuu.plugin.clickhouse.provider.filter.ClickHouseFilterFactory
+import org.finos.vuu.plugin.clickhouse.provider.filter.{ClauseWithParams, ClickHouseFilterFactory, NoFilter}
 import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableDef
 import org.finos.vuu.viewport.ViewPort
 
@@ -38,34 +38,28 @@ class ClickHouseTypeAheadProvider(client: ClickHouseClient,
   }
 
   private def fetchUniqueStringValues(remoteColumnName: String, starts: String, viewPort: ViewPort): Array[String] = {
-    val (whereClause, params) = buildWhereClauseAndParams(remoteColumnName, starts, viewPort)
+    val clauseWithParams = buildWhereClauseAndParams(remoteColumnName, starts, viewPort)
     val query =
-      s"SELECT DISTINCT $remoteColumnName FROM ${tableDef.getRemoteTableName} $whereClause ORDER BY $remoteColumnName LIMIT 10"
+      s"SELECT DISTINCT $remoteColumnName FROM ${tableDef.getRemoteTableName} ${clauseWithParams.clause} ORDER BY $remoteColumnName LIMIT 10"
 
-    client.executeQuery(query, params) { records =>
+    client.executeQuery(query, clauseWithParams.params) { records =>
      recordsToArray(records, remoteColumnName)
     }
   }
 
-  private def buildWhereClauseAndParams(remoteColumnName: String, starts: String, viewPort: ViewPort): (String, java.util.Map[String, Object]) = {
-    val (baseFilter, params) = filterFactory.build(null, tableDef.getRemotePermissionFilterSpecFunction.apply(viewPort))
-    
-    val filterClause =
+  private def buildWhereClauseAndParams(remoteColumnName: String, starts: String, viewPort: ViewPort): ClauseWithParams = {
+    val permissionClauseWithParams = filterFactory.build(tableDef.getRemotePermissionFilterSpecFunction.apply(viewPort))
+
+    val typeAheadClauseWithParams =
       if (starts != null && !starts.isBlank) {
-         params.put("p_starts", starts.toLowerCase)
-         s"startsWith(lowerUTF8($remoteColumnName), {p_starts: String})"
+        val filter = s"startsWith(lowerUTF8($remoteColumnName), {p_starts: String})"
+        val params = Map("p_starts" -> starts.toLowerCase)
+        ClauseWithParams(filter, params)
       } else {
-        ""
+        NoFilter
       }
 
-    val whereClause = (baseFilter, filterClause) match {
-      case ("", "")  => ""
-      case (baseFilter, "")  => baseFilter
-      case ("", filterClause)  => s"WHERE $filterClause"
-      case (baseFilter, filterClause)  => s"$baseFilter AND ($filterClause)"
-    }
-
-    (whereClause, params)
+    permissionClauseWithParams.and(typeAheadClauseWithParams)
   }
 
   private def recordsToArray(records: Records, column: String): Array[String] = {

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/module/ClickHouseTableModule.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/module/ClickHouseTableModule.scala
@@ -27,9 +27,10 @@ object ClickHouseTableModule extends DefaultModule {
       remoteColumns = VirtualizedSessionTableColumnBuilder()
         .addString("orderId", "order_id")
         .addInt("quantity")
-        .addLong("price")
+        .addScaledDecimal6("price")
         .addString("side")
         .addString("trader")
+        .addEpochTimestampNano("time")
         .build(),
       options = TableDefOptions(
         includeDefaultColumns = false,

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/ClickHouseVirtualizedDataProviderTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/ClickHouseVirtualizedDataProviderTest.scala
@@ -6,6 +6,8 @@ import org.finos.toolbox.lifecycle.LifecycleContainer
 import org.finos.toolbox.time.{Clock, TestFriendlyClock}
 import org.finos.vuu.client.messages.RequestId
 import org.finos.vuu.core.module.TableDefContainer
+import org.finos.vuu.core.table.datatype.Scale.Six
+import org.finos.vuu.core.table.datatype.ScaledDecimal
 import org.finos.vuu.net.{FilterSpec, SortDef, SortSpec}
 import org.finos.vuu.plugin.clickhouse.ClickHouseContainer
 import org.finos.vuu.plugin.clickhouse.client.ClickHouseClient
@@ -137,11 +139,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (10, 100L, "Buy", "trader-10"),
-            (2, 20L, "Buy", "trader-2"),
-            (4, 40L, "Buy", "trader-4"),
-            (6, 60L, "Buy", "trader-6"),
-            (8, 80L, "Buy", "trader-8")
+            (10, ScaledDecimal("100", Six), "Buy", "trader-10"),
+            (2, ScaledDecimal("20", Six), "Buy", "trader-2"),
+            (4, ScaledDecimal("40", Six), "Buy", "trader-4"),
+            (6, ScaledDecimal("60", Six), "Buy", "trader-6"),
+            (8, ScaledDecimal("80", Six), "Buy", "trader-8")
           )
         }
 
@@ -158,11 +160,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (42002, 420020L, "Buy", "trader-42002"),
-            (42004, 420040L, "Buy", "trader-42004"),
-            (42006, 420060L, "Buy", "trader-42006"),
-            (42008, 420080L, "Buy", "trader-42008"),
-            (42010, 420100L, "Buy", "trader-42010")
+            (42002, ScaledDecimal("420020", Six), "Buy", "trader-42002"),
+            (42004, ScaledDecimal("420040", Six), "Buy", "trader-42004"),
+            (42006, ScaledDecimal("420060", Six), "Buy", "trader-42006"),
+            (42008, ScaledDecimal("420080", Six), "Buy", "trader-42008"),
+            (42010, ScaledDecimal("420100", Six), "Buy", "trader-42010")
           )
         }
 
@@ -174,11 +176,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (49992, 499920L, "Buy", "trader-49992"),
-            (49994, 499940L, "Buy", "trader-49994"),
-            (49996, 499960L, "Buy", "trader-49996"),
-            (49998, 499980L, "Buy", "trader-49998"),
-            (50000, 500000L, "Buy", "trader-50000")
+            (49992, ScaledDecimal("499920", Six), "Buy", "trader-49992"),
+            (49994, ScaledDecimal("499940", Six), "Buy", "trader-49994"),
+            (49996, ScaledDecimal("499960", Six), "Buy", "trader-49996"),
+            (49998, ScaledDecimal("499980", Six), "Buy", "trader-49998"),
+            (50000, ScaledDecimal("500000", Six), "Buy", "trader-50000")
           )
         }
 
@@ -196,11 +198,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (49992, 499920L, "Buy", "trader-49992"),
-            (49994, 499940L, "Buy", "trader-49994"),
-            (49996, 499960L, "Buy", "trader-49996"),
-            (49998, 499980L, "Buy", "trader-49998"),
-            (50000, 500000L, "Buy", "trader-50000")
+            (49992, ScaledDecimal("499920", Six), "Buy", "trader-49992"),
+            (49994, ScaledDecimal("499940", Six), "Buy", "trader-49994"),
+            (49996, ScaledDecimal("499960", Six), "Buy", "trader-49996"),
+            (49998, ScaledDecimal("499980", Six), "Buy", "trader-49998"),
+            (50000, ScaledDecimal("500000", Six), "Buy", "trader-50000")
           )
         }
 
@@ -212,11 +214,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (10, 100L, "Buy", "trader-10"),
-            (2, 20L, "Buy", "trader-2"),
-            (4, 40L, "Buy", "trader-4"),
-            (6, 60L, "Buy", "trader-6"),
-            (8, 80L, "Buy", "trader-8")
+            (10, ScaledDecimal("100", Six), "Buy", "trader-10"),
+            (2, ScaledDecimal("20", Six), "Buy", "trader-2"),
+            (4, ScaledDecimal("40", Six), "Buy", "trader-4"),
+            (6, ScaledDecimal("60", Six), "Buy", "trader-6"),
+            (8, ScaledDecimal("80", Six), "Buy", "trader-8")
           )
         }
 
@@ -229,11 +231,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (22, 220L, "Buy", "trader-22"),
-            (24, 240L, "Buy", "trader-24"),
-            (26, 260L, "Buy", "trader-26"),
-            (28, 280L, "Buy", "trader-28"),
-            (30, 300L, "Buy", "trader-30")
+            (22, ScaledDecimal("220", Six), "Buy", "trader-22"),
+            (24, ScaledDecimal("240", Six), "Buy", "trader-24"),
+            (26, ScaledDecimal("260", Six), "Buy", "trader-26"),
+            (28, ScaledDecimal("280", Six), "Buy", "trader-28"),
+            (30, ScaledDecimal("300", Six), "Buy", "trader-30")
           )
         }
 
@@ -292,11 +294,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (10, 100L, "Buy", "trader-10"),
-            (2, 20L, "Buy", "trader-2"),
-            (4, 40L, "Buy", "trader-4"),
-            (6, 60L, "Buy", "trader-6"),
-            (8, 80L, "Buy", "trader-8")
+            (10, ScaledDecimal("100", Six), "Buy", "trader-10"),
+            (2, ScaledDecimal("20", Six), "Buy", "trader-2"),
+            (4, ScaledDecimal("40", Six), "Buy", "trader-4"),
+            (6, ScaledDecimal("60", Six), "Buy", "trader-6"),
+            (8, ScaledDecimal("80", Six), "Buy", "trader-8")
           )
         }
 
@@ -319,7 +321,7 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (4, 40L, "Buy", "trader-4")
+            (4, ScaledDecimal("40", Six), "Buy", "trader-4")
           )
         }
       }
@@ -372,11 +374,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (10, 100L, "Buy", "trader-10"),
-            (2, 20L, "Buy", "trader-2"),
-            (4, 40L, "Buy", "trader-4"),
-            (6, 60L, "Buy", "trader-6"),
-            (8, 80L, "Buy", "trader-8")
+            (10, ScaledDecimal("100", Six), "Buy", "trader-10"),
+            (2, ScaledDecimal("20", Six), "Buy", "trader-2"),
+            (4, ScaledDecimal("40", Six), "Buy", "trader-4"),
+            (6, ScaledDecimal("60", Six), "Buy", "trader-6"),
+            (8, ScaledDecimal("80", Six), "Buy", "trader-8")
           )
         }
 
@@ -400,11 +402,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (49992, 499920L, "Buy", "trader-49992"),
-            (49994, 499940L, "Buy", "trader-49994"),
-            (49996, 499960L, "Buy", "trader-49996"),
-            (49998, 499980L, "Buy", "trader-49998"),
-            (50000, 500000L, "Buy", "trader-50000")
+            (49992, ScaledDecimal("499920", Six), "Buy", "trader-49992"),
+            (49994, ScaledDecimal("499940", Six), "Buy", "trader-49994"),
+            (49996, ScaledDecimal("499960", Six), "Buy", "trader-49996"),
+            (49998, ScaledDecimal("499980", Six), "Buy", "trader-49998"),
+            (50000, ScaledDecimal("500000", Six), "Buy", "trader-50000")
           )
         }
       }
@@ -458,11 +460,11 @@ class ClickHouseVirtualizedDataProviderTest extends VuuServerTestCase with ForAl
         assertVpEq(updates) {
           Table(
             ("quantity", "price", "side", "trader"),
-            (10, 100L, "Buy", "trader-10"),
-            (2, 20L, "Buy", "trader-2"),
-            (4, 40L, "Buy", "trader-4"),
-            (6, 60L, "Buy", "trader-6"),
-            (8, 80L, "Buy", "trader-8")
+            (10, ScaledDecimal("100", Six), "Buy", "trader-10"),
+            (2, ScaledDecimal("20", Six), "Buy", "trader-2"),
+            (4, ScaledDecimal("40", Six), "Buy", "trader-4"),
+            (6, ScaledDecimal("60", Six), "Buy", "trader-6"),
+            (8, ScaledDecimal("80", Six), "Buy", "trader-8")
           )
         }
 

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataProviderTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataProviderTest.scala
@@ -9,6 +9,7 @@ import org.finos.vuu.core.table.ViewPortColumnCreator
 import org.finos.vuu.plugin.clickhouse.ClickHouseContainer
 import org.finos.vuu.plugin.clickhouse.client.ClickHouseClient
 import org.finos.vuu.plugin.clickhouse.client.options.ClickHouseClientOptions
+import org.finos.vuu.plugin.clickhouse.provider.filter.{ClauseWithParams, NoFilter}
 import org.finos.vuu.plugin.virtualized.api.{AliasedVirtualizedSessionTableDef, VirtualizedSessionTableColumnBuilder, VirtualizedSessionTableDef}
 import org.scalatest.GivenWhenThen
 import org.scalatest.featurespec.AnyFeatureSpec
@@ -32,8 +33,7 @@ class ClickHouseRowDataProviderTest extends AnyFeatureSpec with GivenWhenThen wi
       val vpColumns = ViewPortColumnCreator.create(tableDef)
 
       val data = clickHouseRowDataProvider.queryForRowData(vpColumns,
-        whereClause = "",
-        params = util.Map.of(),
+        NoFilter,
         orderBy = "",
         offset = 0,
         limit = 100)
@@ -56,9 +56,8 @@ class ClickHouseRowDataProviderTest extends AnyFeatureSpec with GivenWhenThen wi
       val vpColumns = ViewPortColumnCreator.create(tableDef)
 
       val data = clickHouseRowDataProvider.queryForRowData(vpColumns,
-        whereClause = "",
-        params = util.Map.of(),
-        orderBy = "ORDER BY id DESC",
+        clauseWithParams = NoFilter,
+        orderBy = "id DESC",
         offset = 0,
         limit = 100)
 
@@ -84,8 +83,7 @@ class ClickHouseRowDataProviderTest extends AnyFeatureSpec with GivenWhenThen wi
       val vpColumns = ViewPortColumnCreator.create(tableDef)
 
       val data = clickHouseRowDataProvider.queryForRowData(vpColumns,
-        whereClause =  "WHERE val = {p_1:String}",
-        params = util.Map.of("p_1", "world"),
+        clauseWithParams = ClauseWithParams("val = {p_1:String}", Map("p_1" -> "world")),        
         orderBy = "",
         offset = 0,
         limit = 100)
@@ -112,9 +110,8 @@ class ClickHouseRowDataProviderTest extends AnyFeatureSpec with GivenWhenThen wi
       val vpColumns = ViewPortColumnCreator.create(tableDef)
 
       val data = clickHouseRowDataProvider.queryForRowData(vpColumns,
-        whereClause = "WHERE val LIKE {p_1:String}",
-        params = util.Map.of("p_1", "%o%"),
-        orderBy = "ORDER BY id DESC",
+        clauseWithParams = ClauseWithParams("val LIKE {p_1:String}", Map("p_1" -> "%o%")),
+        orderBy = "id DESC",
         offset = 0,
         limit = 100)
 
@@ -140,9 +137,8 @@ class ClickHouseRowDataProviderTest extends AnyFeatureSpec with GivenWhenThen wi
       val vpColumns = ViewPortColumnCreator.create(tableDef)
 
       val data = clickHouseRowDataProvider.queryForRowData(vpColumns,
-        whereClause = "WHERE val LIKE {p_1:String}",
-        params = util.Map.of("p_1", "%o%"),
-        orderBy = "ORDER BY id DESC",
+        clauseWithParams = ClauseWithParams("val LIKE {p_1:String}", Map("p_1" -> "%o%")),
+        orderBy = "id DESC",
         offset = 1,
         limit = 100)
 
@@ -168,9 +164,8 @@ class ClickHouseRowDataProviderTest extends AnyFeatureSpec with GivenWhenThen wi
       val vpColumns = ViewPortColumnCreator.create(tableDef)
 
       val data = clickHouseRowDataProvider.queryForRowData(vpColumns,
-        whereClause = "WHERE val LIKE {p_1:String}",
-        params = util.Map.of("p_1", "%o%"),
-        orderBy = "ORDER BY id DESC",
+        clauseWithParams = ClauseWithParams("val LIKE {p_1:String}", Map("p_1" -> "%o%")),
+        orderBy = "id DESC",
         offset = 0,
         limit = 1)
 
@@ -201,8 +196,7 @@ class ClickHouseRowDataProviderTest extends AnyFeatureSpec with GivenWhenThen wi
 
       val ex = intercept[RuntimeException] {
         clickHouseRowDataProvider.queryForRowData(vpColumns,
-          whereClause = "I am not valid SQL",
-          params = util.Map.of(),
+          clauseWithParams = ClauseWithParams("I am not valid SQL", Map.empty),
           orderBy = "",
           offset = 0,
           limit = 100)
@@ -228,8 +222,7 @@ class ClickHouseRowDataProviderTest extends AnyFeatureSpec with GivenWhenThen wi
 
       val ex = intercept[RuntimeException] {
         clickHouseRowDataProvider.queryForRowData(vpColumns,
-          whereClause = "",
-          params = util.Map.of(),
+          NoFilter,
           orderBy = "I am not valid SQL",
           offset = 0,
           limit = 100)

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataProviderTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseRowDataProviderTest.scala
@@ -15,8 +15,6 @@ import org.scalatest.GivenWhenThen
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.util
-
 class ClickHouseRowDataProviderTest extends AnyFeatureSpec with GivenWhenThen with Matchers with ForAllTestContainer {
 
   override val container: ClickHouseContainer = ClickHouseContainer()

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseTableSizeProviderTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/data/ClickHouseTableSizeProviderTest.scala
@@ -7,6 +7,7 @@ import org.finos.toolbox.time.{Clock, DefaultClock}
 import org.finos.vuu.plugin.clickhouse.ClickHouseContainer
 import org.finos.vuu.plugin.clickhouse.client.ClickHouseClient
 import org.finos.vuu.plugin.clickhouse.client.options.ClickHouseClientOptions
+import org.finos.vuu.plugin.clickhouse.provider.filter.{ClauseWithParams, NoFilter}
 import org.scalatest.GivenWhenThen
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
@@ -27,7 +28,7 @@ class ClickHouseTableSizeProviderTest extends AnyFeatureSpec with GivenWhenThen 
       val client = createClientAndTable()
       val clickHouseTableSizeProvider = ClickHouseTableSizeProvider(client, "test_table")
 
-      val size = clickHouseTableSizeProvider.getTableSize("", util.Map.of())
+      val size = clickHouseTableSizeProvider.getTableSize(NoFilter)
       size shouldEqual 2
 
       stopClient()
@@ -42,8 +43,10 @@ class ClickHouseTableSizeProviderTest extends AnyFeatureSpec with GivenWhenThen 
       val clickHouseTableSizeProvider = ClickHouseTableSizeProvider(client, "test_table")
 
       val size = clickHouseTableSizeProvider.getTableSize(
-        whereClause = "WHERE val = {p_1:String}",
-        params = util.Map.of("p_1", "world"),
+        ClauseWithParams(
+          clause = "val = {p_1:String}",
+          params = Map("p_1" -> "world")
+        )
       )
       size shouldEqual 1
 
@@ -59,7 +62,7 @@ class ClickHouseTableSizeProviderTest extends AnyFeatureSpec with GivenWhenThen 
       val clickHouseTableSizeProvider = ClickHouseTableSizeProvider(client, "lolcats")
 
       a[RuntimeException] should be thrownBy {
-        clickHouseTableSizeProvider.getTableSize("", util.Map.of())
+        clickHouseTableSizeProvider.getTableSize(NoFilter)
       }
 
       stopClient()

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClauseWithParamsTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClauseWithParamsTest.scala
@@ -1,0 +1,81 @@
+package org.finos.vuu.plugin.clickhouse.provider.filter
+
+import org.scalatest.GivenWhenThen
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+
+class ClauseWithParamsTest extends AnyFeatureSpec with GivenWhenThen with Matchers {
+
+  Feature("ClauseWithParams AND combination logic") {
+
+    Scenario("Combining NoFilter with other clauses") {
+      Given("a NoFilter instance and a standard clause")
+      val noFilter = NoFilter
+      val standard = ClauseWithParams("a = 1", Map("p1" -> "val1"))
+
+      When("NoFilter.and(standard) is called")
+      val result1 = noFilter.and(standard)
+
+      Then("it should evaluate directly to the standard clause")
+      result1 shouldBe standard
+
+      When("standard.and(NoFilter) is called")
+      val result2 = standard.and(noFilter)
+
+      Then("it should return the original standard clause unmodified")
+      result2 shouldBe standard
+    }
+
+    Scenario("Combining NoResults with other clauses") {
+      Given("a NoResults instance and a standard clause")
+      val noResults = NoResults
+      val standard = ClauseWithParams("b = 2", Map("p2" -> 2))
+
+      When("NoResults.and(standard) is called")
+      val result1 = noResults.and(standard)
+
+      Then("it should evaluate to NoResults")
+      result1 shouldBe NoResults
+
+      When("standard.and(NoResults) is called")
+      val result2 = standard.and(noResults)
+
+      Then("it should evaluate to NoResults")
+      result2 shouldBe NoResults
+    }
+
+    Scenario("Combining two standard clauses with distinct parameters") {
+      Given("two standard clauses with non-empty parameters")
+      val clause1 = ClauseWithParams("x = 10", Map("p1" -> 10))
+      val clause2 = ClauseWithParams("y = 20", Map("p2" -> 20))
+
+      When("combining both clauses using and()")
+      val result = clause1.and(clause2)
+
+      Then("the clause string should wrap both expressions in parentheses joined by AND")
+      result.clause shouldBe "(x = 10) AND (y = 20)"
+
+      And("the parameter maps should be merged")
+      result.params shouldBe Map("p1" -> 10, "p2" -> 20)
+    }
+
+    Scenario("Combining standard clauses when one or both parameter maps are empty") {
+      Given("a clause with parameters and a clause with an empty parameter map")
+      val clauseWithParams = ClauseWithParams("x = 10", Map("p1" -> 10))
+      val clauseEmptyParams = ClauseWithParams("y IS NOT NULL", Map.empty)
+
+      When("combining the clause with parameters with the empty-parameter clause")
+      val result1 = clauseWithParams.and(clauseEmptyParams)
+
+      Then("the non-empty parameter map should be preserved without re-allocating")
+      result1.params shouldBe Map("p1" -> 10)
+
+      When("combining the empty-parameter clause with the populated clause")
+      val result2 = clauseEmptyParams.and(clauseWithParams)
+
+      Then("the non-empty parameter map should still be preserved")
+      result2.params shouldBe Map("p1" -> 10)
+    }
+
+  }
+}

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterFactoryTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterFactoryTest.scala
@@ -43,8 +43,8 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE side = 'Buy'"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "side = {p_0:String}"
+      clauseWithParams.params.size shouldBe 1
     }
 
     Scenario("Empty user filter, composite permission filter") {
@@ -56,8 +56,8 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("side = \"Buy\" and quantity > 0")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE (side = 'Buy' AND quantity > 0)"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "(side = {p_0:String} AND quantity > {p_1:Int32})"
+      clauseWithParams.params.size shouldBe 2
     }
 
     Scenario("Non empty user filter, empty permission filter") {
@@ -69,8 +69,8 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE side = 'Sell'"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "side = {p_0:String}"
+      clauseWithParams.params.size shouldBe 1
     }
 
     Scenario("Non empty user filter, non empty permission filter") {
@@ -82,8 +82,8 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE (side = 'Buy' AND side = 'Sell')"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "(side = {p_0:String} AND side = {p_1:String})"
+      clauseWithParams.params.size shouldBe 2
     }
 
     Scenario("Non empty user filter, composite permission filter") {
@@ -95,8 +95,8 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("side = \"Buy\" and quantity > 0")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE ((side = 'Buy' AND quantity > 0) AND side = 'Sell')"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "((side = {p_0:String} AND quantity > {p_1:Int32}) AND side = {p_2:String})"
+      clauseWithParams.params.size shouldBe 3
     }
 
     Scenario("Composite user filter, empty permission filter") {
@@ -108,8 +108,8 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE (side = 'Sell' AND quantity > 100)"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "(side = {p_0:String} AND quantity > {p_1:Int32})"
+      clauseWithParams.params.size shouldBe 2
     }
 
     Scenario("Composite user filter, non empty permission filter") {
@@ -121,8 +121,8 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE (side = 'Buy' AND (side = 'Sell' AND quantity > 100))"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "(side = {p_0:String} AND (side = {p_1:String} AND quantity > {p_2:Int32}))"
+      clauseWithParams.params.size shouldBe 3
     }
 
     Scenario("Composite user filter, composite permission filter") {
@@ -134,8 +134,8 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("side = \"Buy\" and quantity > 0")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE ((side = 'Buy' AND quantity > 0) AND (side = 'Sell' AND quantity > 100))"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "((side = {p_0:String} AND quantity > {p_1:Int32}) AND (side = {p_2:String} AND quantity > {p_3:Int32}))"
+      clauseWithParams.params.size shouldBe 4
     }
 
   }
@@ -180,7 +180,7 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("DROP COLUMN;")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE 1 = 0"
+      clauseWithParams.clause shouldEqual "1 = 0"
       clauseWithParams.params.isEmpty shouldBe true
     }
 
@@ -193,24 +193,24 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE side = 'Buy'"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "side = {p_0:String}"
+      clauseWithParams.params.size shouldBe 1
 
       val clauseWithParams2 = filterFactory.build(
         userSpec = FilterSpec(null),
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      clauseWithParams2.clause shouldEqual "WHERE side = 'Buy'"
-      clauseWithParams2.params.isEmpty shouldBe true
+      clauseWithParams2.clause shouldEqual "side = {p_0:String}"
+      clauseWithParams2.params.size shouldBe 1
 
       val clauseWithParams3 = filterFactory.build(
         userSpec = FilterSpec("            "),
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      clauseWithParams3.clause shouldEqual "WHERE side = 'Buy'"
-      clauseWithParams3.params.isEmpty shouldBe true
+      clauseWithParams3.clause shouldEqual "side = {p_0:String}"
+      clauseWithParams3.params.size shouldBe 1
     }
 
     Scenario("User filter cannot be parsed") {
@@ -222,7 +222,7 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE 1 = 0"
+      clauseWithParams.clause shouldEqual "1 = 0"
       clauseWithParams.params.isEmpty shouldBe true
     }
 
@@ -235,24 +235,24 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = null
       )
 
-      clauseWithParams.clause shouldEqual "WHERE side = 'Sell'"
-      clauseWithParams.params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "side = {p_0:String}"
+      clauseWithParams.params.size shouldBe 1
 
       val clauseWithParams2 = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\""),
         permissionSpec = FilterSpec(null)
       )
 
-      clauseWithParams2.clause shouldEqual "WHERE side = 'Sell'"
-      clauseWithParams2.params.isEmpty shouldBe true
+      clauseWithParams2.clause shouldEqual "side = {p_0:String}"
+      clauseWithParams2.params.size shouldBe 1
 
       val clauseWithParams3 = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\""),
         permissionSpec = FilterSpec("            ")
       )
 
-      clauseWithParams3.clause shouldEqual "WHERE side = 'Sell'"
-      clauseWithParams3.params.isEmpty shouldBe true
+      clauseWithParams3.clause shouldEqual "side = {p_0:String}"
+      clauseWithParams3.params.size shouldBe 1
     }
 
     Scenario("Permission filter cannot be parsed") {
@@ -264,7 +264,7 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
         permissionSpec = FilterSpec("DROP TABLES;")
       )
 
-      clauseWithParams.clause shouldEqual "WHERE 1 = 0"
+      clauseWithParams.clause shouldEqual "1 = 0"
       clauseWithParams.params.isEmpty shouldBe true
     }
 

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterFactoryTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterFactoryTest.scala
@@ -25,117 +25,117 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec(""),
         permissionSpec = FilterSpec("")
       )
 
-      whereClause shouldEqual ""
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual ""
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("Empty user filter, non empty permission filter") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec(""),
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      whereClause shouldEqual "WHERE side = 'Buy'"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE side = 'Buy'"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("Empty user filter, composite permission filter") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec(""),
         permissionSpec = FilterSpec("side = \"Buy\" and quantity > 0")
       )
 
-      whereClause shouldEqual "WHERE (side = 'Buy' AND quantity > 0)"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE (side = 'Buy' AND quantity > 0)"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("Non empty user filter, empty permission filter") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\""),
         permissionSpec = FilterSpec("")
       )
 
-      whereClause shouldEqual "WHERE side = 'Sell'"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE side = 'Sell'"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("Non empty user filter, non empty permission filter") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\""),
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      whereClause shouldEqual "WHERE (side = 'Buy' AND side = 'Sell')"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE (side = 'Buy' AND side = 'Sell')"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("Non empty user filter, composite permission filter") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\""),
         permissionSpec = FilterSpec("side = \"Buy\" and quantity > 0")
       )
 
-      whereClause shouldEqual "WHERE ((side = 'Buy' AND quantity > 0) AND side = 'Sell')"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE ((side = 'Buy' AND quantity > 0) AND side = 'Sell')"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("Composite user filter, empty permission filter") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\" and quantity > 100"),
         permissionSpec = FilterSpec("")
       )
 
-      whereClause shouldEqual "WHERE (side = 'Sell' AND quantity > 100)"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE (side = 'Sell' AND quantity > 100)"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("Composite user filter, non empty permission filter") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\" and quantity > 100"),
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      whereClause shouldEqual "WHERE (side = 'Buy' AND (side = 'Sell' AND quantity > 100))"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE (side = 'Buy' AND (side = 'Sell' AND quantity > 100))"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("Composite user filter, composite permission filter") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\" and quantity > 100"),
         permissionSpec = FilterSpec("side = \"Buy\" and quantity > 0")
       )
 
-      whereClause shouldEqual "WHERE ((side = 'Buy' AND quantity > 0) AND (side = 'Sell' AND quantity > 100))"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE ((side = 'Buy' AND quantity > 0) AND (side = 'Sell' AND quantity > 100))"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
   }
@@ -146,126 +146,126 @@ class ClickHouseFilterFactoryTest extends AnyFeatureSpec with Matchers {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = null,
         permissionSpec = null
       )
 
-      whereClause shouldEqual ""
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual ""
+      clauseWithParams.params.isEmpty shouldBe true
 
-      val (whereClause2, params2) = filterFactory.build(
+      val clauseWithParams2 = filterFactory.build(
         userSpec = FilterSpec(null),
         permissionSpec = FilterSpec(null)
       )
 
-      whereClause2 shouldEqual ""
-      params2.isEmpty shouldBe true
+      clauseWithParams2.clause shouldEqual ""
+      clauseWithParams2.params.isEmpty shouldBe true
 
-      val (whereClause3, params3) = filterFactory.build(
+      val clauseWithParams3 = filterFactory.build(
         userSpec = FilterSpec("            "),
         permissionSpec = FilterSpec("            ")
       )
 
-      whereClause3 shouldEqual ""
-      params3.isEmpty shouldBe true
+      clauseWithParams3.clause shouldEqual ""
+      clauseWithParams3.params.isEmpty shouldBe true
     }
 
     Scenario("Both filter specs cannot be parsed") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec("DROP TABLES;"),
         permissionSpec = FilterSpec("DROP COLUMN;")
       )
 
-      whereClause shouldEqual "WHERE 1 = 0"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE 1 = 0"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("User filter spec is null or blank") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = null,
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      whereClause shouldEqual "WHERE side = 'Buy'"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE side = 'Buy'"
+      clauseWithParams.params.isEmpty shouldBe true
 
-      val (whereClause2, params2) = filterFactory.build(
+      val clauseWithParams2 = filterFactory.build(
         userSpec = FilterSpec(null),
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      whereClause2 shouldEqual "WHERE side = 'Buy'"
-      params2.isEmpty shouldBe true
+      clauseWithParams2.clause shouldEqual "WHERE side = 'Buy'"
+      clauseWithParams2.params.isEmpty shouldBe true
 
-      val (whereClause3, params3) = filterFactory.build(
+      val clauseWithParams3 = filterFactory.build(
         userSpec = FilterSpec("            "),
         permissionSpec = FilterSpec("side = \"Buy\"")
       )
 
-      whereClause3 shouldEqual "WHERE side = 'Buy'"
-      params3.isEmpty shouldBe true
+      clauseWithParams3.clause shouldEqual "WHERE side = 'Buy'"
+      clauseWithParams3.params.isEmpty shouldBe true
     }
 
     Scenario("User filter cannot be parsed") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec("DROP TABLES;"),
         permissionSpec = FilterSpec("")
       )
 
-      whereClause shouldEqual "WHERE 1 = 0"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE 1 = 0"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
     Scenario("Permission filter spec is null or blank") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\""),
         permissionSpec = null
       )
 
-      whereClause shouldEqual "WHERE side = 'Sell'"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE side = 'Sell'"
+      clauseWithParams.params.isEmpty shouldBe true
 
-      val (whereClause2, params2) = filterFactory.build(
+      val clauseWithParams2 = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\""),
         permissionSpec = FilterSpec(null)
       )
 
-      whereClause2 shouldEqual "WHERE side = 'Sell'"
-      params2.isEmpty shouldBe true
+      clauseWithParams2.clause shouldEqual "WHERE side = 'Sell'"
+      clauseWithParams2.params.isEmpty shouldBe true
 
-      val (whereClause3, params3) = filterFactory.build(
+      val clauseWithParams3 = filterFactory.build(
         userSpec = FilterSpec("side = \"Sell\""),
         permissionSpec = FilterSpec("            ")
       )
 
-      whereClause3 shouldEqual "WHERE side = 'Sell'"
-      params3.isEmpty shouldBe true
+      clauseWithParams3.clause shouldEqual "WHERE side = 'Sell'"
+      clauseWithParams3.params.isEmpty shouldBe true
     }
 
     Scenario("Permission filter cannot be parsed") {
 
       val filterFactory = ClickHouseFilterFactory(tableDef)
 
-      val (whereClause, params) = filterFactory.build(
+      val clauseWithParams = filterFactory.build(
         userSpec = FilterSpec(""),
         permissionSpec = FilterSpec("DROP TABLES;")
       )
 
-      whereClause shouldEqual "WHERE 1 = 0"
-      params.isEmpty shouldBe true
+      clauseWithParams.clause shouldEqual "WHERE 1 = 0"
+      clauseWithParams.params.isEmpty shouldBe true
     }
 
   }

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
@@ -330,12 +330,310 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
 
   }
 
-    //    Scenario("Magnitude comparisons") {
-    //      compile("price > 123.45") shouldBe "price > 123.45"
-    //      compile("price >= 100") shouldBe "price >= 100"
-    //      compile("price < 50.5") shouldBe "price < 50.5"
-    //      compile("price <= 50") shouldBe "price <= 50"
-    //    }
+  Feature("Less than test cases") {
+
+    Scenario("Int less than comparison") {
+      val expected = ("int_c < {p_0:Int32}", Map("p_0" -> 1))
+
+      val result = compile("intColumn < 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("Double less than comparison") {
+      val expected = ("double_c < {p_0:Float64}", Map("p_0" -> 1.01))
+
+      val result = compile("doubleColumn < 1.01")
+
+      result shouldBe expected
+    }
+
+    Scenario("Long less than comparison") {
+      val expected = ("long_c < {p_0:Int64}", Map("p_0" -> 100L))
+
+      val result = compile("longColumn < 100")
+
+      result shouldBe expected
+    }
+
+    Scenario("Epoch less than comparison") {
+      val expected = ("epoch_c < {p_0:DateTime64}", Map("p_0" -> ofEpochMilli(1L)))
+
+      val result = compile("epochColumn < 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("EpochNano less than comparison") {
+      val expected = ("epoch_nano_c < {p_0:DateTime64}", Map("p_0" -> ofEpochNanosecond(1L)))
+
+      val result = compile("epochNanoColumn < 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal2 less than comparison") {
+      val expected = ("sd2_c < {p_0:Int64}", Map("p_0" -> 101L))
+
+      val result = compile("sd2Column < 1.01")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal4 less than comparison") {
+      val expected = ("sd4_c < {p_0:Int64}", Map("p_0" -> 10001L))
+
+      val result = compile("sd4Column < 1.0001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal6 less than comparison") {
+      val expected = ("sd6_c < {p_0:Int64}", Map("p_0" -> 1000001L))
+
+      val result = compile("sd6Column < 1.000001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal8 less than comparison") {
+      val expected = ("sd8_c < {p_0:Int64}", Map("p_0" -> 100000001L))
+
+      val result = compile("sd8Column < 1.00000001")
+
+      result shouldBe expected
+    }
+
+  }
+
+  Feature("Less than or equal test cases") {
+
+    Scenario("Int less than or equal comparison") {
+      val expected = ("int_c <= {p_0:Int32}", Map("p_0" -> 1))
+
+      val result = compile("intColumn <= 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("Double less than or equal comparison") {
+      val expected = ("double_c <= {p_0:Float64}", Map("p_0" -> 1.01))
+
+      val result = compile("doubleColumn <= 1.01")
+
+      result shouldBe expected
+    }
+
+    Scenario("Long less than or equal comparison") {
+      val expected = ("long_c <= {p_0:Int64}", Map("p_0" -> 100L))
+
+      val result = compile("longColumn <= 100")
+
+      result shouldBe expected
+    }
+
+    Scenario("Epoch less than or equal comparison") {
+      val expected = ("epoch_c <= {p_0:DateTime64}", Map("p_0" -> ofEpochMilli(1L)))
+
+      val result = compile("epochColumn <= 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("EpochNano less than or equal comparison") {
+      val expected = ("epoch_nano_c <= {p_0:DateTime64}", Map("p_0" -> ofEpochNanosecond(1L)))
+
+      val result = compile("epochNanoColumn <= 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal2 less than or equal comparison") {
+      val expected = ("sd2_c <= {p_0:Int64}", Map("p_0" -> 101L))
+
+      val result = compile("sd2Column <= 1.01")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal4 less than or equal comparison") {
+      val expected = ("sd4_c <= {p_0:Int64}", Map("p_0" -> 10001L))
+
+      val result = compile("sd4Column <= 1.0001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal6 less than or equal comparison") {
+      val expected = ("sd6_c <= {p_0:Int64}", Map("p_0" -> 1000001L))
+
+      val result = compile("sd6Column <= 1.000001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal8 less than or equal comparison") {
+      val expected = ("sd8_c <= {p_0:Int64}", Map("p_0" -> 100000001L))
+
+      val result = compile("sd8Column <= 1.00000001")
+
+      result shouldBe expected
+    }
+
+  }
+
+  Feature("Greater than test cases") {
+
+    Scenario("Int greater than comparison") {
+      val expected = ("int_c > {p_0:Int32}", Map("p_0" -> 1))
+
+      val result = compile("intColumn > 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("Double greater than comparison") {
+      val expected = ("double_c > {p_0:Float64}", Map("p_0" -> 1.01))
+
+      val result = compile("doubleColumn > 1.01")
+
+      result shouldBe expected
+    }
+
+    Scenario("Long greater than comparison") {
+      val expected = ("long_c > {p_0:Int64}", Map("p_0" -> 100L))
+
+      val result = compile("longColumn > 100")
+
+      result shouldBe expected
+    }
+
+    Scenario("Epoch greater than comparison") {
+      val expected = ("epoch_c > {p_0:DateTime64}", Map("p_0" -> ofEpochMilli(1L)))
+
+      val result = compile("epochColumn > 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("EpochNano greater than comparison") {
+      val expected = ("epoch_nano_c > {p_0:DateTime64}", Map("p_0" -> ofEpochNanosecond(1L)))
+
+      val result = compile("epochNanoColumn > 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal2 greater than comparison") {
+      val expected = ("sd2_c > {p_0:Int64}", Map("p_0" -> 101L))
+
+      val result = compile("sd2Column > 1.01")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal4 greater than comparison") {
+      val expected = ("sd4_c > {p_0:Int64}", Map("p_0" -> 10001L))
+
+      val result = compile("sd4Column > 1.0001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal6 greater than comparison") {
+      val expected = ("sd6_c > {p_0:Int64}", Map("p_0" -> 1000001L))
+
+      val result = compile("sd6Column > 1.000001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal8 greater than comparison") {
+      val expected = ("sd8_c > {p_0:Int64}", Map("p_0" -> 100000001L))
+
+      val result = compile("sd8Column > 1.00000001")
+
+      result shouldBe expected
+    }
+
+  }
+
+  Feature("Greater than or equal test cases") {
+
+    Scenario("Int greater than or equal comparison") {
+      val expected = ("int_c >= {p_0:Int32}", Map("p_0" -> 1))
+
+      val result = compile("intColumn >= 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("Double greater than or equal comparison") {
+      val expected = ("double_c >= {p_0:Float64}", Map("p_0" -> 1.01))
+
+      val result = compile("doubleColumn >= 1.01")
+
+      result shouldBe expected
+    }
+
+    Scenario("Long greater than or equal comparison") {
+      val expected = ("long_c >= {p_0:Int64}", Map("p_0" -> 100L))
+
+      val result = compile("longColumn >= 100")
+
+      result shouldBe expected
+    }
+
+    Scenario("Epoch greater than or equal comparison") {
+      val expected = ("epoch_c >= {p_0:DateTime64}", Map("p_0" -> ofEpochMilli(1L)))
+
+      val result = compile("epochColumn >= 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("EpochNano greater than or equal comparison") {
+      val expected = ("epoch_nano_c >= {p_0:DateTime64}", Map("p_0" -> ofEpochNanosecond(1L)))
+
+      val result = compile("epochNanoColumn >= 1")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal2 greater than or equal comparison") {
+      val expected = ("sd2_c >= {p_0:Int64}", Map("p_0" -> 101L))
+
+      val result = compile("sd2Column >= 1.01")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal4 greater than or equal comparison") {
+      val expected = ("sd4_c >= {p_0:Int64}", Map("p_0" -> 10001L))
+
+      val result = compile("sd4Column >= 1.0001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal6 greater than or equal comparison") {
+      val expected = ("sd6_c >= {p_0:Int64}", Map("p_0" -> 1000001L))
+
+      val result = compile("sd6Column >= 1.000001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal8 greater than or equal comparison") {
+      val expected = ("sd8_c >= {p_0:Int64}", Map("p_0" -> 100000001L))
+
+      val result = compile("sd8Column >= 1.00000001")
+
+      result shouldBe expected
+    }
+
+  }
+
     //
     //    Scenario("String match operators") {
     //      compile("ric starts \"AAPL\"") shouldBe "ric LIKE 'AAPL%'"

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
@@ -74,6 +74,10 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
       val result = compile("intColumn = 100")
 
       result shouldBe expected
+
+      val result2 = compile("intColumn = \"100\"")
+
+      result2 shouldBe expected
     }
 
     Scenario("Long equality comparison") {
@@ -82,6 +86,10 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
       val result = compile("longColumn = 100")
 
       result shouldBe expected
+
+      val result2 = compile("longColumn = \"100\"")
+
+      result2 shouldBe expected
     }
 
     Scenario("Double equality comparison") {
@@ -90,6 +98,10 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
       val result = compile("doubleColumn = 100.1")
 
       result shouldBe expected
+
+      val result2 = compile("doubleColumn = \"100.1\"")
+
+      result2 shouldBe expected
     }
 
     Scenario("Boolean equality comparison") {
@@ -98,22 +110,34 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
       val result = compile("booleanColumn = true")
 
       result shouldBe expected
+
+      val result2 = compile("booleanColumn = \"true\"")
+
+      result2 shouldBe expected
     }
 
     Scenario("EpochTimestamp equality comparison") {
       val expected = ("epoch_c = {p_0:DateTime64}", Map("p_0" -> ofEpochMilli(1L)))
 
-      val result = compile("epochColumn = \"1\"")
+      val result = compile("epochColumn = 1")
 
       result shouldBe expected
+
+      val result2 = compile("epochColumn = \"1\"")
+
+      result2 shouldBe expected
     }
 
     Scenario("EpochTimestampNano equality comparison") {
       val expected = ("epoch_nano_c = {p_0:DateTime64}", Map("p_0" -> ofEpochNanosecond(1L)))
 
-      val result = compile("epochNanoColumn = \"1\"")
+      val result = compile("epochNanoColumn = 1")
 
       result shouldBe expected
+
+      val result2 = compile("epochNanoColumn = \"1\"")
+
+      result2 shouldBe expected
     }
 
     Scenario("ScaledDecimal2 equality comparison") {
@@ -122,6 +146,10 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
       val result = compile("sd2Column = 1.01")
 
       result shouldBe expected
+
+      val result2 = compile("sd2Column = \"1.01\"")
+
+      result2 shouldBe expected
     }
 
     Scenario("ScaledDecimal4 equality comparison") {
@@ -130,6 +158,10 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
       val result = compile("sd4Column = 1.0001")
 
       result shouldBe expected
+
+      val result2 = compile("sd4Column = \"1.0001\"")
+
+      result2 shouldBe expected
     }
 
     Scenario("ScaledDecimal6 equality comparison") {
@@ -138,6 +170,10 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
       val result = compile("sd6Column = 1.000001")
 
       result shouldBe expected
+
+      val result2 = compile("sd6Column = \"1.000001\"")
+
+      result2 shouldBe expected
     }
 
     Scenario("ScaledDecimal8 equality comparison") {
@@ -146,8 +182,153 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
       val result = compile("sd8Column = 1.00000001")
 
       result shouldBe expected
+
+      val result2 = compile("sd8Column = \"1.00000001\"")
+
+      result2 shouldBe expected
     }
 
+  }
+
+  Feature("Inequality test cases") {
+
+    Scenario("String inequality comparison") {
+      val expected = ("string_c != {p_0:String}", Map("p_0" -> "rahúl"))
+
+      val result = compile("stringColumn != \"rahúl\"")
+
+      result shouldBe expected
+    }
+
+    Scenario("Char inequality comparison") {
+      val expected = ("char_c != {p_0:String}", Map("p_0" -> "r"))
+
+      val result = compile("charColumn != \"r\"")
+
+      result shouldBe expected
+    }
+
+    Scenario("Int inequality comparison") {
+      val expected = ("int_c != {p_0:Int32}", Map("p_0" -> 100))
+
+      val result = compile("intColumn != 100")
+
+      result shouldBe expected
+
+      val result2 = compile("intColumn != \"100\"")
+
+      result2 shouldBe expected
+    }
+
+    Scenario("Long inequality comparison") {
+      val expected = ("long_c != {p_0:Int64}", Map("p_0" -> 100L))
+
+      val result = compile("longColumn != 100")
+
+      result shouldBe expected
+
+      val result2 = compile("longColumn != \"100\"")
+
+      result2 shouldBe expected
+    }
+
+    Scenario("Double inequality comparison") {
+      val expected = ("double_c != {p_0:Float64}", Map("p_0" -> 100.1))
+
+      val result = compile("doubleColumn != 100.1")
+
+      result shouldBe expected
+
+      val result2 = compile("doubleColumn != \"100.1\"")
+
+      result2 shouldBe expected
+    }
+
+    Scenario("Boolean inequality comparison") {
+      val expected = ("boolean_c != {p_0:Bool}", Map("p_0" -> true))
+
+      val result = compile("booleanColumn != true")
+
+      result shouldBe expected
+
+      val result2 = compile("booleanColumn != \"true\"")
+
+      result2 shouldBe expected
+    }
+
+    Scenario("EpochTimestamp inequality comparison") {
+      val expected = ("epoch_c != {p_0:DateTime64}", Map("p_0" -> ofEpochMilli(1L)))
+
+      val result = compile("epochColumn != 1")
+
+      result shouldBe expected
+
+      val result2 = compile("epochColumn != \"1\"")
+
+      result2 shouldBe expected
+    }
+
+    Scenario("EpochTimestampNano inequality comparison") {
+      val expected = ("epoch_nano_c != {p_0:DateTime64}", Map("p_0" -> ofEpochNanosecond(1L)))
+
+      val result = compile("epochNanoColumn != 1")
+
+      result shouldBe expected
+
+      val result2 = compile("epochNanoColumn != \"1\"")
+
+      result2 shouldBe expected
+    }
+
+    Scenario("ScaledDecimal2 equality comparison") {
+      val expected = ("sd2_c != {p_0:Int64}", Map("p_0" -> 101L))
+
+      val result = compile("sd2Column != 1.01")
+
+      result shouldBe expected
+
+      val result2 = compile("sd2Column != \"1.01\"")
+
+      result2 shouldBe expected
+    }
+
+    Scenario("ScaledDecimal4 inequality comparison") {
+      val expected = ("sd4_c != {p_0:Int64}", Map("p_0" -> 10001L))
+
+      val result = compile("sd4Column != 1.0001")
+
+      result shouldBe expected
+
+      val result2 = compile("sd4Column != \"1.0001\"")
+
+      result2 shouldBe expected
+    }
+
+    Scenario("ScaledDecimal6 inequality comparison") {
+      val expected = ("sd6_c != {p_0:Int64}", Map("p_0" -> 1000001L))
+
+      val result = compile("sd6Column != 1.000001")
+
+      result shouldBe expected
+
+      val result2 = compile("sd6Column != \"1.000001\"")
+
+      result2 shouldBe expected
+    }
+
+    Scenario("ScaledDecimal8 inequality comparison") {
+      val expected = ("sd8_c != {p_0:Int64}", Map("p_0" -> 100000001L))
+
+      val result = compile("sd8Column != 1.00000001")
+
+      result shouldBe expected
+
+      val result2 = compile("sd8Column != \"1.00000001\"")
+
+      result2 shouldBe expected
+    }
+
+  }
 
     //    Scenario("Magnitude comparisons") {
     //      compile("price > 123.45") shouldBe "price > 123.45"
@@ -175,5 +356,5 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
     //    }
     //
 
-  }
+
 }

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
@@ -27,56 +27,56 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
     FilterSpecParser.parse(filterStr, clickHouseFilterVisitor)
     (stringBuilder.toString, params)
   }
-
-  Feature("ClickHouseFilterVisitor compiles filter expressions to SQL clauses") {
-
-    Scenario("Invalid column name throws an exception") {
-      var exception: IllegalArgumentException = null
-
-      exception = intercept[IllegalArgumentException] {
-        compile("lolcats = \"Fluffy\"")
-      }
-
-      exception.getMessage should include("Mapping missing for filter column: 'lolcats'")
-    }
-
-    Scenario("Equality comparisons") {
-      compile("trader = \"rahúl\"") shouldBe "trader = 'rahúl'"
-      compile("quantity = 100") shouldBe "quantity = 100"
-      compile("onMkt = true") shouldBe "on_mkt = true"
-      compile("onMkt = false") shouldBe "on_mkt = false"
-      compile("trader != \"steve\"") shouldBe "trader != 'steve'"
-      compile("quantity != 100") shouldBe "quantity != 100"
-    }
-
-    Scenario("String escapes") {
-      compile("trader = \"O'Reilly\"") shouldBe "trader = 'O''Reilly'"
-    }
-
-    Scenario("Magnitude comparisons") {
-      compile("price > 123.45") shouldBe "price > 123.45"
-      compile("price >= 100") shouldBe "price >= 100"
-      compile("price < 50.5") shouldBe "price < 50.5"
-      compile("price <= 50") shouldBe "price <= 50"
-    }
-
-    Scenario("String match operators") {
-      compile("ric starts \"AAPL\"") shouldBe "ric LIKE 'AAPL%'"
-      compile("ric ends \"L\"") shouldBe "ric LIKE '%L'"
-      compile("ric contains \"OD\"") shouldBe "ric LIKE '%OD%'"
-    }
-
-    Scenario("In set operations") {
-      compile("ric in [\"AAPL.L\", \"BT.L\"]") shouldBe "ric IN ('AAPL.L', 'BT.L')"
-      compile("quantity in [10, 20, 30]") shouldBe "quantity IN (10, 20, 30)"
-      compile("ric in []") shouldBe "1 = 0"
-    }
-
-    Scenario("Composite logical operators") {
-      compile("ric = \"AAPL.L\" and quantity > 100") shouldBe "(ric = 'AAPL.L' AND quantity > 100)"
-      compile("ric = \"AAPL.L\" or quantity > 100") shouldBe "(ric = 'AAPL.L' OR quantity > 100)"
-      compile("(ric = \"AAPL.L\" or ric = \"BT.L\") and quantity > 100") shouldBe "((ric = 'AAPL.L' OR ric = 'BT.L') AND quantity > 100)"
-    }
-
-  }
+//
+//  Feature("ClickHouseFilterVisitor compiles filter expressions to SQL clauses") {
+//
+//    Scenario("Invalid column name throws an exception") {
+//      var exception: IllegalArgumentException = null
+//
+//      exception = intercept[IllegalArgumentException] {
+//        compile("lolcats = \"Fluffy\"")
+//      }
+//
+//      exception.getMessage should include("Mapping missing for filter column: 'lolcats'")
+//    }
+//
+//    Scenario("Equality comparisons") {
+//      compile("trader = \"rahúl\"") shouldBe "trader = 'rahúl'"
+//      compile("quantity = 100") shouldBe "quantity = 100"
+//      compile("onMkt = true") shouldBe "on_mkt = true"
+//      compile("onMkt = false") shouldBe "on_mkt = false"
+//      compile("trader != \"steve\"") shouldBe "trader != 'steve'"
+//      compile("quantity != 100") shouldBe "quantity != 100"
+//    }
+//
+//    Scenario("String escapes") {
+//      compile("trader = \"O'Reilly\"") shouldBe "trader = 'O''Reilly'"
+//    }
+//
+//    Scenario("Magnitude comparisons") {
+//      compile("price > 123.45") shouldBe "price > 123.45"
+//      compile("price >= 100") shouldBe "price >= 100"
+//      compile("price < 50.5") shouldBe "price < 50.5"
+//      compile("price <= 50") shouldBe "price <= 50"
+//    }
+//
+//    Scenario("String match operators") {
+//      compile("ric starts \"AAPL\"") shouldBe "ric LIKE 'AAPL%'"
+//      compile("ric ends \"L\"") shouldBe "ric LIKE '%L'"
+//      compile("ric contains \"OD\"") shouldBe "ric LIKE '%OD%'"
+//    }
+//
+//    Scenario("In set operations") {
+//      compile("ric in [\"AAPL.L\", \"BT.L\"]") shouldBe "ric IN ('AAPL.L', 'BT.L')"
+//      compile("quantity in [10, 20, 30]") shouldBe "quantity IN (10, 20, 30)"
+//      compile("ric in []") shouldBe "1 = 0"
+//    }
+//
+//    Scenario("Composite logical operators") {
+//      compile("ric = \"AAPL.L\" and quantity > 100") shouldBe "(ric = 'AAPL.L' AND quantity > 100)"
+//      compile("ric = \"AAPL.L\" or quantity > 100") shouldBe "(ric = 'AAPL.L' OR quantity > 100)"
+//      compile("(ric = \"AAPL.L\" or ric = \"BT.L\") and quantity > 100") shouldBe "((ric = 'AAPL.L' OR ric = 'BT.L') AND quantity > 100)"
+//    }
+//
+//  }
 }

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
@@ -718,7 +718,7 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
     Scenario("EpochTimestamp In") {
       val expected = (
         "epoch_c IN {p_0:Array(DateTime64)}",
-        Map("p_0" -> java.util.List.of[String]("'1970-01-01 00:00:00.001000000'", "'1970-01-01 00:00:00.002000000'"))
+        Map("p_0" -> java.util.List.of[String]("'1970-01-01 00:00:00.001'", "'1970-01-01 00:00:00.002'"))
       )
 
       val result = compile("epochColumn in [1, 2]")

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
@@ -6,6 +6,7 @@ import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumnBuilder
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.time.Instant
 import java.time.Instant.ofEpochMilli
 import scala.collection.mutable
 
@@ -634,25 +635,198 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
 
   }
 
-    //
-    //    Scenario("String match operators") {
-    //      compile("ric starts \"AAPL\"") shouldBe "ric LIKE 'AAPL%'"
-    //      compile("ric ends \"L\"") shouldBe "ric LIKE '%L'"
-    //      compile("ric contains \"OD\"") shouldBe "ric LIKE '%OD%'"
-    //    }
-    //
-    //    Scenario("In set operations") {
-    //      compile("ric in [\"AAPL.L\", \"BT.L\"]") shouldBe "ric IN ('AAPL.L', 'BT.L')"
-    //      compile("quantity in [10, 20, 30]") shouldBe "quantity IN (10, 20, 30)"
-    //      compile("ric in []") shouldBe "1 = 0"
-    //    }
-    //
-    //    Scenario("Composite logical operators") {
-    //      compile("ric = \"AAPL.L\" and quantity > 100") shouldBe "(ric = 'AAPL.L' AND quantity > 100)"
-    //      compile("ric = \"AAPL.L\" or quantity > 100") shouldBe "(ric = 'AAPL.L' OR quantity > 100)"
-    //      compile("(ric = \"AAPL.L\" or ric = \"BT.L\") and quantity > 100") shouldBe "((ric = 'AAPL.L' OR ric = 'BT.L') AND quantity > 100)"
-    //    }
-    //
+  Feature("String operators") {
 
+    Scenario("Starts with") {
+      val expected = ("startsWith(string_c, {p_0:String})", Map("p_0" -> "rahúl"))
+
+      val result = compile("stringColumn starts \"rahúl\"")
+
+      result shouldBe expected
+    }
+
+    Scenario("Ends with") {
+      val expected = ("endsWith(string_c, {p_0:String})", Map("p_0" -> "rahúl"))
+
+      val result = compile("stringColumn ends \"rahúl\"")
+
+      result shouldBe expected
+    }
+
+    Scenario("Contains") {
+      val expected = ("string_c LIKE {p_0:String}", Map("p_0" -> "%rahúl%"))
+
+      val result = compile("stringColumn contains \"rahúl\"")
+
+      result shouldBe expected
+    }
+
+  }
+
+  Feature("In test cases") {
+
+    Scenario("String In") {
+      val expected = ("string_c IN {p_0:Array(String)}", Map("p_0" -> java.util.List.of("'rahúl'", "'manuel'")))
+
+      val result = compile("stringColumn in [\"rahúl\", \"manuel\"]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("Int In") {
+      val expected = ("int_c IN {p_0:Array(Int32)}", Map("p_0" -> java.util.List.of[Integer](1, 2)))
+
+      val result = compile("intColumn in [1, 2]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("Double In") {
+      val expected = ("double_c IN {p_0:Array(Float64)}", Map("p_0" -> java.util.List.of[Double](1.01, 2.02)))
+
+      val result = compile("doubleColumn in [1.01, 2.02]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("Long In") {
+      val expected = ("long_c IN {p_0:Array(Int64)}", Map("p_0" -> java.util.List.of[Long](101L, 202L)))
+
+      val result = compile("longColumn in [101, 202]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("Char In") {
+      val expected = ("char_c IN {p_0:Array(String)}", Map("p_0" -> java.util.List.of("'t'", "'f'")))
+
+      val result = compile("charColumn in [\"t\", \"f\"]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("EpochTimestamp In") {
+      val expected = (
+        "epoch_c IN {p_0:Array(DateTime64)}",
+        Map("p_0" -> java.util.List.of[String]("'1970-01-01 00:00:00.001000000'", "'1970-01-01 00:00:00.002000000'"))
+      )
+
+      val result = compile("epochColumn in [1, 2]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("EpochTimestampNano In") {
+      val expected = (
+        "epoch_nano_c IN {p_0:Array(DateTime64)}",
+        Map("p_0" -> java.util.List.of[String]("'1970-01-01 00:00:00.000000001'", "'1970-01-01 00:00:00.000000002'"))
+      )
+
+      val result = compile("epochNanoColumn in [1, 2]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("ScaledDecimal2 In") {
+      val expected = (
+        "sd2_c IN {p_0:Array(Int64)}",
+        Map("p_0" -> java.util.List.of[Long](101L, 202L))
+      )
+
+      val result = compile("sd2Column in [1.01, 2.02]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("ScaledDecimal4 In") {
+      val expected = (
+        "sd4_c IN {p_0:Array(Int64)}",
+        Map("p_0" -> java.util.List.of[Long](10100L, 20200L))
+      )
+
+      val result = compile("sd4Column in [1.01, 2.02]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("ScaledDecimal6 In") {
+      val expected = (
+        "sd6_c IN {p_0:Array(Int64)}",
+        Map("p_0" -> java.util.List.of[Long](1010000L, 2020000L))
+      )
+
+      val result = compile("sd6Column in [1.01, 2.02]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+    Scenario("ScaledDecimal8 In") {
+      val expected = (
+        "sd8_c IN {p_0:Array(Int64)}",
+        Map("p_0" -> java.util.List.of[Long](101000000L, 202000000L))
+      )
+
+      val result = compile("sd8Column in [1.01, 2.02]")
+
+      result._1 shouldBe expected._1
+      result._2.head._1 shouldEqual expected._2.head._1
+      result._2.head._2 shouldEqual expected._2.head._2
+    }
+
+  }
+
+  Feature("Composite operators") {
+
+    Scenario("And") {
+      val expected = ("(string_c = {p_0:String} AND int_c = {p_1:Int32})",
+        Map("p_0" -> "rahúl", "p_1" -> 5)
+      )
+
+      val result = compile("stringColumn = \"rahúl\" and intColumn = 5")
+
+      result shouldBe expected
+    }
+
+    Scenario("Or") {
+      val expected = ("(string_c = {p_0:String} OR int_c = {p_1:Int32})",
+        Map("p_0" -> "rahúl", "p_1" -> 5)
+      )
+
+      val result = compile("stringColumn = \"rahúl\" or intColumn = 5")
+
+      result shouldBe expected
+    }
+
+    Scenario("Nested") {
+      val expected = ("(string_c = {p_0:String} OR (int_c = {p_1:Int32} AND long_c = {p_2:Int64}))",
+        Map("p_0" -> "rahúl", "p_1" -> 5, "p_2" -> 100L)
+      )
+
+      val result = compile("stringColumn = \"rahúl\" or (intColumn = 5 and longColumn = 100)")
+
+      result shouldBe expected
+    }
+
+  }
 
 }

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
@@ -5,6 +5,8 @@ import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumnBuilder
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.collection.mutable
+
 class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
 
   private val remoteNameMapping = VirtualizedSessionTableColumnBuilder()
@@ -18,10 +20,12 @@ class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
     .map(f => f.name -> f.remoteName)
     .toMap
 
-  private def compile(filterStr: String): String = {
-    val clickHouseFilterVisitor = new ClickHouseFilterVisitor(remoteNameMapping)
+  private def compile(filterStr: String): (String, mutable.HashMap[String, Any]) = {
+    val stringBuilder = new java.lang.StringBuilder(256)
+    val params = new mutable.HashMap[String, Any]()
+    val clickHouseFilterVisitor = ClickHouseFilterVisitor(remoteNameMapping, stringBuilder, params)
     FilterSpecParser.parse(filterStr, clickHouseFilterVisitor)
-    clickHouseFilterVisitor.getBuffer.toString
+    (stringBuilder.toString, params)
   }
 
   Feature("ClickHouseFilterVisitor compiles filter expressions to SQL clauses") {

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/filter/ClickHouseFilterVisitorTest.scala
@@ -1,82 +1,179 @@
 package org.finos.vuu.plugin.clickhouse.provider.filter
 
+import org.finos.toolbox.time.TimeUtils.ofEpochNanosecond
 import org.finos.vuu.core.filter.FilterSpecParser
 import org.finos.vuu.plugin.virtualized.api.VirtualizedSessionTableColumnBuilder
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.time.Instant.ofEpochMilli
 import scala.collection.mutable
 
 class ClickHouseFilterVisitorTest extends AnyFeatureSpec with Matchers {
 
-  private val remoteNameMapping = VirtualizedSessionTableColumnBuilder()
-    .addString("orderId", "order_id")
-    .addString("ric")
-    .addString("trader")
-    .addInt("quantity")
-    .addBoolean("onMkt", "on_mkt")
-    .addDouble("price")
+  private val remoteColumns = VirtualizedSessionTableColumnBuilder()
+    .addString("stringColumn", "string_c")
+    .addChar("charColumn", "char_c")
+    .addInt("intColumn", "int_c")
+    .addLong("longColumn", "long_c")
+    .addDouble("doubleColumn", "double_c")
+    .addBoolean("booleanColumn", "boolean_c")
+    .addScaledDecimal2("sd2Column", "sd2_c")
+    .addScaledDecimal4("sd4Column", "sd4_c")
+    .addScaledDecimal6("sd6Column", "sd6_c")
+    .addScaledDecimal8("sd8Column", "sd8_c")
+    .addEpochTimestamp("epochColumn", "epoch_c")
+    .addEpochTimestampNano("epochNanoColumn", "epoch_nano_c")
     .build()
-    .map(f => f.name -> f.remoteName)
+    .map(f => f.name -> f)
     .toMap
 
   private def compile(filterStr: String): (String, mutable.HashMap[String, Any]) = {
     val stringBuilder = new java.lang.StringBuilder(256)
     val params = new mutable.HashMap[String, Any]()
-    val clickHouseFilterVisitor = ClickHouseFilterVisitor(remoteNameMapping, stringBuilder, params)
+    val clickHouseFilterVisitor = ClickHouseFilterVisitor(remoteColumns, stringBuilder, params)
     FilterSpecParser.parse(filterStr, clickHouseFilterVisitor)
     (stringBuilder.toString, params)
   }
-//
-//  Feature("ClickHouseFilterVisitor compiles filter expressions to SQL clauses") {
-//
-//    Scenario("Invalid column name throws an exception") {
-//      var exception: IllegalArgumentException = null
-//
-//      exception = intercept[IllegalArgumentException] {
-//        compile("lolcats = \"Fluffy\"")
-//      }
-//
-//      exception.getMessage should include("Mapping missing for filter column: 'lolcats'")
-//    }
-//
-//    Scenario("Equality comparisons") {
-//      compile("trader = \"rahúl\"") shouldBe "trader = 'rahúl'"
-//      compile("quantity = 100") shouldBe "quantity = 100"
-//      compile("onMkt = true") shouldBe "on_mkt = true"
-//      compile("onMkt = false") shouldBe "on_mkt = false"
-//      compile("trader != \"steve\"") shouldBe "trader != 'steve'"
-//      compile("quantity != 100") shouldBe "quantity != 100"
-//    }
-//
-//    Scenario("String escapes") {
-//      compile("trader = \"O'Reilly\"") shouldBe "trader = 'O''Reilly'"
-//    }
-//
-//    Scenario("Magnitude comparisons") {
-//      compile("price > 123.45") shouldBe "price > 123.45"
-//      compile("price >= 100") shouldBe "price >= 100"
-//      compile("price < 50.5") shouldBe "price < 50.5"
-//      compile("price <= 50") shouldBe "price <= 50"
-//    }
-//
-//    Scenario("String match operators") {
-//      compile("ric starts \"AAPL\"") shouldBe "ric LIKE 'AAPL%'"
-//      compile("ric ends \"L\"") shouldBe "ric LIKE '%L'"
-//      compile("ric contains \"OD\"") shouldBe "ric LIKE '%OD%'"
-//    }
-//
-//    Scenario("In set operations") {
-//      compile("ric in [\"AAPL.L\", \"BT.L\"]") shouldBe "ric IN ('AAPL.L', 'BT.L')"
-//      compile("quantity in [10, 20, 30]") shouldBe "quantity IN (10, 20, 30)"
-//      compile("ric in []") shouldBe "1 = 0"
-//    }
-//
-//    Scenario("Composite logical operators") {
-//      compile("ric = \"AAPL.L\" and quantity > 100") shouldBe "(ric = 'AAPL.L' AND quantity > 100)"
-//      compile("ric = \"AAPL.L\" or quantity > 100") shouldBe "(ric = 'AAPL.L' OR quantity > 100)"
-//      compile("(ric = \"AAPL.L\" or ric = \"BT.L\") and quantity > 100") shouldBe "((ric = 'AAPL.L' OR ric = 'BT.L') AND quantity > 100)"
-//    }
-//
-//  }
+
+  Feature("Edge cases") {
+
+    Scenario("Invalid column name throws an exception") {
+      var exception: IllegalArgumentException = null
+
+      exception = intercept[IllegalArgumentException] {
+        compile("lolcats = \"Fluffy\"")
+      }
+
+      exception.getMessage should include("Mapping missing for filter column: 'lolcats'")
+    }
+
+  }
+
+  Feature("Equality test cases") {
+
+    Scenario("String equality comparison") {
+      val expected = ("string_c = {p_0:String}", Map("p_0" -> "rahúl"))
+
+      val result = compile("stringColumn = \"rahúl\"")
+
+      result shouldBe expected
+    }
+
+    Scenario("Char equality comparison") {
+      val expected = ("char_c = {p_0:String}", Map("p_0" -> "r"))
+
+      val result = compile("charColumn = \"r\"")
+
+      result shouldBe expected
+    }
+
+    Scenario("Int equality comparison") {
+      val expected = ("int_c = {p_0:Int32}", Map("p_0" -> 100))
+
+      val result = compile("intColumn = 100")
+
+      result shouldBe expected
+    }
+
+    Scenario("Long equality comparison") {
+      val expected = ("long_c = {p_0:Int64}", Map("p_0" -> 100L))
+
+      val result = compile("longColumn = 100")
+
+      result shouldBe expected
+    }
+
+    Scenario("Double equality comparison") {
+      val expected = ("double_c = {p_0:Float64}", Map("p_0" -> 100.1))
+
+      val result = compile("doubleColumn = 100.1")
+
+      result shouldBe expected
+    }
+
+    Scenario("Boolean equality comparison") {
+      val expected = ("boolean_c = {p_0:Bool}", Map("p_0" -> true))
+
+      val result = compile("booleanColumn = true")
+
+      result shouldBe expected
+    }
+
+    Scenario("EpochTimestamp equality comparison") {
+      val expected = ("epoch_c = {p_0:DateTime64}", Map("p_0" -> ofEpochMilli(1L)))
+
+      val result = compile("epochColumn = \"1\"")
+
+      result shouldBe expected
+    }
+
+    Scenario("EpochTimestampNano equality comparison") {
+      val expected = ("epoch_nano_c = {p_0:DateTime64}", Map("p_0" -> ofEpochNanosecond(1L)))
+
+      val result = compile("epochNanoColumn = \"1\"")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal2 equality comparison") {
+      val expected = ("sd2_c = {p_0:Int64}", Map("p_0" -> 101L))
+
+      val result = compile("sd2Column = 1.01")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal4 equality comparison") {
+      val expected = ("sd4_c = {p_0:Int64}", Map("p_0" -> 10001L))
+
+      val result = compile("sd4Column = 1.0001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal6 equality comparison") {
+      val expected = ("sd6_c = {p_0:Int64}", Map("p_0" -> 1000001L))
+
+      val result = compile("sd6Column = 1.000001")
+
+      result shouldBe expected
+    }
+
+    Scenario("ScaledDecimal8 equality comparison") {
+      val expected = ("sd8_c = {p_0:Int64}", Map("p_0" -> 100000001L))
+
+      val result = compile("sd8Column = 1.00000001")
+
+      result shouldBe expected
+    }
+
+
+    //    Scenario("Magnitude comparisons") {
+    //      compile("price > 123.45") shouldBe "price > 123.45"
+    //      compile("price >= 100") shouldBe "price >= 100"
+    //      compile("price < 50.5") shouldBe "price < 50.5"
+    //      compile("price <= 50") shouldBe "price <= 50"
+    //    }
+    //
+    //    Scenario("String match operators") {
+    //      compile("ric starts \"AAPL\"") shouldBe "ric LIKE 'AAPL%'"
+    //      compile("ric ends \"L\"") shouldBe "ric LIKE '%L'"
+    //      compile("ric contains \"OD\"") shouldBe "ric LIKE '%OD%'"
+    //    }
+    //
+    //    Scenario("In set operations") {
+    //      compile("ric in [\"AAPL.L\", \"BT.L\"]") shouldBe "ric IN ('AAPL.L', 'BT.L')"
+    //      compile("quantity in [10, 20, 30]") shouldBe "quantity IN (10, 20, 30)"
+    //      compile("ric in []") shouldBe "1 = 0"
+    //    }
+    //
+    //    Scenario("Composite logical operators") {
+    //      compile("ric = \"AAPL.L\" and quantity > 100") shouldBe "(ric = 'AAPL.L' AND quantity > 100)"
+    //      compile("ric = \"AAPL.L\" or quantity > 100") shouldBe "(ric = 'AAPL.L' OR quantity > 100)"
+    //      compile("(ric = \"AAPL.L\" or ric = \"BT.L\") and quantity > 100") shouldBe "((ric = 'AAPL.L' OR ric = 'BT.L') AND quantity > 100)"
+    //    }
+    //
+
+  }
 }

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/sort/ClickHouseSortFactoryTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/provider/sort/ClickHouseSortFactoryTest.scala
@@ -34,7 +34,7 @@ class ClickHouseSortFactoryTest extends AnyFeatureSpec with GivenWhenThen with M
       val nullResult = clickHouseSortFactory.build(nullSpec)
 
       Then("it should return the keyField")
-      nullResult shouldBe "ORDER BY order_id ASC"
+      nullResult shouldBe "order_id ASC"
 
       And("given an empty SortSpec object with no definitions")
       val emptySpec = SortSpec(List.empty)
@@ -43,7 +43,7 @@ class ClickHouseSortFactoryTest extends AnyFeatureSpec with GivenWhenThen with M
       val emptyResult = clickHouseSortFactory.build(emptySpec)
 
       Then("it should return the keyField")
-      emptyResult shouldBe "ORDER BY order_id ASC"
+      emptyResult shouldBe "order_id ASC"
     }
 
     Scenario("Generating a single column ascending sort") {
@@ -58,7 +58,7 @@ class ClickHouseSortFactoryTest extends AnyFeatureSpec with GivenWhenThen with M
       val result = clickHouseSortFactory.build(spec)
 
       Then("it should format a valid single-column + key field ORDER BY clause")
-      result shouldBe "ORDER BY quantity ASC, order_id ASC"
+      result shouldBe "quantity ASC, order_id ASC"
     }
 
     Scenario("Generating a single column sort with an alias") {
@@ -73,7 +73,7 @@ class ClickHouseSortFactoryTest extends AnyFeatureSpec with GivenWhenThen with M
       val result = clickHouseSortFactory.build(spec)
 
       Then("it should format a valid single-column ORDER BY clause using the remote name")
-      result shouldBe "ORDER BY order_id DESC"
+      result shouldBe "order_id DESC"
     }
 
     Scenario("Generating a single column sort with an invalid column") {
@@ -88,7 +88,7 @@ class ClickHouseSortFactoryTest extends AnyFeatureSpec with GivenWhenThen with M
       val result = clickHouseSortFactory.build(spec)
 
       Then("it should return primary key sort as the mapping is missing")
-      result shouldBe "ORDER BY order_id ASC"
+      result shouldBe "order_id ASC"
     }
 
     Scenario("Generating a multi-column mixed direction sort") {
@@ -104,7 +104,7 @@ class ClickHouseSortFactoryTest extends AnyFeatureSpec with GivenWhenThen with M
       val result = clickHouseSortFactory.build(spec)
 
       Then("it should chain the columns separated by commas with matching keywords")
-      result shouldBe "ORDER BY price DESC, counterparty ASC, order_id ASC"
+      result shouldBe "price DESC, counterparty ASC, order_id ASC"
     }
 
   }

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/util/ClickHouseOrderCreator.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/util/ClickHouseOrderCreator.scala
@@ -31,7 +31,8 @@ object ClickHouseOrderCreator extends StrictLogging {
           |  quantity Int32,
           |  price Int64,
           |  side String,
-          |  trader String
+          |  trader String,
+          |  time DateTime64(9, 'UTC')
           |) ENGINE = MergeTree() ORDER BY order_id
           |""".stripMargin
       ),
@@ -48,11 +49,15 @@ object ClickHouseOrderCreator extends StrictLogging {
     val bos = new java.io.BufferedOutputStream(fos, 8 * 1024 * 1024) // 8MB buffer
     val writer = new java.io.BufferedWriter(new java.io.OutputStreamWriter(bos, "UTF-8"))
     try {
+      val now = java.time.Instant.now()
+        .toString
+        .replace("T", " ")
+        .replace("Z", "")
+
       var currentId = 1
       while (currentId <= totalCount) {
-        val now = System.currentTimeMillis().toString
         val side = if (currentId % 2 == 0) "Buy" else "Sell"
-        val price = currentId * 10L
+        val price = currentId * 10_000_000L
         val quantity = currentId
         writer.write(currentId.toString)
         writer.write(',')
@@ -63,6 +68,8 @@ object ClickHouseOrderCreator extends StrictLogging {
         writer.write(side)
         writer.write(",trader-")
         writer.write(currentId.toString)
+        writer.write(',')
+        writer.write(now)
         writer.write(System.lineSeparator())
         currentId += 1
       }
@@ -75,7 +82,7 @@ object ClickHouseOrderCreator extends StrictLogging {
     try {
       ClickHouseHttpUtil.executeUpdate(
         container = container,
-        query = "INSERT INTO order_history (order_id, quantity, price, side, trader) FORMAT CSV",
+        query = "INSERT INTO order_history (order_id, quantity, price, side, trader, time) FORMAT CSV",
         bodyPublisher = BodyPublishers.ofFile(tempFile),
         contentType = "text/csv"
       )

--- a/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/wsapi/ClickHouseWSApiTest.scala
+++ b/plugin/clickhouse-plugin/src/test/scala/org/finos/vuu/plugin/clickhouse/wsapi/ClickHouseWSApiTest.scala
@@ -38,8 +38,8 @@ class ClickHouseWSApiTest extends WebSocketApiTestBase with ForAllTestContainer 
       val response = vuuClient.awaitForResponse(requestId)
 
       val responseBody = assertBodyIsInstanceOf[GetTableMetaResponse](response)
-      responseBody.columns.length shouldEqual 5
-      responseBody.columns shouldEqual Array("orderId", "quantity", "price", "side", "trader")
+      responseBody.columns.length shouldEqual 6
+      responseBody.columns shouldEqual Array("orderId", "quantity", "price", "side", "trader", "time")
       responseBody.editableColumns shouldEqual Array[String]()
       responseBody.maxRangeEnd shouldEqual 1_000_000
       responseBody.maxRangeWidth shouldEqual 1_000

--- a/plugin/virtualized-table-plugin/pom.xml
+++ b/plugin/virtualized-table-plugin/pom.xml
@@ -173,6 +173,39 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check-coverage</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.69</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/plugin/virtualized-table-plugin/src/main/scala/org/finos/vuu/plugin/virtualized/api/VirtualizedSessionTableDef.scala
+++ b/plugin/virtualized-table-plugin/src/main/scala/org/finos/vuu/plugin/virtualized/api/VirtualizedSessionTableDef.scala
@@ -16,7 +16,7 @@ abstract class VirtualizedSessionTableDef(
                                          )
   extends SessionTableDef(name, keyField, remoteColumns.map(f => f.asInstanceOf[Column]), options) {
 
-  private val remoteMapping : Map[String, String] = remoteColumns.map(f => f.name -> f.remoteName).toMap
+  private val remoteMapping : Map[String, VirtualizedSessionTableColumn] = remoteColumns.map(f => f.name -> f).toMap
 
   override def pluginType: PluginType = VirtualizedTablePluginType
 
@@ -28,7 +28,7 @@ abstract class VirtualizedSessionTableDef(
 
   def getRemotePermissionFilterSpecFunction: ViewPort => FilterSpec = remotePermissionFilterSpecFunction
 
-  def getRemoteColumnMapping: Map[String, String] = remoteMapping
+  def getRemoteColumnMapping: Map[String, VirtualizedSessionTableColumn] = remoteMapping
 
 }
 

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -212,7 +212,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.46</minimum>
+                                            <minimum>0.55</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/toolbox/src/main/scala/org/finos/toolbox/time/TimeUtils.scala
+++ b/toolbox/src/main/scala/org/finos/toolbox/time/TimeUtils.scala
@@ -1,0 +1,15 @@
+package org.finos.toolbox.time
+
+import java.time.{Duration, Instant}
+
+object TimeUtils {
+
+  private val NANOS_PER_SECOND = Duration.ofSeconds(1).toNanos
+
+  def ofEpochNanosecond(epochNanosecond: Long): Instant = {
+    val seconds = epochNanosecond / NANOS_PER_SECOND
+    val nanos = epochNanosecond % NANOS_PER_SECOND
+    Instant.ofEpochSecond(seconds, nanos)
+  }
+
+}

--- a/toolbox/src/test/scala/org/finos/toolbox/time/TimeUtilsTest.scala
+++ b/toolbox/src/test/scala/org/finos/toolbox/time/TimeUtilsTest.scala
@@ -1,0 +1,20 @@
+package org.finos.toolbox.time
+
+import org.finos.toolbox.time.TimeUtils.ofEpochNanosecond
+import org.scalatest.GivenWhenThen
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+
+class TimeUtilsTest extends AnyFeatureSpec with Matchers with GivenWhenThen {
+
+  Feature("Test epoch nano conversion") {
+
+    Scenario("Long to Instant") {
+      val result = ofEpochNanosecond(1_000_000)
+
+      result shouldEqual java.time.Instant.ofEpochMilli(1)
+    }
+
+  }
+
+}

--- a/vuu-java/pom.xml
+++ b/vuu-java/pom.xml
@@ -124,7 +124,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.76</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/vuu/pom.xml
+++ b/vuu/pom.xml
@@ -338,7 +338,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                     </limits>
                                 </rule>


### PR DESCRIPTION
Prevent SQL injection by moving from string concatenation to parameterised queries.

Also:
* Fixed a bug with typeahead where we weren't applying the users current filter before querying for distinct values.
* Fixed querying on ScaledDecimal and EpochTimestamp data types which weren't previously working.
* Reviewed our Jacoco code coverage levels.