### PR TITLE
Separate portal code from shared @vuu-ui/core entry

### DIFF
--- a/vuu-ui/packages/core/README.md
+++ b/vuu-ui/packages/core/README.md
@@ -1,5 +1,10 @@
-# @vuu-ui/core portal
+# @vuu-ui/core
 
-Reusable VUU portal host and Module Federation integration components.
+Core VUU authentication and data-context APIs are exported from
+`@vuu-ui/core` and can be registered as a shared Module Federation dependency.
 
-See [DESIGN.md](./DESIGN.md) for the package design.
+Portal host and remote-module APIs are exported separately from
+`@vuu-ui/core/portal` so portal dependencies are not included in the shared
+module.
+
+See [the portal design](./docs/portal-design.md) for details.

--- a/vuu-ui/packages/core/docs/portal-design.md
+++ b/vuu-ui/packages/core/docs/portal-design.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-`@vuu-ui/core` provides the reusable components, types, and utilities
+`@vuu-ui/core/portal` provides the reusable components, types, and utilities
 needed to build VUU portals with Module Federation. It is the package boundary
 for portal host behavior and remote-module integration.
 
@@ -45,8 +45,9 @@ core/
 |   |-- portal-shell/
 |   |-- remote-module/
 |   |-- index.ts
+|   |-- portal.ts
 |   `-- RemoteModuleDescriptor.ts
-|-- DESIGN.md
+|-- docs/
 |-- README.md
 |-- package.json
 `-- tsconfig.json

--- a/vuu-ui/packages/core/package.json
+++ b/vuu-ui/packages/core/package.json
@@ -6,6 +6,10 @@
     "docs"
   ],
   "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./portal": "./src/portal.ts"
+  },
   "author": "heswell",
   "license": "Apache-2.0",
   "type": "module",

--- a/vuu-ui/packages/core/src/index.ts
+++ b/vuu-ui/packages/core/src/index.ts
@@ -4,14 +4,3 @@ export {
   DataProvider,
   useData,
 } from "./context-definitions/DataProvider";
-export {
-  PortalHeader,
-  type PortalHeaderProps,
-} from "./portal-header/PortalHeader";
-export { PortalNav, type PortalNavProps } from "./portal-nav/PortalNav";
-export { PortalShell, type PortalShellProps } from "./portal-shell/PortalShell";
-export {
-  RemoteModule,
-  type RemoteModuleProps,
-} from "./remote-module/RemoteModule";
-export type { RemoteModuleDescriptor } from "./RemoteModuleDescriptor";

--- a/vuu-ui/packages/core/src/portal-header/PortalHeader.tsx
+++ b/vuu-ui/packages/core/src/portal-header/PortalHeader.tsx
@@ -1,5 +1,5 @@
 import { Button, Toolbar, ToolbarContent, Tooltray } from "@salt-ds/core";
-import { useLogout } from "../auth";
+import { useLogout } from "@vuu-ui/core";
 import cx from "clsx";
 import type { HTMLAttributes } from "react";
 

--- a/vuu-ui/packages/core/src/portal.ts
+++ b/vuu-ui/packages/core/src/portal.ts
@@ -1,0 +1,11 @@
+export {
+  PortalHeader,
+  type PortalHeaderProps,
+} from "./portal-header/PortalHeader";
+export { PortalNav, type PortalNavProps } from "./portal-nav/PortalNav";
+export { PortalShell, type PortalShellProps } from "./portal-shell/PortalShell";
+export {
+  RemoteModule,
+  type RemoteModuleProps,
+} from "./remote-module/RemoteModule";
+export type { RemoteModuleDescriptor } from "./RemoteModuleDescriptor";

--- a/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
+++ b/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
@@ -1,4 +1,7 @@
-import { AuthenticationProvider, type RemoteModuleConnection } from "../auth";
+import {
+  AuthenticationProvider,
+  type RemoteModuleConnection,
+} from "@vuu-ui/core";
 import {
   loadRemote,
   registerRemotes,

--- a/vuu-ui/packages/vuu-shell/src/feature/Feature.tsx
+++ b/vuu-ui/packages/vuu-shell/src/feature/Feature.tsx
@@ -1,7 +1,7 @@
-import { RemoteModule } from "@vuu-ui/core";
+import { RemoteModule } from "@vuu-ui/core/portal";
 import { registerComponent } from "@vuu-ui/vuu-utils";
 
-/** @deprecated Use RemoteModule from @vuu-ui/core. */
+/** @deprecated Use RemoteModule from @vuu-ui/core/portal. */
 export const Feature = RemoteModule;
 Feature.displayName = "Feature";
 registerComponent("Feature", Feature, "view");

--- a/vuu-ui/packages/vuu-shell/src/feature/index.ts
+++ b/vuu-ui/packages/vuu-shell/src/feature/index.ts
@@ -2,4 +2,4 @@ export * from "./Feature";
 export {
   RemoteModule,
   type RemoteModuleProps,
-} from "@vuu-ui/core";
+} from "@vuu-ui/core/portal";

--- a/vuu-ui/sample-apps/vuu-portal/src/App.tsx
+++ b/vuu-ui/sample-apps/vuu-portal/src/App.tsx
@@ -4,7 +4,7 @@ import { registerComponent } from "@vuu-ui/vuu-utils";
 import { useEffect, useState } from "react";
 import { ConfirmSelectionPanel } from "./order-management/cancel-confirm-prompt/ConfirmSelectionPanel";
 import { BrowserRouter } from "react-router-dom";
-import { PortalShell, type RemoteModuleDescriptor } from "@vuu-ui/core";
+import { PortalShell, type RemoteModuleDescriptor } from "@vuu-ui/core/portal";
 import { getRegisteredModules } from "@vuu-ui/vuu-shell";
 
 import "./App.css";

--- a/vuu-ui/scripts/package-json.ts
+++ b/vuu-ui/scripts/package-json.ts
@@ -2,14 +2,8 @@ import fs from "fs";
 
 export const readPackageJson = (path = "package.json") => readJson(path);
 
-type PackageExports = {
-  ".": {
-    import: string;
-  };
-  style?: {
-    import: string;
-  };
-};
+type PackageExport = string | { import: string };
+type PackageExports = Record<string, PackageExport>;
 type Json = {
   exports?: PackageExports;
   files?: string[];
@@ -32,6 +26,7 @@ export async function writePackageJSON(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const {
+      exports: sourceExports,
       files: filesFromPackageJson = [],
       name: scopedPackageName,
       style,
@@ -49,9 +44,14 @@ export async function writePackageJSON(
       });
     });
 
-    const exports: PackageExports = {
-      ".": { import: "./src/index.js" },
-    };
+    const exports: PackageExports = Object.fromEntries(
+      Object.entries(
+        sourceExports ?? { ".": "./src/index.ts" },
+      ).map(([subpath, target]) => {
+        const importPath = typeof target === "string" ? target : target.import;
+        return [subpath, { import: importPath.replace(/\.tsx?$/, ".js") }];
+      }),
+    );
 
     if (style) {
       exports.style = { import: style };

--- a/vuu-ui/showcase/src/examples/vuuportal/PortalNav.examples.tsx
+++ b/vuu-ui/showcase/src/examples/vuuportal/PortalNav.examples.tsx
@@ -1,7 +1,7 @@
 import {
   PortalNav,
   type RemoteModuleDescriptor,
-} from "@vuu-ui/core";
+} from "@vuu-ui/core/portal";
 
 const remoteModule = (path: string): RemoteModuleDescriptor => {
   const name = path.split("/").filter(Boolean).at(-1) ?? path;


### PR DESCRIPTION
## Summary
- keep the shared `@vuu-ui/core` root limited to authentication and data-context APIs
- expose portal components through the non-shared `@vuu-ui/core/portal` subpath
- preserve self-imports from portal code to the shared root so authentication contexts remain singleton
- publish both package entry points and update portal consumers

## Validation
- built `@vuu-ui/core` and verified the published export map
- built the `vuu-portal` host
- built the `feature-simple-div` federated remote
- confirmed MF manifests share only `@vuu-ui/core`
- passed all 10 core authentication tests