### PR TITLE
Make Vuu use custom maven property names to avoid clashing with SpringBoot plugin.

### DIFF
--- a/example/basket/pom.xml
+++ b/example/basket/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
@@ -48,14 +48,14 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/editable/pom.xml
+++ b/example/editable/pom.xml
@@ -21,13 +21,13 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/http2-server/pom.xml
+++ b/example/http2-server/pom.xml
@@ -21,39 +21,39 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vuu.vertx.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vuu.vertx.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vuu.vertx.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_3</artifactId>
-            <version>${scalamock.version}</version>
+            <version>${vuu.scalamock.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/main-clickhouse/pom.xml
+++ b/example/main-clickhouse/pom.xml
@@ -42,37 +42,37 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>${typesafe.conf.version}</version>
+            <version>${vuu.typesafe.conf.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
+            <version>${vuu.testcontainers.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala-scalatest_3</artifactId>
-            <version>${testcontainers.scalatest.version}</version>
+            <version>${vuu.testcontainers.scalatest.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/main-java/pom.xml
+++ b/example/main-java/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
         </dependency>
 
         <dependency>
@@ -60,14 +60,14 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${vuu.junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/main/pom.xml
+++ b/example/main/pom.xml
@@ -70,19 +70,19 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/notifications/pom.xml
+++ b/example/notifications/pom.xml
@@ -29,20 +29,20 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/order/pom.xml
+++ b/example/order/pom.xml
@@ -33,13 +33,13 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/permission/pom.xml
+++ b/example/permission/pom.xml
@@ -27,13 +27,13 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -49,14 +49,14 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
-            <version>${vertx.version}</version>
+            <version>${vuu.vertx.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -13,9 +13,9 @@
     <name>${project.artifactId}</name>
 
     <properties>
-        <sttp.client4.version>4.0.26</sttp.client4.version>
-        <typesafe.conf.version>1.4.9</typesafe.conf.version>
-        <vertx.version>5.1.6</vertx.version>
+        <vuu.sttp.client4.version>4.0.26</vuu.sttp.client4.version>
+        <vuu.typesafe.conf.version>1.4.9</vuu.typesafe.conf.version>
+        <vuu.vertx.version>5.1.6</vuu.vertx.version>
     </properties>
 
     <modules>

--- a/example/price/pom.xml
+++ b/example/price/pom.xml
@@ -21,13 +21,13 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/rest-api/pom.xml
+++ b/example/rest-api/pom.xml
@@ -21,19 +21,19 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>${typesafe.conf.version}</version>
+            <version>${vuu.typesafe.conf.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.softwaremill.sttp.client4</groupId>
             <artifactId>core_3</artifactId>
-            <version>${sttp.client4.version}</version>
+            <version>${vuu.sttp.client4.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.scala-lang</groupId>
@@ -45,14 +45,14 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_3</artifactId>
-            <version>${scalamock.version}</version>
+            <version>${vuu.scalamock.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/example/virtualized-table/pom.xml
+++ b/example/virtualized-table/pom.xml
@@ -26,13 +26,13 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/plugin/clickhouse-plugin/pom.xml
+++ b/plugin/clickhouse-plugin/pom.xml
@@ -27,13 +27,13 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>client-v2</artifactId>
-            <version>${clickhouse.client.version}</version>
+            <version>${vuu.clickhouse.client.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.roaringbitmap</groupId>
@@ -45,28 +45,28 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
+            <version>${vuu.testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala-scalatest_3</artifactId>
-            <version>${testcontainers.scalatest.version}</version>
+            <version>${vuu.testcontainers.scalatest.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_3</artifactId>
-            <version>${scalamock.version}</version>
+            <version>${vuu.scalamock.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -14,8 +14,8 @@
     <name>${project.artifactId}</name>
 
     <properties>
-        <caffeine.version>3.2.4</caffeine.version>
-        <clickhouse.client.version>0.9.8</clickhouse.client.version>
+        <vuu.caffeine.version>3.2.4</vuu.caffeine.version>
+        <vuu.clickhouse.client.version>0.9.8</vuu.clickhouse.client.version>
     </properties>
 
     <modules>

--- a/plugin/virtualized-table-plugin/pom.xml
+++ b/plugin/virtualized-table-plugin/pom.xml
@@ -20,19 +20,19 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>${caffeine.version}</version>
+            <version>${vuu.caffeine.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_3</artifactId>
-            <version>${scalamock.version}</version>
+            <version>${vuu.scalamock.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -42,21 +42,21 @@
         <publish.server.id>ossrh</publish.server.id>
 
         <!-- Dependencies -->
-        <antlr.version>4.13.2</antlr.version>
-        <assertj.version>3.27.7</assertj.version>
-        <jackson.version>3.1.5</jackson.version>
-        <junit.jupiter.version>6.1.2</junit.jupiter.version>
-        <logback.version>1.6.1</logback.version>
-        <metrics.version>4.2.39</metrics.version>
-        <netty.version>4.2.17.Final</netty.version>
-        <roaring.bitmap.version>1.6.14</roaring.bitmap.version>
-        <scala.version>3.3.8</scala.version> <!-- Scala LTS -->
-        <scala.logging.version>3.9.6</scala.logging.version>
-        <scalamock.version>7.5.5</scalamock.version>
-        <scalatest.version>3.2.20</scalatest.version>
-        <slf4j.version>2.0.18</slf4j.version>
-        <testcontainers.version>2.0.5</testcontainers.version>
-        <testcontainers.scalatest.version>0.44.1</testcontainers.scalatest.version>
+        <vuu.antlr.version>4.13.2</vuu.antlr.version>
+        <vuu.assertj.version>3.27.7</vuu.assertj.version>
+        <vuu.jackson.version>3.1.5</vuu.jackson.version>
+        <vuu.junit.jupiter.version>6.1.2</vuu.junit.jupiter.version>
+        <vuu.logback.version>1.6.1</vuu.logback.version>
+        <vuu.metrics.version>4.2.39</vuu.metrics.version>
+        <vuu.netty.version>4.2.17.Final</vuu.netty.version>
+        <vuu.roaring.bitmap.version>1.6.14</vuu.roaring.bitmap.version>
+        <vuu.scala.version>3.3.8</vuu.scala.version> <!-- Scala LTS -->
+        <vuu.scala.logging.version>3.9.6</vuu.scala.logging.version>
+        <vuu.scalamock.version>7.5.5</vuu.scalamock.version>
+        <vuu.scalatest.version>3.2.20</vuu.scalatest.version>
+        <vuu.slf4j.version>2.0.18</vuu.slf4j.version>
+        <vuu.testcontainers.version>2.0.5</vuu.testcontainers.version>
+        <vuu.testcontainers.scalatest.version>0.44.1</vuu.testcontainers.scalatest.version>
     </properties>
 
     <modules>
@@ -111,7 +111,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
+                <version>${vuu.netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -119,7 +119,7 @@
             <dependency>
                 <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
+                <version>${vuu.jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -127,7 +127,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-bom</artifactId>
-                <version>${slf4j.version}</version>
+                <version>${vuu.slf4j.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/toolbox/pom.xml
+++ b/toolbox/pom.xml
@@ -17,13 +17,13 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
             <artifactId>scala-logging_3</artifactId>
-            <version>${scala.logging.version}</version>
+            <version>${vuu.scala.logging.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.scala-lang</groupId>
@@ -35,32 +35,32 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>${metrics.version}</version>
+            <version>${vuu.metrics.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jmx</artifactId>
-            <version>${metrics.version}</version>
+            <version>${vuu.metrics.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>${roaring.bitmap.version}</version>
+            <version>${vuu.roaring.bitmap.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/vuu-java/pom.xml
+++ b/vuu-java/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -36,14 +36,14 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${vuu.junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
+            <version>${vuu.assertj.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/vuu-ui/pom.xml
+++ b/vuu-ui/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>${junit.jupiter.version}</version>
+        <version>${vuu.junit.jupiter.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/vuu/pom.xml
+++ b/vuu/pom.xml
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
+                <version>${vuu.jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -35,13 +35,13 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala3-library_3</artifactId>
-            <version>${scala.version}</version>
+            <version>${vuu.scala.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
             <artifactId>scala-logging_3</artifactId>
-            <version>${scala.logging.version}</version>
+            <version>${vuu.scala.logging.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.scala-lang</groupId>
@@ -125,20 +125,20 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>${antlr.version}</version>
+            <version>${vuu.antlr.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
+            <version>${vuu.logback.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_3</artifactId>
-            <version>${scalatest.version}</version>
+            <version>${vuu.scalatest.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_3</artifactId>
-            <version>${scalamock.version}</version>
+            <version>${vuu.scalamock.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -276,7 +276,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>${antlr.version}</version>
+                <version>${vuu.antlr.version}</version>
                 <configuration>
                     <visitor>true</visitor>
                     <listener>false</listener>


### PR DESCRIPTION
We currently clash with SpringBoot, which leads to some third party dependencies being silently downgraded or upgraded.

