### PR TITLE
#2231 add CreateSessionTableRpcHandlerImpl for java

### DIFF
--- a/example/main-java/src/main/java/org/finos/vuu/module/JavaExampleModule.java
+++ b/example/main-java/src/main/java/org/finos/vuu/module/JavaExampleModule.java
@@ -11,9 +11,11 @@ import org.finos.vuu.core.table.Columns;
 import org.finos.vuu.core.table.DataTable;
 import org.finos.vuu.core.table.DefaultColumn;
 import org.finos.vuu.core.table.TableContainer;
+import org.finos.vuu.net.rpc.AllowAllRpcPermissionChecker$;
 import org.finos.vuu.net.rpc.RpcHandler;
 import org.finos.vuu.person.DeleteRecordRpcHandler;
 import org.finos.vuu.person.DeleteRecordRpcHandlerIF;
+import org.finos.vuu.person.EditRecordRpcHandler;
 import org.finos.vuu.person.PersonRpcHandler;
 import org.finos.vuu.person.UpdateRecordRpcHandler;
 import org.finos.vuu.person.auto.AutoMappedPersonProvider;
@@ -46,7 +48,7 @@ public class JavaExampleModule extends DefaultModule {
                         (table, vs) -> new PersonProvider(table, new PersonStore()),
                         (table, provider, providerContainer, tableContainer) -> new ViewPortDef(
                                 table.getTableDef().getColumns(),
-                                buildRpcHandler(table)
+                                buildRpcHandler2(table, tableContainer)
                         )
                 )
                 .addTable(new TableDefBuilder()
@@ -72,9 +74,9 @@ public class JavaExampleModule extends DefaultModule {
 
     // Example of a mixture of RPC handlers in scala and in java
     private RpcHandler buildRpcHandler2(DataTable table, TableContainer tableContainer) {
+        EditRecordRpcHandler editRecordRpcHandler = new EditRecordRpcHandler(AllowAllRpcPermissionChecker$.MODULE$, tableContainer);
         PersonRpcHandler personRpcHandler = new PersonRpcHandler(table);
         DeleteRecordRpcHandlerIF deleteRecordRpcHandler = new DeleteRecordRpcHandler();
-
         UpdateRecordRpcHandler updateRecordRpcHandler = new UpdateRecordRpcHandler(tableContainer);
         updateRecordRpcHandler.registerRpc("UpdateName", personRpcHandler::processUpdateNameRpcRequest);
         updateRecordRpcHandler.registerRpc("GetAccountId", personRpcHandler::processGetAccountIdRpcRequest);

--- a/example/main-java/src/main/java/org/finos/vuu/module/JavaExampleModule.java
+++ b/example/main-java/src/main/java/org/finos/vuu/module/JavaExampleModule.java
@@ -23,6 +23,7 @@ import org.finos.vuu.person.auto.EntitySchema;
 import org.finos.vuu.person.datasource.PersonStore;
 import org.finos.vuu.person.manual.PersonProvider;
 import org.finos.vuu.util.RpcHandlerBuilder;
+import org.finos.vuu.util.SessionTableDefBuilder;
 import org.finos.vuu.util.SortSpecBuilder;
 import org.finos.vuu.util.TableDefBuilder;
 
@@ -69,6 +70,20 @@ public class JavaExampleModule extends DefaultModule {
                                 buildRpcHandler3(tableContainer)
                         )
                 )
+                .addSessionTable(new SessionTableDefBuilder()
+                                .name("export-PersonManualMapped2")
+                                .keyField("Id")
+                                .customColumns(new ColumnBuilder()
+                                        .addString("id")
+                                        .addString("name")
+                                        .addInt("account")
+                                        .build())
+                                .build(),
+                        (table, provider, providerContainer, tableContainer) -> ViewPortDef.createDefault(new ColumnBuilder()
+                                .addString("id")
+                                .addString("name")
+                                .addInt("account")
+                                .build()))
                 .addTable(new TableDefBuilder()
                                 .name("PersonAutoMapped")
                                 .keyField("id")

--- a/example/main-java/src/main/java/org/finos/vuu/module/JavaExampleModule.java
+++ b/example/main-java/src/main/java/org/finos/vuu/module/JavaExampleModule.java
@@ -15,7 +15,7 @@ import org.finos.vuu.net.rpc.AllowAllRpcPermissionChecker$;
 import org.finos.vuu.net.rpc.RpcHandler;
 import org.finos.vuu.person.DeleteRecordRpcHandler;
 import org.finos.vuu.person.DeleteRecordRpcHandlerIF;
-import org.finos.vuu.person.EditRecordRpcHandler;
+import org.finos.vuu.person.EditPersonRecordRpcHandler;
 import org.finos.vuu.person.PersonRpcHandler;
 import org.finos.vuu.person.UpdateRecordRpcHandler;
 import org.finos.vuu.person.auto.AutoMappedPersonProvider;
@@ -52,6 +52,24 @@ public class JavaExampleModule extends DefaultModule {
                         )
                 )
                 .addTable(new TableDefBuilder()
+                                .name("PersonManualMapped2")
+                                .keyField("id")
+                                .customColumns(new ColumnBuilder()
+                                        .addString("id")
+                                        .addString("name")
+                                        .addInt("account")
+                                        .build())
+                                .defaultSort(new SortSpecBuilder()
+                                        .addAscending(DefaultColumn.CREATED_TIME().name())
+                                        .build())
+                                .build(),
+                        (table, vs) -> new PersonProvider(table, new PersonStore()),
+                        (table, provider, providerContainer, tableContainer) -> new ViewPortDef(
+                                table.getTableDef().getColumns(),
+                                buildRpcHandler3(tableContainer)
+                        )
+                )
+                .addTable(new TableDefBuilder()
                                 .name("PersonAutoMapped")
                                 .keyField("id")
                                 .customColumns(Columns.fromExternalSchema(EntitySchema.person))
@@ -74,7 +92,6 @@ public class JavaExampleModule extends DefaultModule {
 
     // Example of a mixture of RPC handlers in scala and in java
     private RpcHandler buildRpcHandler2(DataTable table, TableContainer tableContainer) {
-        EditRecordRpcHandler editRecordRpcHandler = new EditRecordRpcHandler(AllowAllRpcPermissionChecker$.MODULE$, tableContainer);
         PersonRpcHandler personRpcHandler = new PersonRpcHandler(table);
         DeleteRecordRpcHandlerIF deleteRecordRpcHandler = new DeleteRecordRpcHandler();
         UpdateRecordRpcHandler updateRecordRpcHandler = new UpdateRecordRpcHandler(tableContainer);
@@ -82,5 +99,9 @@ public class JavaExampleModule extends DefaultModule {
         updateRecordRpcHandler.registerRpc("GetAccountId", personRpcHandler::processGetAccountIdRpcRequest);
         updateRecordRpcHandler.registerRpc("DeleteRecprd", deleteRecordRpcHandler::deleteRecord);
         return updateRecordRpcHandler;
+    }
+
+    private RpcHandler buildRpcHandler3(TableContainer tableContainer) {
+        return new EditPersonRecordRpcHandler(AllowAllRpcPermissionChecker$.MODULE$, tableContainer);
     }
 }

--- a/example/main-java/src/main/java/org/finos/vuu/person/EditPersonRecordRpcHandler.java
+++ b/example/main-java/src/main/java/org/finos/vuu/person/EditPersonRecordRpcHandler.java
@@ -4,9 +4,9 @@ import org.finos.vuu.core.table.TableContainer;
 import org.finos.vuu.net.rpc.CreateSessionTableRpcHandlerImpl;
 import org.finos.vuu.net.rpc.RpcPermissionChecker;
 
-public class EditRecordRpcHandler extends CreateSessionTableRpcHandlerImpl {
+public class EditPersonRecordRpcHandler extends CreateSessionTableRpcHandlerImpl {
 
-    public EditRecordRpcHandler(RpcPermissionChecker rpcPermissionChecker, TableContainer tableContainer) {
+    public EditPersonRecordRpcHandler(RpcPermissionChecker rpcPermissionChecker, TableContainer tableContainer) {
         super(rpcPermissionChecker, tableContainer);
     }
 }

--- a/example/main-java/src/main/java/org/finos/vuu/person/EditRecordRpcHandler.java
+++ b/example/main-java/src/main/java/org/finos/vuu/person/EditRecordRpcHandler.java
@@ -1,0 +1,12 @@
+package org.finos.vuu.person;
+
+import org.finos.vuu.core.table.TableContainer;
+import org.finos.vuu.net.rpc.CreateSessionTableRpcHandlerImpl;
+import org.finos.vuu.net.rpc.RpcPermissionChecker;
+
+public class EditRecordRpcHandler extends CreateSessionTableRpcHandlerImpl {
+
+    public EditRecordRpcHandler(RpcPermissionChecker rpcPermissionChecker, TableContainer tableContainer) {
+        super(rpcPermissionChecker, tableContainer);
+    }
+}

--- a/example/main-java/src/main/java/org/finos/vuu/person/UpdateRecordRpcHandler.java
+++ b/example/main-java/src/main/java/org/finos/vuu/person/UpdateRecordRpcHandler.java
@@ -13,6 +13,9 @@ public class UpdateRecordRpcHandler extends DefaultRpcHandlerImpl implements Edi
     private final TableContainer tableContainer;
 
     public UpdateRecordRpcHandler(TableContainer tableContainer) {
+        super();
+        registerEditTableRpcs();
+        registerEndEditSessionRpcs();
         this.tableContainer = tableContainer;
     }
 

--- a/example/main-java/src/main/java/org/finos/vuu/person/UpdateRecordRpcHandler.java
+++ b/example/main-java/src/main/java/org/finos/vuu/person/UpdateRecordRpcHandler.java
@@ -75,9 +75,4 @@ public class UpdateRecordRpcHandler extends DefaultRpcHandlerImpl implements Edi
     public boolean submit(RpcParams params) {
         return true;
     }
-
-    @Override
-    public TableContainer tableContainer() {
-        return tableContainer;
-    }
 }

--- a/example/main-java/src/test/java/org/finos/vuu/PersonRpcHandlerWSApiTest.java
+++ b/example/main-java/src/test/java/org/finos/vuu/PersonRpcHandlerWSApiTest.java
@@ -170,7 +170,7 @@ public class PersonRpcHandlerWSApiTest extends WebSocketApiJavaTestBase {
 
     @Test
     public void table2_custom_rpc_request_createSessionTable() {
-        // test rpc registered in UpdateRecordRpcHandler (DefaultRpcHandler) works
+        // test rpc registered in EditPersonRecordRpcHandler (CreateSessionTableRpcHandlerImpl) works
         var viewPortId = createViewPort("PersonManualMapped2");
 
         var rpcRequest = new RpcRequest(
@@ -189,7 +189,7 @@ public class PersonRpcHandlerWSApiTest extends WebSocketApiJavaTestBase {
 
     @Test
     public void table2_custom_rpc_request_getUniqueFieldValues() {
-        // test rpc registered in UpdateRecordRpcHandler (DefaultRpcHandler) works
+        // test rpc registered in EditPersonRecordRpcHandler (DefaultRpcHandler) works
         var viewPortId = createViewPort("PersonManualMapped2");
 
         var rpcRequest = new RpcRequest(

--- a/example/main-java/src/test/java/org/finos/vuu/PersonRpcHandlerWSApiTest.java
+++ b/example/main-java/src/test/java/org/finos/vuu/PersonRpcHandlerWSApiTest.java
@@ -57,7 +57,7 @@ public class PersonRpcHandlerWSApiTest extends WebSocketApiJavaTestBase {
 
         assertInstanceOf(RpcSuccessResult.class, responseBody.result(), "Response contains Successful result");
         var result = (RpcSuccessResult) responseBody.result();
-        var data = toJava((scala.collection.immutable.List<?>)result.data());
+        var data = toJava((scala.collection.immutable.List<?>) result.data());
         assertEquals(List.of("Adam", "Natalie"), data);
 
         assertEquals(NoneAction$.MODULE$, responseBody.action(), "Response contains no action");
@@ -112,6 +112,101 @@ public class PersonRpcHandlerWSApiTest extends WebSocketApiJavaTestBase {
     }
 
     @Test
+    public void custom_rpc_request_deleteRow() {
+        // test rpc registered in UpdateRecordRpcHandler (EditTableRpcHandler) works
+        var viewPortId = createViewPort();
+
+        var rpcRequest = new RpcRequest(
+                new ViewPortContext(viewPortId),
+                "deleteRow",
+                toScala(Map.of())
+        );
+
+        var requestId = vuuClient.send(sessionId, rpcRequest);
+        var response = vuuClient.awaitForResponse(requestId);
+
+        RpcResponseNew responseBody = assertBodyIsInstanceOf(response, "Request response");
+        assertEquals("deleteRow", responseBody.rpcName());
+        assertInstanceOf(RpcSuccessResult.class, responseBody.result());
+    }
+
+    @Test
+    public void custom_rpc_request_endEditSession() {
+        // test rpc registered in UpdateRecordRpcHandler (EndEditSessionRpcHandler) works
+        var viewPortId = createViewPort();
+
+        var rpcRequest = new RpcRequest(
+                new ViewPortContext(viewPortId),
+                "endEditSession",
+                toScala(Map.of())
+        );
+
+        var requestId = vuuClient.send(sessionId, rpcRequest);
+        var response = vuuClient.awaitForResponse(requestId);
+
+        RpcResponseNew responseBody = assertBodyIsInstanceOf(response, "Request response");
+        assertEquals("endEditSession", responseBody.rpcName());
+        assertInstanceOf(RpcSuccessResult.class, responseBody.result());
+    }
+
+    @Test
+    public void custom_rpc_request_getUniqueFieldValues() {
+        // test rpc registered in UpdateRecordRpcHandler (DefaultRpcHandler) works
+        var viewPortId = createViewPort();
+
+        var rpcRequest = new RpcRequest(
+                new ViewPortContext(viewPortId),
+                "getUniqueFieldValues",
+                toScala(Map.of("column", "id"))
+        );
+
+        var requestId = vuuClient.send(sessionId, rpcRequest);
+        var response = vuuClient.awaitForResponse(requestId);
+
+        RpcResponseNew responseBody = assertBodyIsInstanceOf(response, "Request response");
+        assertEquals("getUniqueFieldValues", responseBody.rpcName());
+        assertInstanceOf(RpcSuccessResult.class, responseBody.result());
+    }
+
+    @Test
+    public void table2_custom_rpc_request_createSessionTable() {
+        // test rpc registered in UpdateRecordRpcHandler (DefaultRpcHandler) works
+        var viewPortId = createViewPort("PersonManualMapped2");
+
+        var rpcRequest = new RpcRequest(
+                new ViewPortContext(viewPortId),
+                "createSessionTable",
+                toScala(Map.of("column", "id"))
+        );
+
+        var requestId = vuuClient.send(sessionId, rpcRequest);
+        var response = vuuClient.awaitForResponse(requestId);
+
+        RpcResponseNew responseBody = assertBodyIsInstanceOf(response, "Request response");
+        assertEquals("createSessionTable", responseBody.rpcName());
+        assertInstanceOf(RpcSuccessResult.class, responseBody.result());
+    }
+
+    @Test
+    public void table2_custom_rpc_request_getUniqueFieldValues() {
+        // test rpc registered in UpdateRecordRpcHandler (DefaultRpcHandler) works
+        var viewPortId = createViewPort("PersonManualMapped2");
+
+        var rpcRequest = new RpcRequest(
+                new ViewPortContext(viewPortId),
+                "getUniqueFieldValues",
+                toScala(Map.of("column", "id"))
+        );
+
+        var requestId = vuuClient.send(sessionId, rpcRequest);
+        var response = vuuClient.awaitForResponse(requestId);
+
+        RpcResponseNew responseBody = assertBodyIsInstanceOf(response, "Request response");
+        assertEquals("getUniqueFieldValues", responseBody.rpcName());
+        assertInstanceOf(RpcSuccessResult.class, responseBody.result());
+    }
+
+    @Test
     public void custom_rpc_request_that_does_not_exist() {
         var viewPortId = createViewPort();
 
@@ -140,6 +235,10 @@ public class PersonRpcHandlerWSApiTest extends WebSocketApiJavaTestBase {
     }
 
     private String createViewPort() {
+        return createViewPort(tableName);
+    }
+
+    private String createViewPort(String tableName) {
         var createViewPortRequest = new CreateViewPortRequest(
                 new ViewPortTable(tableName, moduleName),
                 new ViewPortRange(1, 100),
@@ -154,7 +253,7 @@ public class PersonRpcHandlerWSApiTest extends WebSocketApiJavaTestBase {
         var viewPortCreateResponse = vuuClient.awaitForResponse(viewPortRequestId);
 
         CreateViewPortSuccess responseBody = assertBodyIsInstanceOf(viewPortCreateResponse, "View port create response");
-        var viewportId =  responseBody.viewPortId();
+        var viewportId = responseBody.viewPortId();
 
         waitForData(viewportId, 1);
         return viewportId;

--- a/example/main-java/src/test/java/org/finos/vuu/PersonRpcHandlerWSApiTest.java
+++ b/example/main-java/src/test/java/org/finos/vuu/PersonRpcHandlerWSApiTest.java
@@ -176,7 +176,7 @@ public class PersonRpcHandlerWSApiTest extends WebSocketApiJavaTestBase {
         var rpcRequest = new RpcRequest(
                 new ViewPortContext(viewPortId),
                 "createSessionTable",
-                toScala(Map.of("column", "id"))
+                toScala(Map.of("sessionType", "export"))
         );
 
         var requestId = vuuClient.send(sessionId, rpcRequest);

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -7,7 +7,9 @@ import org.finos.vuu.net.rpc.SessionTableCopyOption.{All, Empty, Selected}
 import org.finos.vuu.viewport.{RowSource, ViewPort}
 
 // Added this class for java
-class CreateSessionTableRpcHandlerImpl(rpcPermissionChecker: RpcPermissionChecker, tableContainer: TableContainer) extends CreateSessionTableRpcHandler(rpcPermissionChecker, tableContainer)
+class CreateSessionTableRpcHandlerImpl(rpcPermissionChecker: RpcPermissionChecker, tableContainer: TableContainer)
+  extends CreateSessionTableRpcHandler(rpcPermissionChecker, tableContainer)
+    with DefaultRpcHandler
 
 trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, tableContainer: TableContainer) extends RpcHandler {
   registerRpc(RpcNames.CreateSessionTableRpc, this.createSessionTable)

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/CreateSessionTableRpcHandler.scala
@@ -6,6 +6,9 @@ import org.finos.vuu.net.ClientSessionId
 import org.finos.vuu.net.rpc.SessionTableCopyOption.{All, Empty, Selected}
 import org.finos.vuu.viewport.{RowSource, ViewPort}
 
+// Added this class for java
+class CreateSessionTableRpcHandlerImpl(rpcPermissionChecker: RpcPermissionChecker, tableContainer: TableContainer) extends CreateSessionTableRpcHandler(rpcPermissionChecker, tableContainer)
+
 trait CreateSessionTableRpcHandler(rpcPermissionChecker: RpcPermissionChecker, tableContainer: TableContainer) extends RpcHandler {
   registerRpc(RpcNames.CreateSessionTableRpc, this.createSessionTable)
 

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/EditTableRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/EditTableRpcHandler.scala
@@ -1,15 +1,20 @@
 package org.finos.vuu.net.rpc
 
 trait EditTableRpcHandler() extends RpcHandler {
-  registerRpc(RpcNames.DeleteRowRpc, this.deleteRow)
-  registerRpc(RpcNames.DeleteSelectedRowsRpc, this.deleteSelectedRows)
-  registerRpc(RpcNames.DeleteCellRpc, this.deleteCell)
-  registerRpc(RpcNames.AddRowRpc, this.addRow)
-  registerRpc(RpcNames.EditRowRpc, this.editRow)
-  registerRpc(RpcNames.EditCellRpc, this.editCell)
-  registerRpc(RpcNames.SubmitFormRpc, this.submitForm)
-  registerRpc(RpcNames.CloseFormRpc, this.closeForm)
-  registerRpc(RpcNames.UndoRowChangeRpc, this.undoRowChange)
+
+  registerEditTableRpcs()
+
+  protected final def registerEditTableRpcs(): Unit = {
+    registerRpc(RpcNames.DeleteRowRpc, this.deleteRow)
+    registerRpc(RpcNames.DeleteSelectedRowsRpc, this.deleteSelectedRows)
+    registerRpc(RpcNames.DeleteCellRpc, this.deleteCell)
+    registerRpc(RpcNames.AddRowRpc, this.addRow)
+    registerRpc(RpcNames.EditRowRpc, this.editRow)
+    registerRpc(RpcNames.EditCellRpc, this.editCell)
+    registerRpc(RpcNames.SubmitFormRpc, this.submitForm)
+    registerRpc(RpcNames.CloseFormRpc, this.closeForm)
+    registerRpc(RpcNames.UndoRowChangeRpc, this.undoRowChange)
+  }
 
   def deleteRow(params: RpcParams): RpcFunctionResult
 

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/EndEditSessionRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/EndEditSessionRpcHandler.scala
@@ -1,8 +1,6 @@
 package org.finos.vuu.net.rpc
 
-import org.finos.vuu.core.table.TableContainer
-
-trait EndEditSessionRpcHandler(using val tableContainer: TableContainer) extends RpcHandler {
+trait EndEditSessionRpcHandler() extends RpcHandler {
   registerRpc(RpcNames.EndEditSessionRpc, this.endEditSession)
 
   def endEditSession(params: RpcParams): RpcFunctionResult = {

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/EndEditSessionRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/EndEditSessionRpcHandler.scala
@@ -1,7 +1,12 @@
 package org.finos.vuu.net.rpc
 
 trait EndEditSessionRpcHandler() extends RpcHandler {
-  registerRpc(RpcNames.EndEditSessionRpc, this.endEditSession)
+
+  registerEndEditSessionRpcs()
+
+  protected final def registerEndEditSessionRpcs(): Unit = {
+    registerRpc(RpcNames.EndEditSessionRpc, this.endEditSession)
+  }
 
   def endEditSession(params: RpcParams): RpcFunctionResult = {
     if (!verifyPermission(params)) {


### PR DESCRIPTION
Changes:
1. Added registerEditTableRpcs() and registerEndEditSessionRpcs() to traits so it can be called in java implementation
2. Removed TableContainer  EndEditSessionRpcHandler as it is no longer required
3. Added CreateSessionTableRpcHandlerImpl so when using CreateSessionTableRpcHandler in java compiler doesn't complain about RpcPermissionChecker and TableContainer in the constructor