### PR TITLE
Fix table browser route updates

### DIFF
--- a/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
+++ b/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
@@ -7,6 +7,7 @@ import {
   registerRemotes,
 } from "@module-federation/enhanced/runtime";
 import React, { lazy } from "react";
+import { useInRouterContext, useLocation } from "react-router-dom";
 import { RemoteModuleErrorBoundary } from "./RemoteModuleErrorBoundary";
 
 export interface RemoteModuleProps<
@@ -118,5 +119,19 @@ function RawRemoteModule<ComponentProps extends object | undefined>({
   );
 }
 
-export const RemoteModule = React.memo(RawRemoteModule);
+type RoutedRemoteModuleProps = RemoteModuleProps;
+
+const RoutedRemoteModule = (props: RoutedRemoteModuleProps) => {
+  useLocation();
+  return <RawRemoteModule {...props} />;
+};
+
+export const RemoteModule = React.memo(
+  (props: RoutedRemoteModuleProps) =>
+    useInRouterContext() ? (
+      <RoutedRemoteModule {...props} />
+    ) : (
+      <RawRemoteModule {...props} />
+    ),
+);
 RemoteModule.displayName = "RemoteModule";


### PR DESCRIPTION
## Summary
- subscribe hosted remote modules to React Router location changes
- ensure selecting a table propagates the updated route and selected table to the browser/viewer remotes
- preserve connectionless `RemoteModule` usage outside a router

## Validation
- targeted `RemoteModule` test
- `@vuu-ui/core` build
- `vuu-table-browser` build