### PR TITLE
Use readable table browser routes

### DIFF
--- a/vuu-ui/packages/core/src/portal-shell/PortalShell.tsx
+++ b/vuu-ui/packages/core/src/portal-shell/PortalShell.tsx
@@ -18,6 +18,9 @@ const classBase = "vuuPortalShell";
 
 const accentPurple = "purple" as Accent;
 
+const getRemoteRoutePath = (path: string) =>
+  path.endsWith("*") ? path : `${path}/*`;
+
 export interface PortalShellProps {
   id?: string;
   remoteModules: RemoteModuleDescriptor[];
@@ -64,7 +67,7 @@ export const PortalShell = ({ id, remoteModules, title }: PortalShellProps) => {
                     {remoteModules.map(({ id, path, ...feature }) => (
                       <Route
                         key={id}
-                        path={path}
+                        path={getRemoteRoutePath(path)}
                         element={<RemoteModule {...feature} />}
                       />
                     ))}

--- a/vuu-ui/sample-apps/vuu-table-browser/src/VuuTableBrowser.tsx
+++ b/vuu-ui/sample-apps/vuu-table-browser/src/VuuTableBrowser.tsx
@@ -241,7 +241,7 @@ export default function VuuTableBrowser({
               return [];
             }
 
-            const sourceId = String(module.id ?? module.name);
+            const sourceId = String(module.name ?? module.id);
             if (sourceIds.has(sourceId)) {
               return [];
             }

--- a/vuu-ui/sample-apps/vuu-table-browser/src/VuuTableBrowser.tsx
+++ b/vuu-ui/sample-apps/vuu-table-browser/src/VuuTableBrowser.tsx
@@ -24,7 +24,12 @@ import type { RemoteModuleConnection } from "@vuu-ui/vuu-data-types";
 import type { VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { getRegisteredModules } from "@vuu-ui/vuu-shell";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useLocation, useParams } from "react-router-dom";
+import {
+  Link,
+  useLocation,
+  useParams,
+  useResolvedPath,
+} from "react-router-dom";
 
 import "./VuuTableBrowser.css";
 
@@ -107,6 +112,8 @@ const SourceNavigation = ({
   source?: SourceState;
 }) => {
   const location = useLocation();
+  const browserRoute = useResolvedPath(".");
+  const browserRoutePath = browserRoute.pathname.replace(/\/$/, "");
   const duplicateNames = useMemo(() => {
     const counts = new Map<string, number>();
     for (const table of source?.tables ?? []) {
@@ -163,7 +170,12 @@ const SourceNavigation = ({
               return (
                 <VerticalNavigationItem active={selected} key={path}>
                   <VerticalNavigationItemContent>
-                    <Link to={{ pathname: path, search: location.search }}>
+                    <Link
+                      to={{
+                        pathname: `${browserRoutePath}/${path}`,
+                        search: location.search,
+                      }}
+                    >
                       <VerticalNavigationItemLabel title={label}>
                         {label}
                       </VerticalNavigationItemLabel>


### PR DESCRIPTION
## Summary
- use registry module names instead of numeric IDs in table-browser routes
- avoid ambiguous routes when registry entries reuse numeric IDs
- produce readable URLs such as `/user-admin/KEYCLOAK_ADMIN/users`

## Validation
- built the `vuu-table-browser` remote