### PR TITLE
2231 add more config for edit mode

### DIFF
--- a/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
+++ b/vuu/src/main/scala/org/finos/vuu/core/VuuServerOptions.scala
@@ -50,7 +50,7 @@ object VuuJoinTableProviderOptions {
 
 object VuuRpcOptions {
   def apply(): VuuRpcOptions = {
-    VuuRpcOptionsImpl.apply(maxCopySize = 10_000)
+    VuuRpcOptionsImpl.apply(maxSessionTableSize = 10_000)
   }
 }
 
@@ -117,9 +117,9 @@ trait VuuJoinTableProviderOptions {
 }
 
 trait VuuRpcOptions {
-  def maxCopySize: Int
+  def maxSessionTableSize: Int
 
-  def withMaxCopySize(maxCopySize: Int): VuuRpcOptions
+  def withMaxSessionTableSize(maxSessionTableSize: Int): VuuRpcOptions
 }
 
 private case class VuuWebSocketOptionsImpl(wsPort: Int,
@@ -176,8 +176,8 @@ case class VuuJoinProviderOptionsImpl(batchSize: Int, maxQueueSize: Int) extends
   override def withMaxQueueDepth(maxQueueSize: Int): VuuJoinTableProviderOptions = this.copy(maxQueueSize = maxQueueSize)
 }
 
-case class VuuRpcOptionsImpl(maxCopySize: Int) extends VuuRpcOptions {
-  override def withMaxCopySize(maxCopySize: Int): VuuRpcOptions = this.copy(maxCopySize = maxCopySize)
+case class VuuRpcOptionsImpl(maxSessionTableSize: Int) extends VuuRpcOptions {
+  override def withMaxSessionTableSize(maxSessionTableSize: Int): VuuRpcOptions = this.copy(maxSessionTableSize = maxSessionTableSize)
 }
 
 case class VuuSecurityOptionsImpl(loginTokenService: LoginTokenService) extends VuuSecurityOptions {

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -8,6 +8,8 @@ import org.finos.vuu.net.rpc.SessionTableCopyOption.{All, Empty, Selected}
 trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, tableContainer: TableContainer) extends RpcHandler {
   registerRpc(RpcNames.CreateSessionTableRpc, this.createSessionTable)
 
+  // todo add new boolean isImport  - true - use "import-" + source table name
+  // add vuuAction to default
   def createSessionTable(params: RpcParams): RpcFunctionResult = {
     val vuuUser: VuuUser = params.ctx.user
     if (!rpcPermissionChecker.isRpcAllowed(RpcNames.CreateSessionTableRpc, vuuUser)) {
@@ -31,7 +33,10 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
     }
     val sessionTableName = params.namedParams.get("sessionTableName") match {
       case Some(value) => value.asInstanceOf[String]
-      case None => s"edit-${sourceTable.name}"
+      case None => params.namedParams.get("isImport") match {
+        case Some(true) => s"import-${sourceTable.name}"
+        case _ => s"edit-${sourceTable.name}"
+      }
     }
 
     if (!sourceTable.asTable.getTableDef.options.isEditable) {

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -21,13 +21,19 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
       case Some("edit") => createSessionTableForEdit(params)
       case Some("import") => createSessionTableForImport(params)
       case Some("export") => createSessionTableForExport(params)
-      case _ => new RpcFunctionFailure("sessionType undefined")
+      case _ => new RpcFunctionFailure("Session type undefined")
     } // TODO 2231 add tests for sessionType, e.g. edit, import, export
   }
 
   def createSessionTableForEdit(params: RpcParams): RpcFunctionResult = {
     val session: ClientSessionId = params.ctx.session
     val sourceTable = params.viewPort.table
+
+    if (!sourceTable.asTable.getTableDef.options.isEditable) {
+      logger.warn(s"Table ${sourceTable.name} is not editable")
+      return new RpcFunctionFailure("Table not editable")
+    }
+
     val copyOption = SessionTableCopyOption.fromString(params.namedParams("copyOption").asInstanceOf[String])
     val sessionTableName = params.namedParams.get("sessionTableName") match {
       case Some(value) => value.asInstanceOf[String]
@@ -42,11 +48,6 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
           return new RpcFunctionFailure("Column(s) not found in source table.")
       }
 
-    if (!sourceTable.asTable.getTableDef.options.isEditable) {
-      logger.warn(s"Table ${sourceTable.name} is not editable")
-      return new RpcFunctionFailure("Table not editable")
-    }
-
     val sessionTableSource = tableContainer.getTable(sessionTableName)
     val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
     copyDataToSessionTable(copyOption, params.viewPort, sessionTable, columnsToCopy)
@@ -56,6 +57,12 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
   def createSessionTableForImport(params: RpcParams): RpcFunctionResult = {
     val session: ClientSessionId = params.ctx.session
     val sourceTable = params.viewPort.table
+
+    if (!sourceTable.asTable.getTableDef.options.isEditable) {
+      logger.warn(s"Table ${sourceTable.name} is not editable")
+      return new RpcFunctionFailure("Table not editable")
+    }
+
     val sessionTableName = params.namedParams.get("sessionTableName") match {
       case Some(value) => value.asInstanceOf[String]
       case None => s"import-${sourceTable.name}"
@@ -68,11 +75,6 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
         case _: IllegalArgumentException =>
           return new RpcFunctionFailure("Column(s) not found in source table.")
       }
-
-    if (!sourceTable.asTable.getTableDef.options.isEditable) {
-      logger.warn(s"Table ${sourceTable.name} is not editable")
-      return new RpcFunctionFailure("Table not editable")
-    }
 
     val sessionTableSource = tableContainer.getTable(sessionTableName)
     val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -35,8 +35,8 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
         case Some("edit") => s"edit-${sourceTable.name}"
         case Some("import") => s"import-${sourceTable.name}"
         case Some("export") => s"export-${sourceTable.name}"
-        case _ => s"edit-${sourceTable.name}"
-      }
+        case _ => return new RpcFunctionFailure("sessionType undefined")
+      }// TODO 2231 add tests for sessionType
     }
 
     if (!sourceTable.asTable.getTableDef.options.isEditable) {

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -33,8 +33,10 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
     }
     val sessionTableName = params.namedParams.get("sessionTableName") match {
       case Some(value) => value.asInstanceOf[String]
-      case None => params.namedParams.get("isImport") match {
-        case Some(true) => s"import-${sourceTable.name}"
+      case None => params.namedParams.get("sessionType") match {
+        case Some("edit") => s"edit-${sourceTable.name}"
+        case Some("import") => s"import-${sourceTable.name}"
+        case Some("export") => s"export-${sourceTable.name}"
         case _ => s"edit-${sourceTable.name}"
       }
     }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -22,7 +22,7 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
       case Some("import") => createSessionTableForImport(params)
       case Some("export") => createSessionTableForExport(params)
       case _ => new RpcFunctionFailure("Session type undefined")
-    } // TODO 2231 add tests for sessionType, e.g. edit, import, export
+    }
   }
 
   def createSessionTableForEdit(params: RpcParams): RpcFunctionResult = {

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -8,8 +8,6 @@ import org.finos.vuu.net.rpc.SessionTableCopyOption.{All, Empty, Selected}
 trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, tableContainer: TableContainer) extends RpcHandler {
   registerRpc(RpcNames.CreateSessionTableRpc, this.createSessionTable)
 
-  // todo add new boolean isImport  - true - use "import-" + source table name
-  // add vuuAction to default
   def createSessionTable(params: RpcParams): RpcFunctionResult = {
     val vuuUser: VuuUser = params.ctx.user
     if (!rpcPermissionChecker.isRpcAllowed(RpcNames.CreateSessionTableRpc, vuuUser)) {

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -54,14 +54,14 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
       case All =>
         val vp = params.viewPort
         val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy)
-        val iterator = vp.getKeys.iterator.take(tableContainer.rpcOptions.maxCopySize)
+        val iterator = vp.getKeys.iterator.take(tableContainer.rpcOptions.maxSessionTableSize)
         while (iterator.hasNext) {
           sessionTable.processUpdate(vp.table.pullRow(iterator.next(), vpColumns))
         }
       case Selected =>
         val vp = params.viewPort
         val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy)
-        val iterator = vp.getSelection.iterator.take(tableContainer.rpcOptions.maxCopySize)
+        val iterator = vp.getSelection.iterator.take(tableContainer.rpcOptions.maxSessionTableSize)
         while (iterator.hasNext) {
           sessionTable.processUpdate(vp.table.pullRow(iterator.next(), vpColumns))
         }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -1,23 +1,126 @@
 package org.finos.vuu.net.rpc
 
 import org.finos.vuu.core.auths.VuuUser
-import org.finos.vuu.core.table.{TableContainer, ViewPortColumnCreator}
+import org.finos.vuu.core.table.{InMemSessionDataTable, TableContainer, ViewPortColumnCreator}
 import org.finos.vuu.net.ClientSessionId
 import org.finos.vuu.net.rpc.SessionTableCopyOption.{All, Empty, Selected}
+import org.finos.vuu.viewport.{RowSource, ViewPort}
 
 trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, tableContainer: TableContainer) extends RpcHandler {
   registerRpc(RpcNames.CreateSessionTableRpc, this.createSessionTable)
 
   def createSessionTable(params: RpcParams): RpcFunctionResult = {
     val vuuUser: VuuUser = params.ctx.user
+    // TODO 2231 handle different permission for edit/import/export
     if (!rpcPermissionChecker.isRpcAllowed(RpcNames.CreateSessionTableRpc, vuuUser)) {
       logger.warn(s"User ${vuuUser.name} does not have permission to call ${RpcNames.CreateSessionTableRpc}")
       return new RpcFunctionFailure("No permission to create session table.")
     }
 
+    params.namedParams.get("sessionType") match {
+      case Some("edit") => createSessionTableForEdit(params)
+      case Some("import") => createSessionTableForImport(params)
+      case Some("export") => createSessionTableForExport(params)
+      case _ => new RpcFunctionFailure("sessionType undefined")
+    } // TODO 2231 add tests for sessionType, e.g. edit, import, export
+  }
+
+  def createSessionTableForEdit(params: RpcParams): RpcFunctionResult = {
     val session: ClientSessionId = params.ctx.session
     val sourceTable = params.viewPort.table
     val copyOption = SessionTableCopyOption.fromString(params.namedParams("copyOption").asInstanceOf[String])
+    val sessionTableName = params.namedParams.get("sessionTableName") match {
+      case Some(value) => value.asInstanceOf[String]
+      case None => s"edit-${sourceTable.name}"
+    }
+
+    val columnsToCopy =
+      try {
+        getColumnsToCopy(params, sourceTable)
+      } catch {
+        case _: IllegalArgumentException =>
+          return new RpcFunctionFailure("Column(s) not found in source table.")
+      }
+
+    if (!sourceTable.asTable.getTableDef.options.isEditable) {
+      logger.warn(s"Table ${sourceTable.name} is not editable")
+      return new RpcFunctionFailure("Table not editable")
+    }
+
+    val sessionTableSource = tableContainer.getTable(sessionTableName)
+    val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
+    copyDataToSessionTable(copyOption, params.viewPort, sessionTable, columnsToCopy)
+    RpcFunctionSuccess(Some(Map("sessionTable" -> sessionTable.name, "module" -> sessionTable.tableDef.getModule().name)))
+  }
+
+  def createSessionTableForImport(params: RpcParams): RpcFunctionResult = {
+    val session: ClientSessionId = params.ctx.session
+    val sourceTable = params.viewPort.table
+    val sessionTableName = params.namedParams.get("sessionTableName") match {
+      case Some(value) => value.asInstanceOf[String]
+      case None => s"import-${sourceTable.name}"
+    }
+
+    val columnsToCopy =
+      try {
+        getColumnsToCopy(params, sourceTable)
+      } catch {
+        case _: IllegalArgumentException =>
+          return new RpcFunctionFailure("Column(s) not found in source table.")
+      }
+
+    if (!sourceTable.asTable.getTableDef.options.isEditable) {
+      logger.warn(s"Table ${sourceTable.name} is not editable")
+      return new RpcFunctionFailure("Table not editable")
+    }
+
+    val sessionTableSource = tableContainer.getTable(sessionTableName)
+    val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
+    copyDataToSessionTable(All, params.viewPort, sessionTable, columnsToCopy)
+    RpcFunctionSuccess(Some(Map("sessionTable" -> sessionTable.name, "module" -> sessionTable.tableDef.getModule().name)))
+  }
+
+  def createSessionTableForExport(params: RpcParams): RpcFunctionResult = {
+    val session: ClientSessionId = params.ctx.session
+    val sourceTable = params.viewPort.table
+    val sessionTableName = params.namedParams.get("sessionTableName") match {
+      case Some(value) => value.asInstanceOf[String]
+      case None => s"export-${sourceTable.name}"
+    }
+
+    val columnsToCopy =
+      try {
+        getColumnsToCopy(params, sourceTable)
+      } catch {
+        case _: IllegalArgumentException =>
+          return new RpcFunctionFailure("Column(s) not found in source table.")
+      }
+
+    val sessionTableSource = tableContainer.getTable(sessionTableName)
+    val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
+    copyDataToSessionTable(Empty, params.viewPort, sessionTable, columnsToCopy)
+    RpcFunctionSuccess(Some(Map("sessionTable" -> sessionTable.name, "module" -> sessionTable.tableDef.getModule().name)))
+  }
+
+  def copyDataToSessionTable(copyOption: SessionTableCopyOption, vp: ViewPort, sessionTable: InMemSessionDataTable, columns: List[String]): Unit = {
+    copyOption match {
+      case All =>
+        val vpColumns = ViewPortColumnCreator.create(vp.table.asTable, columns)
+        val iterator = vp.getKeys.iterator.take(tableContainer.rpcOptions.maxSessionTableSize)
+        while (iterator.hasNext) {
+          sessionTable.processUpdate(vp.table.pullRow(iterator.next(), vpColumns))
+        }
+      case Selected =>
+        val vpColumns = ViewPortColumnCreator.create(vp.table.asTable, columns)
+        val iterator = vp.getSelection.iterator.take(tableContainer.rpcOptions.maxSessionTableSize)
+        while (iterator.hasNext) {
+          sessionTable.processUpdate(vp.table.pullRow(iterator.next(), vpColumns))
+        }
+      case Empty =>
+    }
+  }
+
+  private def getColumnsToCopy(params: RpcParams, sourceTable: RowSource): List[String] = {
     val columnsToCopy = params.namedParams.get("columnsToCopy") match {
       case Some(value) =>
         val columnsToCopyStr = value.asInstanceOf[String]
@@ -29,20 +132,6 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
       case None =>
         sourceTable.asTable.getTableDef.customColumns.map(_.name).toList // exclude default columns
     }
-    val sessionTableName = params.namedParams.get("sessionTableName") match {
-      case Some(value) => value.asInstanceOf[String]
-      case None => params.namedParams.get("sessionType") match {
-        case Some("edit") => s"edit-${sourceTable.name}"
-        case Some("import") => s"import-${sourceTable.name}"
-        case Some("export") => s"export-${sourceTable.name}"
-        case _ => s"edit-${sourceTable.name}"
-      }
-    }
-
-    if (!sourceTable.asTable.getTableDef.options.isEditable) {
-      logger.warn(s"Table ${sourceTable.name} is not editable")
-      return new RpcFunctionFailure("Table not editable")
-    }
 
     val columnsInSource = sourceTable.asTable.columnsForNames(columnsToCopy)
       .filter(_ != null)
@@ -50,28 +139,9 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
     val columnsNotInSource = columnsToCopy.filterNot(columnsInSource.contains)
     if (columnsNotInSource.nonEmpty) {
       logger.warn(s"Column(s) [${columnsNotInSource.mkString(", ")}] not found in table ${sourceTable.name}")
-      return new RpcFunctionFailure("Column(s) not found in source table.")
+      throw new IllegalArgumentException("Column(s) not found in source table.")
     }
 
-    val sessionTableSource = tableContainer.getTable(sessionTableName)
-    val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
-    copyOption match {
-      case All =>
-        val vp = params.viewPort
-        val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy)
-        val iterator = vp.getKeys.iterator.take(tableContainer.rpcOptions.maxSessionTableSize)
-        while (iterator.hasNext) {
-          sessionTable.processUpdate(vp.table.pullRow(iterator.next(), vpColumns))
-        }
-      case Selected =>
-        val vp = params.viewPort
-        val vpColumns = ViewPortColumnCreator.create(params.viewPort.table.asTable, columnsToCopy)
-        val iterator = vp.getSelection.iterator.take(tableContainer.rpcOptions.maxSessionTableSize)
-        while (iterator.hasNext) {
-          sessionTable.processUpdate(vp.table.pullRow(iterator.next(), vpColumns))
-        }
-      case Empty =>
-    }
-    RpcFunctionSuccess(Some(Map("sessionTable" -> sessionTable.name, "module" -> sessionTable.tableDef.getModule().name)))
+    columnsToCopy
   }
 }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -78,7 +78,7 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
 
     val sessionTableSource = tableContainer.getTable(sessionTableName)
     val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
-    copyDataToSessionTable(All, params.viewPort, sessionTable, columnsToCopy)
+    copyDataToSessionTable(Empty, params.viewPort, sessionTable, columnsToCopy)
     RpcFunctionSuccess(Some(Map("sessionTable" -> sessionTable.name, "module" -> sessionTable.tableDef.getModule().name)))
   }
 
@@ -100,7 +100,7 @@ trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, t
 
     val sessionTableSource = tableContainer.getTable(sessionTableName)
     val sessionTable = tableContainer.createSimpleSessionTable(sessionTableSource, session)
-    copyDataToSessionTable(Empty, params.viewPort, sessionTable, columnsToCopy)
+    copyDataToSessionTable(All, params.viewPort, sessionTable, columnsToCopy)
     RpcFunctionSuccess(Some(Map("sessionTable" -> sessionTable.name, "module" -> sessionTable.tableDef.getModule().name)))
   }
 

--- a/vuu/src/test/scala/org/finos/vuu/core/filter/type/VisualLinkedFilterTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/core/filter/type/VisualLinkedFilterTest.scala
@@ -9,6 +9,7 @@ import org.finos.vuu.core.table.datatype.EpochTimestamp
 import org.finos.vuu.core.table.{DataType, SimpleColumn}
 import org.finos.vuu.feature.ViewPortKeys
 import org.finos.vuu.net.{ClientSessionId, FilterSpec, SortSpec}
+import org.finos.vuu.test.DummyViewPort
 import org.finos.vuu.util.PublishQueue
 import org.finos.vuu.viewport.*
 import org.finos.vuu.viewport.tree.TreeNodeState
@@ -87,110 +88,4 @@ class VisualLinkedFilterTest extends AnyFeatureSpec with Matchers {
       results.toSet shouldEqual Set("LDN-0001")
     }
   }
-
-  private class DummyViewPort(val id: String,
-                              val name: String,
-                              val selection: Set[String],
-                              val table: RowSource
-                             ) extends ViewPort {
-
-    override def updateSpecificKeys(keys: ImmutableArray[String]): Unit = ???
-
-    override def setRequestId(request: String): Unit = ???
-
-    override def getRequestId: String = ???
-
-    override def setEnabled(enabled: Boolean): Unit = ???
-
-    override def freeze(): Unit = ???
-
-    override def unfreeze(): Unit = ???
-
-    override def isEnabled: Boolean = ???
-
-    override def isFrozen: Boolean = ???
-
-    override def viewPortFrozenTime: Option[EpochTimestamp] = ???
-
-    override def size: Int = ???
-
-    override def filterAndSort: FilterAndSort = ???
-
-    override def user: VuuUser = ???
-
-    override def session: ClientSessionId = ???
-
-    override def setRange(range: ViewPortRange): Unit = ???
-
-    override def selectRow(rowKey: String, preserveExistingSelection: Boolean): Unit = ???
-
-    override def deselectRow(rowKey: String, preserveExistingSelection: Boolean): Unit = ???
-
-    override def selectRowRange(fromRowKey: String, toRowKey: String, preserveExistingSelection: Boolean): Unit = ???
-
-    override def selectAll(): Unit = ???
-
-    override def deselectAll(): Unit = ???
-
-    override def setVisualLink(link: ViewPortVisualLink): Unit = ???
-
-    override def removeVisualLink(): Unit = ???
-
-    override def getRange: ViewPortRange = ???
-
-    override def setKeys(keys: ViewPortKeys): Unit = ???
-
-    override def setKeysAndNotify(key: String, keys: ViewPortKeys): Unit = ???
-
-    override def getKeys: ViewPortKeys = ???
-
-    override def getKeysInRange: ViewPortKeys = ???
-
-    override def getVisualLink: Option[ViewPortVisualLink] = ???
-
-    override def outboundQ: PublishQueue[ViewPortUpdate] = ???
-
-    override def getColumns: ViewPortColumns = ???
-
-    override def getSelection: Set[String] = selection
-
-    override def getRowKeyMappingSize_ForTest: Int = ???
-
-    override def getGroupBy: GroupBy = ???
-
-    override def getSort: Sort = ???
-
-    override def filterSpec: FilterSpec = ???
-
-    override def sortSpec: SortSpec = ???
-
-    override def changeStructure(newStructuralFields: ViewPortStructuralFields): Unit = ???
-
-    override def getTreeNodeStateStore: TreeNodeState = ???
-
-    override def getStructure: ViewPortStructuralFields = ???
-
-    override def getStructuralHashCode(): Int = ???
-
-    override def getTableUpdateCount(): Long = ???
-
-    override def ForTest_getSubcribedKeys: util.Set[String] = ???
-
-    override def ForTest_getRowKeyToRowIndex: ConcurrentHashMap[String, Int] = ???
-
-    override def delete(): Unit = ???
-
-    override def keyBuildCount: Long = ???
-
-    override def setLastHashAndUpdateCount(lastHash: Int, lastUpdateCount: Long): Unit = ???
-
-    override def getLastHash(): Int = ???
-
-    override def getLastUpdateCount(): Long = ???
-
-    override def setPermissionFilter(filter: PermissionFilter): Unit = ???
-
-    override def getPermissionFilter: PermissionFilter = ???
-  }
-
 }

--- a/vuu/src/test/scala/org/finos/vuu/test/DummyViewPort.scala
+++ b/vuu/src/test/scala/org/finos/vuu/test/DummyViewPort.scala
@@ -1,0 +1,120 @@
+package org.finos.vuu.test
+
+import org.finos.toolbox.collection.array.ImmutableArray
+import org.finos.vuu.core.auths.VuuUser
+import org.finos.vuu.core.filter.`type`.PermissionFilter
+import org.finos.vuu.core.sort.{FilterAndSort, Sort}
+import org.finos.vuu.core.table.datatype.EpochTimestamp
+import org.finos.vuu.feature.ViewPortKeys
+import org.finos.vuu.net.{ClientSessionId, FilterSpec, SortSpec}
+import org.finos.vuu.util.PublishQueue
+import org.finos.vuu.viewport.{GroupBy, RowSource, ViewPort, ViewPortColumns, ViewPortRange, ViewPortStructuralFields, ViewPortUpdate, ViewPortVisualLink}
+import org.finos.vuu.viewport.tree.TreeNodeState
+
+import java.util
+import java.util.concurrent.ConcurrentHashMap
+
+class DummyViewPort(val id: String,
+                    val name: String,
+                    val selection: Set[String],
+                    val table: RowSource
+                   ) extends ViewPort {
+
+  override def updateSpecificKeys(keys: ImmutableArray[String]): Unit = ???
+
+  override def setRequestId(request: String): Unit = ???
+
+  override def getRequestId: String = ???
+
+  override def setEnabled(enabled: Boolean): Unit = ???
+
+  override def freeze(): Unit = ???
+
+  override def unfreeze(): Unit = ???
+
+  override def isEnabled: Boolean = ???
+
+  override def isFrozen: Boolean = ???
+
+  override def viewPortFrozenTime: Option[EpochTimestamp] = ???
+
+  override def size: Int = ???
+
+  override def filterAndSort: FilterAndSort = ???
+
+  override def user: VuuUser = ???
+
+  override def session: ClientSessionId = ???
+
+  override def setRange(range: ViewPortRange): Unit = ???
+
+  override def selectRow(rowKey: String, preserveExistingSelection: Boolean): Unit = ???
+
+  override def deselectRow(rowKey: String, preserveExistingSelection: Boolean): Unit = ???
+
+  override def selectRowRange(fromRowKey: String, toRowKey: String, preserveExistingSelection: Boolean): Unit = ???
+
+  override def selectAll(): Unit = ???
+
+  override def deselectAll(): Unit = ???
+
+  override def setVisualLink(link: ViewPortVisualLink): Unit = ???
+
+  override def removeVisualLink(): Unit = ???
+
+  override def getRange: ViewPortRange = ???
+
+  override def setKeys(keys: ViewPortKeys): Unit = ???
+
+  override def setKeysAndNotify(key: String, keys: ViewPortKeys): Unit = ???
+
+  override def getKeys: ViewPortKeys = ???
+
+  override def getKeysInRange: ViewPortKeys = ???
+
+  override def getVisualLink: Option[ViewPortVisualLink] = ???
+
+  override def outboundQ: PublishQueue[ViewPortUpdate] = ???
+
+  override def getColumns: ViewPortColumns = ???
+
+  override def getSelection: Set[String] = selection
+
+  override def getRowKeyMappingSize_ForTest: Int = ???
+
+  override def getGroupBy: GroupBy = ???
+
+  override def getSort: Sort = ???
+
+  override def filterSpec: FilterSpec = ???
+
+  override def sortSpec: SortSpec = ???
+
+  override def changeStructure(newStructuralFields: ViewPortStructuralFields): Unit = ???
+
+  override def getTreeNodeStateStore: TreeNodeState = ???
+
+  override def getStructure: ViewPortStructuralFields = ???
+
+  override def getStructuralHashCode(): Int = ???
+
+  override def getTableUpdateCount(): Long = ???
+
+  override def ForTest_getSubcribedKeys: util.Set[String] = ???
+
+  override def ForTest_getRowKeyToRowIndex: ConcurrentHashMap[String, Int] = ???
+
+  override def delete(): Unit = ???
+
+  override def keyBuildCount: Long = ???
+
+  override def setLastHashAndUpdateCount(lastHash: Int, lastUpdateCount: Long): Unit = ???
+
+  override def getLastHash(): Int = ???
+
+  override def getLastUpdateCount(): Long = ???
+
+  override def setPermissionFilter(filter: PermissionFilter): Unit = ???
+
+  override def getPermissionFilter: PermissionFilter = ???
+}

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -376,6 +376,28 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   }
 
   Feature("[Web Socket API] create a session table for export mode") {
+    Scenario("create a session table from source table using default name") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(tableName1)
+
+      When("request creating a session table using default name")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionType" -> "export"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is created using default name")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      sessionTableName.contains("simple-export-testTable1") shouldBe true
+    }
+
     // TODO 2231 add tests
   }
 

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -23,11 +23,11 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   private val noEnoughPermissionTableName = "noEnoughPermissionTable"
   private val nonEditableTableName = "nonEditableTable"
   private val tableName1 = "testTable1"
+  private val largeTableName = "largeTable"
   private val defaultEditTableName = "edit-" + tableName1
   private val defaultImportTableName = "import-" + tableName1
   private val defaultExportTableName = "export-" + tableName1
-  private val sessionTableDefName = "testSessionTable1"
-  private val largeTableName = "largeTable"
+  private val sessionTableName1 = "testSessionTable1"
   private val largeSessionTableDefName = "edit-" + largeTableName
   private val moduleName = "EditInSessionTableRpcTest"
   private val testProviderFactory = new TestProviderFactory
@@ -137,7 +137,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableDefName,
+          "sessionTableName" -> sessionTableName1,
           "copyOption" -> "Empty",
           "sessionType" -> "edit"
         ))
@@ -373,6 +373,29 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
       sessionTableName.contains("simple-import-testTable1") shouldBe true
     }
+
+    Scenario("create a session table from source table using a given name") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(tableName1)
+
+      When("request creating a session table using given session table def")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionType" -> "import",
+          "sessionTableName" -> sessionTableName1
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is created using given session table def")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      sessionTableName.contains("simple-testSessionTable1") shouldBe true
+    }
   }
 
   Feature("[Web Socket API] create a session table for export mode") {
@@ -398,7 +421,29 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       sessionTableName.contains("simple-export-testTable1") shouldBe true
     }
 
-    // TODO 2231 add tests
+    Scenario("create a session table from source table using a specific session table def") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(tableName1)
+
+      When("request creating a session table using given session table def")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionTableName" -> sessionTableName1,
+          "copyOption" -> "Empty",
+          "sessionType" -> "edit"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is created using given session table def")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      sessionTableName.contains("simple-testSessionTable1") shouldBe true
+    }
   }
 
   private def createTableDef(tableName: String, isEditable: Boolean): TableDef = {
@@ -475,7 +520,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         customColumns = allColumns
       ), viewPortDefFactoryForSessionTable)
       .addSessionTable(SessionTableDef(
-        name = sessionTableDefName,
+        name = sessionTableName1,
         keyField = "Id",
         customColumns = allColumns
       ), viewPortDefFactoryForSessionTable)

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -372,6 +372,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
       val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
       sessionTableName.contains("simple-import-testTable1") shouldBe true
+
+      createViewPortAndVerifyDataSize(sessionTableName, 0)
     }
 
     Scenario("create a session table from source table using a given name") {
@@ -421,6 +423,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
       val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
       sessionTableName.contains("simple-export-testTable1") shouldBe true
+
+      createViewPortAndVerifyDataSize(sessionTableName, 3)
     }
 
     Scenario("create a session table from source table using a given name") {

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -78,7 +78,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
     }
   }
 
-  // TODO add more tests:
+  // TODO 2231 add more tests:
   // Test when vp is filtered and sorted, the data copied to session table is also filtered and sorted
   // Test when copying from a given list of columns, only data from those columns are copied
   Feature("[Web Socket API] create a session table for edit mode") {

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -80,6 +80,29 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   // Test when vp is filtered and sorted, the data copied to session table is also filtered and sorted
   // Test when copying from a given list of columns, only data from those columns are copied
   Feature("[Web Socket API] create a session table for edit mode") {
+
+    Scenario("Request to create a session table failed for non-editable table") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(nonEditableTableName)
+
+      When("request createSessionTable for non-editable source table")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "copyOption" -> "Empty",
+          "sessionType" -> "edit"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is not created")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
+      rpcResult.errorMessage shouldBe "Table not editable"
+    }
+    
     Scenario("create a session table from source table using default session table def") {
       Given("a view port exist")
       val viewPortId = createViewPort(tableName1)
@@ -281,28 +304,6 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
     }
 
 
-    Scenario("Request to create a session table failed for non-editable table") {
-      Given("a view port exist")
-      val viewPortId = createViewPort(nonEditableTableName)
-
-      When("request createSessionTable for non-editable source table")
-      val createSessionTableRequest = RpcRequest(
-        ViewPortContext(viewPortId),
-        RpcNames.CreateSessionTableRpc,
-        params = Map(
-          "copyOption" -> "Empty",
-          "sessionType" -> "edit"
-        ))
-      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
-
-      Then("session table is not created")
-      val response = vuuClient.awaitForResponse(requestId)
-      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
-      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
-      val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
-      rpcResult.errorMessage shouldBe "Table not editable"
-    }
-
     Scenario("Request to create a session table failed for copying from columns not in source table") {
       Given("a view port exist")
       val viewPortId = createViewPortAndVerifyDataSize(tableName1, 3)
@@ -328,11 +329,30 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   }
 
   Feature("[Web Socket API] create a session table for import mode") {
+    Scenario("Request to create a session table failed for non-editable table") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(nonEditableTableName)
 
+      When("request createSessionTable for non-editable source table")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionType" -> "import"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is not created")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
+      rpcResult.errorMessage shouldBe "Table not editable"
+    }
   }
 
   Feature("[Web Socket API] create a session table for export mode") {
-
+    // TODO 2231 add tests
   }
 
   private def createTableDef(tableName: String, isEditable: Boolean): TableDef = {
@@ -390,7 +410,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
 
     ModuleFactory.withNamespace(moduleName)
       .addTableForTest(createTableDef(tableName1, true), viewPortDefFactory, providerFactory)
-      .addTableForTest(createTableDef(noEnoughPermissionTableName, false), noEnoughPermissionViewPortDefFactory, providerFactory)
+      .addTableForTest(createTableDef(noEnoughPermissionTableName, true), noEnoughPermissionViewPortDefFactory, providerFactory)
       .addTableForTest(createTableDef(nonEditableTableName, false), viewPortDefFactory, providerFactory)
       .addTableForTest(createTableDef(largeTableName, true), viewPortDefFactory, largeProviderFactory)
       .addSessionTable(SessionTableDef(

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -1,6 +1,5 @@
 package org.finos.vuu.wsapi
 
-import com.typesafe.scalalogging.StrictLogging
 import org.finos.vuu.api.{ColumnBuilder, SessionTableDef, TableDef, TableDefOptions, ViewPortDef}
 import org.finos.vuu.core.AbstractVuuServer
 import org.finos.vuu.core.auths.VuuUser
@@ -44,7 +43,10 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val createSessionTableRequest = RpcRequest(
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
-        params = Map("copyOption" -> "Empty"))
+        params = Map(
+          "copyOption" -> "Empty",
+          "sessionType" -> "edit"
+        ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
       Then("session table is created using default session table def")
@@ -66,7 +68,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         RpcNames.CreateSessionTableRpc,
         params = Map(
           "sessionTableName" -> sessionTableDefName,
-          "copyOption" -> "Empty"
+          "copyOption" -> "Empty",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -89,7 +92,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         RpcNames.CreateSessionTableRpc,
         params = Map(
           "copyOption" -> "Empty",
-          "columnsToCopy" -> "Id,Name"
+          "columnsToCopy" -> "Id,Name",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -112,7 +116,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         RpcNames.CreateSessionTableRpc,
         params = Map(
           "copyOption" -> "All",
-          "columnsToCopy" -> "*"
+          "columnsToCopy" -> "*",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -135,7 +140,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         RpcNames.CreateSessionTableRpc,
         params = Map(
           "copyOption" -> "All",
-          "columnsToCopy" -> "Id,Name"
+          "columnsToCopy" -> "Id,Name",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -158,7 +164,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         RpcNames.CreateSessionTableRpc,
         params = Map(
           "copyOption" -> "All",
-          "columnsToCopy" -> "*"
+          "columnsToCopy" -> "*",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -187,7 +194,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "copyOption" -> "Selected"
+          "copyOption" -> "Selected",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -213,7 +221,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "copyOption" -> "Selected"
+          "copyOption" -> "Selected",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -235,7 +244,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "copyOption" -> "Empty"
+          "copyOption" -> "Empty",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -256,7 +266,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "copyOption" -> "Empty"
+          "copyOption" -> "Empty",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -278,7 +289,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         RpcNames.CreateSessionTableRpc,
         params = Map(
           "copyOption" -> "Empty",
-          "columnsToCopy" -> "DUMMY1,DUMMY2"
+          "columnsToCopy" -> "DUMMY1,DUMMY2",
+          "sessionType" -> "edit"
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -23,7 +23,9 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   private val noEnoughPermissionTableName = "noEnoughPermissionTable"
   private val nonEditableTableName = "nonEditableTable"
   private val tableName1 = "testTable1"
-  private val defaultSessionTableDefName = "edit-" + tableName1
+  private val defaultEditTableName = "edit-" + tableName1
+  private val defaultImportTableName = "import-" + tableName1
+  private val defaultExportTableName = "export-" + tableName1
   private val sessionTableDefName = "testSessionTable1"
   private val largeTableName = "largeTable"
   private val largeSessionTableDefName = "edit-" + largeTableName
@@ -102,7 +104,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
       rpcResult.errorMessage shouldBe "Table not editable"
     }
-    
+
     Scenario("create a session table from source table using default session table def") {
       Given("a view port exist")
       val viewPortId = createViewPort(tableName1)
@@ -349,6 +351,28 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
       rpcResult.errorMessage shouldBe "Table not editable"
     }
+
+    Scenario("create a session table from source table using default name") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(tableName1)
+
+      When("request creating a session table using default name")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionType" -> "import"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is created using default name")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
+      val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
+      sessionTableName.contains("simple-import-testTable1") shouldBe true
+    }
   }
 
   Feature("[Web Socket API] create a session table for export mode") {
@@ -414,7 +438,17 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       .addTableForTest(createTableDef(nonEditableTableName, false), viewPortDefFactory, providerFactory)
       .addTableForTest(createTableDef(largeTableName, true), viewPortDefFactory, largeProviderFactory)
       .addSessionTable(SessionTableDef(
-        name = defaultSessionTableDefName,
+        name = defaultEditTableName,
+        keyField = "Id",
+        customColumns = allColumns
+      ), viewPortDefFactoryForSessionTable)
+      .addSessionTable(SessionTableDef(
+        name = defaultImportTableName,
+        keyField = "Id",
+        customColumns = allColumns
+      ), viewPortDefFactoryForSessionTable)
+      .addSessionTable(SessionTableDef(
+        name = defaultExportTableName,
         keyField = "Id",
         customColumns = allColumns
       ), viewPortDefFactoryForSessionTable)

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -31,7 +31,29 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   private val testProviderFactory = new TestProviderFactory
   private val maxSessionTableSize = 10 // configured in CoreServerApiTest
 
-  Feature("[Web Socket API] create a session table failed for undefined session type") {
+  Feature("[Web Socket API] create a session table failed") {
+    Scenario("Request to create a session table failed for no enough permission") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(noEnoughPermissionTableName)
+
+      When("request createSessionTable")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "copyOption" -> "Empty",
+          "sessionType" -> "edit"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is not created")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
+      rpcResult.errorMessage shouldBe "No permission to create session table."
+    }
+
     Scenario("create a session table failed for undefined session type") {
       Given("a view port exist")
       val viewPortId = createViewPort(tableName1)
@@ -258,27 +280,6 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, maxSessionTableSize)
     }
 
-    Scenario("Request to create a session table failed for no enough permission") {
-      Given("a view port exist")
-      val viewPortId = createViewPort(noEnoughPermissionTableName)
-
-      When("request createSessionTable")
-      val createSessionTableRequest = RpcRequest(
-        ViewPortContext(viewPortId),
-        RpcNames.CreateSessionTableRpc,
-        params = Map(
-          "copyOption" -> "Empty",
-          "sessionType" -> "edit"
-        ))
-      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
-
-      Then("session table is not created")
-      val response = vuuClient.awaitForResponse(requestId)
-      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
-      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
-      val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
-      rpcResult.errorMessage shouldBe "No permission to create session table."
-    }
 
     Scenario("Request to create a session table failed for non-editable table") {
       Given("a view port exist")

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -79,7 +79,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   // TODO add more tests:
   // Test when vp is filtered and sorted, the data copied to session table is also filtered and sorted
   // Test when copying from a given list of columns, only data from those columns are copied
-  Feature("[Web Socket API] create a session table and copy data from source table") {
+  Feature("[Web Socket API] create a session table for edit mode") {
     Scenario("create a session table from source table using default session table def") {
       Given("a view port exist")
       val viewPortId = createViewPort(tableName1)
@@ -325,6 +325,14 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
       rpcResult.errorMessage shouldBe "Column(s) not found in source table."
     }
+  }
+
+  Feature("[Web Socket API] create a session table for import mode") {
+
+  }
+
+  Feature("[Web Socket API] create a session table for export mode") {
+
   }
 
   private def createTableDef(tableName: String, isEditable: Boolean): TableDef = {

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -395,6 +395,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
       val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
       sessionTableName.contains("simple-testSessionTable1") shouldBe true
+
+      createViewPortAndVerifyDataSize(sessionTableName, 0)
     }
   }
 
@@ -421,7 +423,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       sessionTableName.contains("simple-export-testTable1") shouldBe true
     }
 
-    Scenario("create a session table from source table using a specific session table def") {
+    Scenario("create a session table from source table using a given name") {
       Given("a view port exist")
       val viewPortId = createViewPort(tableName1)
 
@@ -430,9 +432,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
         ViewPortContext(viewPortId),
         RpcNames.CreateSessionTableRpc,
         params = Map(
-          "sessionTableName" -> sessionTableName1,
-          "copyOption" -> "Empty",
-          "sessionType" -> "edit"
+          "sessionType" -> "export",
+          "sessionTableName" -> sessionTableName1
         ))
       val requestId = vuuClient.send(sessionId, createSessionTableRequest)
 
@@ -443,6 +444,8 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
       val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
       sessionTableName.contains("simple-testSessionTable1") shouldBe true
+
+      createViewPortAndVerifyDataSize(sessionTableName, 3)
     }
   }
 

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -30,7 +30,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   private val largeSessionTableDefName = "edit-" + largeTableName
   private val moduleName = "EditInSessionTableRpcTest"
   private val testProviderFactory = new TestProviderFactory
-  private val maxCopySize = 10 // configured in CoreServerApiTest
+  private val maxSessionTableSize = 10 // configured in CoreServerApiTest
 
   // TODO add more tests:
   // Test when vp is filtered and sorted, the data copied to session table is also filtered and sorted
@@ -168,7 +168,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
       val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
-      val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, maxCopySize)
+      val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, maxSessionTableSize)
     }
 
     Scenario("create a session table from selected rows of source table") {
@@ -223,7 +223,7 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
       responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
       val rpcResult = assertAndCastAsInstanceOf[RpcSuccessResult](responseBody.result)
       val sessionTableName = rpcResult.data.asInstanceOf[Map[String, String]]("sessionTable")
-      val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, maxCopySize)
+      val sessionTableViewPortId = createViewPortAndVerifyDataSize(sessionTableName, maxSessionTableSize)
     }
 
     Scenario("Request to create a session table failed for no enough permission") {

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/EditInSessionTableRpcWSApiTest.scala
@@ -31,6 +31,29 @@ class EditInSessionTableRpcWSApiTest extends WebSocketApiTestBase {
   private val testProviderFactory = new TestProviderFactory
   private val maxSessionTableSize = 10 // configured in CoreServerApiTest
 
+  Feature("[Web Socket API] create a session table failed for undefined session type") {
+    Scenario("create a session table failed for undefined session type") {
+      Given("a view port exist")
+      val viewPortId = createViewPort(tableName1)
+
+      When("request creating a session table using undefined session type")
+      val createSessionTableRequest = RpcRequest(
+        ViewPortContext(viewPortId),
+        RpcNames.CreateSessionTableRpc,
+        params = Map(
+          "sessionType" -> "dummy"
+        ))
+      val requestId = vuuClient.send(sessionId, createSessionTableRequest)
+
+      Then("session table is not created")
+      val response = vuuClient.awaitForResponse(requestId)
+      val responseBody = assertBodyIsInstanceOf[RpcResponseNew](response)
+      responseBody.rpcName shouldEqual RpcNames.CreateSessionTableRpc
+      val rpcResult = assertAndCastAsInstanceOf[RpcErrorResult](responseBody.result)
+      rpcResult.errorMessage shouldBe "Session type undefined"
+    }
+  }
+
   // TODO add more tests:
   // Test when vp is filtered and sorted, the data copied to session table is also filtered and sorted
   // Test when copying from a given list of columns, only data from those columns are copied


### PR DESCRIPTION
1. rename maxCopySIze to maxSessionTableSize
2. add "sessionType" to CreateSessionTableRpc params and handle edit/import/export in separate methods. By default edit allows 3 options for copy, import creates empty table, export copies all data