### PR TITLE
Add sessionType to createSessionDataSource and fix csvupload error rows preview

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -5,6 +5,7 @@ import type {
   DeleteSelectedRowsResult,
   EditApi,
   EditSessionMode,
+  SessionType,
   UndoRowChangeResult,
 } from "@vuu-ui/vuu-data-types";
 import type { RpcResult, VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
@@ -490,7 +491,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     return result;
   }
 
-  begin(copyOption: CopyOption = "All"): Promise<DataSource> {
+  begin(copyOption: CopyOption = "All", sessionType: SessionType = "edit"): Promise<DataSource> {
     return this.#enqueue(async () => {
       if (
         this.#lifecycle.status === "active" ||
@@ -519,7 +520,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
             ? await sourceDataSource?.beginEditSession?.(
                 toEditSessionMode(copyOption),
               )
-            : await sourceDataSource?.createSessionDataSource?.(copyOption);
+            : await sourceDataSource?.createSessionDataSource?.(copyOption, sessionType);
         if (!sessionDataSource) {
           throw new Error(
             `[EditSession] datasource does not support ${this.#editSessionApi}`,

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -203,9 +203,9 @@ describe("EditSession lifecycle", () => {
     expect(editSession.lifecycle.status).toBe("active");
   });
 
-  it("forwards copy options and defaults to All", async () => {
+  it("forwards copy options and defaults to All, defaults sessionType to edit", async () => {
     await editSession.begin();
-    expect(createSession).toHaveBeenCalledWith("All");
+    expect(createSession).toHaveBeenCalledWith("All", "edit");
 
     await editSession.end();
     createSession = vi.fn(
@@ -214,7 +214,12 @@ describe("EditSession lifecycle", () => {
     const selectedDataSource = new MockDataSource(endEdit, createSession);
     editSession = new EditSession(selectedDataSource);
     await editSession.begin("Selected");
-    expect(createSession).toHaveBeenCalledWith("Selected");
+    expect(createSession).toHaveBeenCalledWith("Selected", "edit");
+  });
+
+  it("forwards sessionType to createSessionDataSource", async () => {
+    await editSession.begin("Empty", "import");
+    expect(createSession).toHaveBeenCalledWith("Empty", "import");
   });
 
   it("keeps a failed end session active and allows retry", async () => {

--- a/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
+++ b/vuu-ui/packages/vuu-data-local/src/array-data-source/array-data-source.ts
@@ -628,6 +628,16 @@ export class ArrayDataSource
       filterSpec: { filterStruct },
     } = combineFilters(this._config);
     if (filterStruct) {
+      // When a dataMap exists use actual raw-data positions so the predicate
+      // remains correct after processNewColumns rebuilds #columnMap.
+      if (this.dataMap) {
+        const { count: offset } = metadataKeys;
+        const actualColumnMap: ColumnMap = {};
+        for (const [col, idx] of Object.entries(this.dataMap)) {
+          actualColumnMap[col] = offset + (idx as number);
+        }
+        return filterPredicate(actualColumnMap, filterStruct);
+      }
       return filterPredicate(this.#columnMap, filterStruct);
     } else {
       throw Error("filter must include filterStruct");

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -2,6 +2,7 @@ import type {
   CopyOption,
   DataSource,
   DataSourceBase,
+  SessionType,
   DataSourceCallbackMessage,
   DataSourceConstructorProps,
   DataSourceStatus,
@@ -686,11 +687,12 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
 
   async createSessionDataSource(
     copyOption: CopyOption,
+    sessionType: SessionType = "edit",
   ): Promise<VuuDataSource | undefined> {
     const rpcResponse = await this?.rpcRequest?.({
       type: "RPC_REQUEST",
       rpcName: "createSessionTable",
-      params: { copyOption },
+      params: { copyOption, sessionType },
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -12,6 +12,7 @@ import type {
   DeleteRowMode,
   CopyOption,
   EditSessionMode,
+  SessionType,
 } from "@vuu-ui/vuu-data-types";
 import type {
   LinkDescriptorWithLabel,
@@ -169,17 +170,22 @@ export class TickingArrayDataSource extends ArrayDataSource {
 
   async createSessionDataSource(
     copyOption: CopyOption,
+    sessionType: SessionType = "edit",
   ): Promise<DataSourceBase<DataSourceRowWithBigint> | undefined> {
     const rpcResponse = await this?.rpcRequest?.({
       type: "RPC_REQUEST",
       rpcName: "createSessionTable",
-      params: { copyOption },
+      params: { copyOption, sessionType },
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
-      const columns = this.config.columns.includes("vuuAction")
+      const baseColumns = this.config.columns.includes("vuuAction")
         ? this.config.columns
         : this.config.columns.concat("vuuAction");
+      const columns =
+        sessionType === "import" && !baseColumns.includes("vuuRowNum")
+          ? baseColumns.concat("vuuRowNum")
+          : baseColumns;
       const sessionDataSource = this.#vuuModule?.createDataSource(
         sessionTable.table,
         sessionTable.table,
@@ -237,10 +243,17 @@ export class TickingArrayDataSource extends ArrayDataSource {
   addRow = async (
     rowData: Record<string, VuuRowDataItemType> = {},
   ): Promise<true | string> => {
+    const keyValue = rowData[this.tableSchema.key];
+    const key =
+      keyValue !== undefined
+        ? String(keyValue)
+        : "vuuRowNum" in rowData
+          ? String(rowData.vuuRowNum)
+          : undefined;
     const response = await this.rpcRequest?.({
       type: "RPC_REQUEST",
       rpcName: "addRow",
-      params: { key: rowData[this.tableSchema.key] as string, data: rowData },
+      params: { key, data: rowData },
     });
     if (isRpcSuccess(response)) {
       return true;

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -7,6 +7,7 @@ import type {
   DeleteRowMode,
   EditSessionMode,
   CopyOption,
+  SessionType,
   TableSchema,
 } from "@vuu-ui/vuu-data-types";
 import type {
@@ -669,7 +670,7 @@ export abstract class VuuModule<T extends string = string>
   private createSessionTableService: ServiceHandler = async (rpcRequest) => {
     if (isCreateSessionTableRpcRequest(rpcRequest)) {
       const { viewPortId } = rpcRequest.context;
-      const { copyOption } = rpcRequest.params;
+      const { copyOption, sessionType } = rpcRequest.params;
       const subscription = this.getSubscriptionByViewport(viewPortId);
       const { dataSource } = subscription;
       const { table: vuuTable } = dataSource;
@@ -683,6 +684,7 @@ export abstract class VuuModule<T extends string = string>
               sessionTableName,
               copyOption,
               dataSource as TickingArrayDataSource,
+              sessionType,
             );
             this.#sessionTableMap[sessionTableName] = sessionTable;
             this.#sessionSourceTableMap[sessionTableName] = vuuTable.table as T;
@@ -770,9 +772,9 @@ export abstract class VuuModule<T extends string = string>
           errorMessage: `addRow: no active session table for viewport ${viewPortId}`,
         };
       }
-      const { data } = rpcRequest.params;
+      const { data, key } = rpcRequest.params;
       const keyColumn = sessionTable.schema.key;
-      const rowKey = data[keyColumn] ?? uuid();
+      const rowKey = data[keyColumn] ?? key ?? uuid();
       const rowData = { ...data, [keyColumn]: rowKey };
 
       const columnMap = sessionTable.map;
@@ -919,6 +921,7 @@ export abstract class VuuModule<T extends string = string>
     sessionTableName: string,
     editSessionMode: EditSessionMode | CopyOption,
     dataSource: TickingArrayDataSource,
+    sessionType?: SessionType,
   ) {
     if (editSessionMode === "All" || editSessionMode.endsWith("all-rows")) {
       return this.createSessionTableWithAllRows(sourceTable, sessionTableName);
@@ -935,7 +938,7 @@ export abstract class VuuModule<T extends string = string>
       editSessionMode === "Empty" ||
       editSessionMode === "empty-session-table"
     ) {
-      return this.createEmptySessionTable(sourceTable, sessionTableName);
+      return this.createEmptySessionTable(sourceTable, sessionTableName, sessionType);
     } else {
       throw Error(
         `[VuuModule] createSessionTable, invalid editSessionMode ${editSessionMode}`,
@@ -958,6 +961,7 @@ export abstract class VuuModule<T extends string = string>
   protected createEmptySessionTable(
     { schema }: Table,
     sessionTableName: string,
+    sessionType?: SessionType,
   ) {
     // Override schema.table.table so isSessionTable() returns true for this session.
     // sessionTableSchema adds the vuuMsg column, consistent with all other session tables.
@@ -965,6 +969,11 @@ export abstract class VuuModule<T extends string = string>
       ...schema,
       table: { ...schema.table, table: sessionTableName },
     });
+    if (sessionType === "import") {
+      (sessionSchema.columns as { name: string; serverDataType: string }[]).push(
+        { name: "vuuRowNum", serverDataType: "int" },
+      );
+    }
     return new Table(
       sessionSchema,
       [],

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -307,7 +307,7 @@ describe("createSessionDataSource", () => {
     data: { table: { module: "TEST", table: "session-xyz" } },
   };
 
-  it("dispatches createSessionTable RPC with copyOption 'All'", async () => {
+  it("dispatches createSessionTable RPC with copyOption 'All' and default sessionType 'edit'", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
     await ds.createSessionDataSource?.("All");
@@ -315,12 +315,12 @@ describe("createSessionDataSource", () => {
       expect.objectContaining({
         type: "RPC_REQUEST",
         rpcName: "createSessionTable",
-        params: { copyOption: "All" },
+        params: { copyOption: "All", sessionType: "edit" },
       }),
     );
   });
 
-  it("dispatches createSessionTable RPC with copyOption 'Selected'", async () => {
+  it("dispatches createSessionTable RPC with copyOption 'Selected' and default sessionType 'edit'", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
     await ds.createSessionDataSource?.("Selected");
@@ -328,12 +328,12 @@ describe("createSessionDataSource", () => {
       expect.objectContaining({
         type: "RPC_REQUEST",
         rpcName: "createSessionTable",
-        params: { copyOption: "Selected" },
+        params: { copyOption: "Selected", sessionType: "edit" },
       }),
     );
   });
 
-  it("dispatches createSessionTable RPC with copyOption 'Empty'", async () => {
+  it("dispatches createSessionTable RPC with copyOption 'Empty' and default sessionType 'edit'", async () => {
     const ds = createDataSource();
     vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
     await ds.createSessionDataSource?.("Empty");
@@ -341,7 +341,33 @@ describe("createSessionDataSource", () => {
       expect.objectContaining({
         type: "RPC_REQUEST",
         rpcName: "createSessionTable",
-        params: { copyOption: "Empty" },
+        params: { copyOption: "Empty", sessionType: "edit" },
+      }),
+    );
+  });
+
+  it("passes sessionType 'import' to the RPC request", async () => {
+    const ds = createDataSource();
+    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
+    await ds.createSessionDataSource?.("Empty", "import");
+    expect(ds.rpcRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RPC_REQUEST",
+        rpcName: "createSessionTable",
+        params: { copyOption: "Empty", sessionType: "import" },
+      }),
+    );
+  });
+
+  it("passes sessionType 'export' to the RPC request", async () => {
+    const ds = createDataSource();
+    vi.mocked(ds.rpcRequest).mockResolvedValue(sessionSuccess);
+    await ds.createSessionDataSource?.("All", "export");
+    expect(ds.rpcRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RPC_REQUEST",
+        rpcName: "createSessionTable",
+        params: { copyOption: "All", sessionType: "export" },
       }),
     );
   });

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -585,6 +585,9 @@ export declare type DataSourceSuspenseProps = {
 /** Controls which source rows are copied into a newly created session table. */
 export declare type CopyOption = "All" | "Empty" | "Selected";
 
+/** Controls the intended purpose of a created session table. */
+export declare type SessionType = "edit" | "import" | "export";
+
 /**
  * Wire-level values used by the legacy beginEditSession menu/server service.
  * Client edit lifecycles use CopyOption with createSessionDataSource instead.
@@ -618,6 +621,7 @@ export interface EditApi<
    */
   createSessionDataSource?: (
     copyOption: CopyOption,
+    sessionType?: SessionType,
   ) => Promise<DataSource<T> | undefined>;
   /**
    * Legacy session creation API. Prefer createSessionDataSource for new servers.

--- a/vuu-ui/packages/vuu-filter-parser/src/filter-evaluation-utils.ts
+++ b/vuu-ui/packages/vuu-filter-parser/src/filter-evaluation-utils.ts
@@ -91,6 +91,8 @@ export function filterPredicate(
         return testDataRowInclude(columnMapOrFilter);
       case "=":
         return testDataRowEQ(columnMapOrFilter);
+      case "!=":
+        return testDataRowNE(columnMapOrFilter);
       case ">":
         return testDataRowGT(columnMapOrFilter);
       case ">=":
@@ -120,6 +122,8 @@ export function filterPredicate(
         return testInclude(columnMapOrFilter, filter);
       case "=":
         return testEQ(columnMapOrFilter, filter);
+      case "!=":
+        return testNE(columnMapOrFilter, filter);
       case ">":
         return testGT(columnMapOrFilter, filter);
       case ">=":
@@ -173,10 +177,27 @@ const testEQ = (
   }
 };
 
+const testNE = (
+  columnMap: ColumnMap,
+  filter: SingleValueFilterClause,
+): FilterPredicate => {
+  if (isScaledDecimalFilterClause(filter)) {
+    return (row) => row[columnMap[filter.column]] !== filter.value.asLong;
+  } else {
+    return (row) => row[columnMap[filter.column]] !== filter.value;
+  }
+};
+
 const testDataRowEQ = (
   filter: SingleValueFilterClause,
 ): DataRowFilterPredicate => {
   return (row) => row[filter.column] === filter.value;
+};
+
+const testDataRowNE = (
+  filter: SingleValueFilterClause,
+): DataRowFilterPredicate => {
+  return (row) => row[filter.column] !== filter.value;
 };
 
 const testGT = (

--- a/vuu-ui/packages/vuu-filter-parser/src/filter-evaluation-utils.ts
+++ b/vuu-ui/packages/vuu-filter-parser/src/filter-evaluation-utils.ts
@@ -112,7 +112,8 @@ export function filterPredicate(
       case "or":
         return testDataRowOR(columnMapOrFilter as MultiClauseFilter<"or">);
       default:
-        console.log(`unrecognized filter type ${columnMapOrFilter.op}`);
+        const unreachable: never = columnMapOrFilter;
+        console.log('unrecognized filter type', unreachable);
         return () => true;
     }
   } else if (filter) {
@@ -143,7 +144,8 @@ export function filterPredicate(
       case "or":
         return testOR(columnMapOrFilter, filter as MultiClauseFilter<"or">);
       default:
-        console.log(`unrecognized filter type ${filter.op}`);
+        const unreachable: never = filter;
+        console.log('unrecognized filter type', unreachable);
         return () => true;
     }
   } else {

--- a/vuu-ui/packages/vuu-protocol-types/index.d.ts
+++ b/vuu-ui/packages/vuu-protocol-types/index.d.ts
@@ -628,6 +628,7 @@ export declare type DeleteSelectedRowsRpcServiceRequest = {
  */
 export declare type CreateSessionTableParams = {
   copyOption: "All" | "Empty" | "Selected";
+  sessionType?: "edit" | "import" | "export";
 };
 export declare type CreateSessionTableRpcServiceRequest = {
   context: ViewportRpcContext;

--- a/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-upload/CsvUpload.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-upload/CsvUpload.playwright.test.tsx
@@ -86,6 +86,17 @@ test.describe("Given a CsvUpload with the instruments schema", () => {
     await expect(page.locator(".vuuCsvUpload-dropZone")).toContainText(
       "Your file contains errors",
     );
+    const errorItems = page.locator(".vuuCsvUpload-errorItem");
+    await expect(errorItems).toHaveCount(3);
+    await expect(errorItems.nth(0)).toHaveText(
+      "CSV must include key column 'isin'.",
+    );
+    await expect(errorItems.nth(1)).toHaveText(
+      "Column symbol is not present in table schema.",
+    );
+    await expect(errorItems.nth(2)).toHaveText(
+      "Column name is not present in table schema.",
+    );
     await expect(page.locator("button", { hasText: "Import" })).toBeDisabled();
   });
 });

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/CsvUpload.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/CsvUpload.tsx
@@ -146,7 +146,16 @@ export const CsvUpload = (props: CsvUploadProps) => {
         {validation && validation.errors.length > 0 ? (
           <>
             <div>Your file contains errors</div>
-            <div> Please rectify and reupload</div>
+            <ul className={`${classBase}-errorList`}>
+              {validation.errors
+                .filter((e) => e.column in validation.errorMap.fileErrors)
+                .map((error, i) => (
+                  <li className={`${classBase}-errorItem`} key={i}>
+                    {error.message}
+                  </li>
+                ))}
+            </ul>
+            <div>Please rectify and reupload</div>
           </>
         ) : (
           <div>Drop a file here or</div>

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
@@ -29,7 +29,7 @@ import { CsvUpload } from "@vuu-ui/vuu-table-extras";
 
 | Prop | Type | Description |
 |---|---|---|
-| `dataSource` | `DataSource` | **Required.** The Vuu data source for the target table. Direct imports require `createSessionDataSource`; the returned session datasource must support `addRow` and `endEditSession`. |
+| `dataSource` | `DataSource` | **Required.** The Vuu data source for the target table. Must support `createSessionDataSource` (used internally with `sessionType: "import"`), `addRow`, and `endEditSession`. |
 | `embedded` | `boolean` | Renders the upload content and actions without its own `Dialog`, for use inside an existing modal. Defaults to `false`. |
 | `importMode` | `"direct" \| "preview"` | Both modes create and populate an `EditSession`. `"direct"` commits it when Import is pressed; `"preview"` returns the live session through `onPreview` so the caller can edit or delete rows before ending it. Defaults to `"direct"`. |
 | `maxRows` | `number` | Maximum number of data rows permitted in the CSV. Defaults to `25000`. |
@@ -44,7 +44,7 @@ import { CsvUpload } from "@vuu-ui/vuu-table-extras";
 | `onError` | `(result: CsvUploadErrorResult \| undefined) => void` | Fired when any error occurs. Called with `undefined` to clear a previous error. |
 | `onCancel` | `() => void` | Fired when the Cancel button is clicked. |
 | `onClose` | `() => void` | Fired after a successful import completes (i.e. the Import button was clicked and the session committed). |
-| `children` | `ReactNode` | Optional children rendered inside the dialog content area, below the drop zone. Useful for displaying validation error tables or status messages. |
+| `children` | `ReactNode` | Optional children rendered inside the dialog content area, below the drop zone. Typically used to display a read-only error table — see [Displaying validation errors](#displaying-validation-errors). |
 
 ---
 
@@ -173,6 +173,64 @@ type CsvParseOptions = {
   // the row is rejected with UNQUOTED_VALUE.
 };
 ```
+
+---
+
+## Import session table columns
+
+When the component opens a session for CSV import it requests a session table of type `"import"`. The server adds two extra columns to the schema on top of the source table columns:
+
+| Column | Type | Purpose |
+|---|---|---|
+| `vuuMsg` | `string` | Validation error message for this row. Empty string when the row is valid. |
+| `vuuRowNum` | `int` | 1-based row number from the original CSV file (including the header row, so data starts at 2). |
+
+Row payloads sent to `addRow` differ by validity:
+
+- **Valid rows** — full column data plus `vuuRowNum` and `vuuMsg: ""`.
+- **Error rows** — only `{ vuuRowNum, vuuMsg }` (no column data); the session table key is set to the string value of `vuuRowNum`.
+
+On `endEditSession(save: true)` the server skips any row where `vuuMsg` is non-empty, so error rows are never committed to the source table.
+
+---
+
+## Displaying validation errors
+
+Use the `children` prop together with `onImportSessionStarted` to render an inline error table. The session datasource already contains both valid and error rows; apply a `vuuMsg != ""` filter to show only error rows:
+
+```tsx
+const [sessionDataSource, setSessionDataSource] = useState<DataSource | undefined>();
+
+const handleImportSessionStarted = useCallback((sessionDs: DataSource) => {
+  sessionDs.filter = { filter: 'vuuMsg != ""' };
+  setSessionDataSource(sessionDs);
+}, []);
+
+const handleImportSessionEnded = useCallback(() => {
+  setSessionDataSource(undefined);
+}, []);
+
+const errorTableConfig: TableConfig = {
+  columns: [
+    { name: "vuuRowNum", label: "Row",   width: 80,  serverDataType: "int" },
+    { name: "vuuMsg",    label: "Error", width: 400, serverDataType: "string" },
+  ],
+};
+
+<CsvUpload
+  dataSource={dataSource}
+  onImportSessionStarted={handleImportSessionStarted}
+  onImportSessionEnded={handleImportSessionEnded}
+>
+  {sessionDataSource ? (
+    <div style={{ height: 200 }}>
+      <Table config={errorTableConfig} dataSource={sessionDataSource} />
+    </div>
+  ) : null}
+</CsvUpload>
+```
+
+The `Table` is a virtualized component and requires an explicit height on its container to render rows.
 
 ---
 

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/parse/csv-constants.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/parse/csv-constants.ts
@@ -1,2 +1,3 @@
 export const CSV_HEADER_ROW_NUMBER = 1;
 export const CSV_FIRST_DATA_ROW_NUMBER = 2;
+export const MAX_ROWS_IN_CSV = 10000;

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/parse/csv-schema-validation.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/parse/csv-schema-validation.ts
@@ -13,7 +13,7 @@ import type {
   CsvParseError,
 } from "./csv-errors";
 import type { CsvParseResult } from "./csv-parse";
-import { CSV_FIRST_DATA_ROW_NUMBER } from "./csv-constants";
+import { CSV_FIRST_DATA_ROW_NUMBER, MAX_ROWS_IN_CSV } from "./csv-constants";
 import type { VuuColumnDataType } from "@vuu-ui/vuu-protocol-types";
 import type { DataValueTypeSimple } from "@vuu-ui/vuu-data-types";
 
@@ -36,8 +36,6 @@ export type CsvValidationResult = {
 export type CsvValidationOptions = {
   maxRows?: number;
 };
-
-const MAX_ROWS_IN_CSV = 25000;
 
 export const validateCsvAgainstSchema = (
   parsed: CsvParseResult,
@@ -65,7 +63,7 @@ export const validateCsvAgainstSchema = (
         errorState,
         column,
         CsvValidationErrorEnum.UNKNOWN_COLUMN,
-        "Column is not present in table schema.",
+        `Column ${column} is not present in table schema.`,
         column,
       );
     }

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
@@ -189,7 +189,7 @@ export const useCsvUpload = ({
           return false;
         }
         try {
-          const payload = { ...rowData, rowNum, vuuMsg };
+          const payload = vuuMsg ? { vuuRowNum: rowNum, vuuMsg } : { ...rowData, vuuRowNum: rowNum, vuuMsg };
           const result = await editSession.addRow(payload);
           if (isRpcError(result)) {
             throw Error(result.errorMessage);
@@ -211,7 +211,7 @@ export const useCsvUpload = ({
   );
 
   const beginEditSession = useCallback(async () => {
-    const sessionDataSource = await editSession.begin("Empty");
+    const sessionDataSource = await editSession.begin("Empty", "import");
 
     const sessionVuuTable = sessionDataSource?.table;
     if (

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvUpload.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvUpload.examples.tsx
@@ -1,7 +1,12 @@
-import { CsvUpload } from "@vuu-ui/vuu-table-extras";
+import {
+  CsvUpload,
+} from "@vuu-ui/vuu-table-extras";
 import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
 import { useCallback, useMemo, useState } from "react";
 import { Button } from "@salt-ds/core";
+import { LocalDataSourceProvider, simulModule } from "@vuu-ui/vuu-data-test";
+import { Table } from "@vuu-ui/vuu-table";
+import type { TableConfig } from "@vuu-ui/vuu-table-types";
 
 const mockSchema: TableSchema = {
   columns: [
@@ -91,3 +96,58 @@ export const CsvUploadWithInstrumentsSchema = () => {
   const dataSource = useMemo(() => createInstrumentsMockDataSource(), []);
   return <CsvUpload dataSource={dataSource} />;
 };
+
+const CsvUploadWithErrorsOnlyPreviewContent = () => {
+  const dataSource = useMemo(
+    () => simulModule.createDataSource("instruments"),
+    [],
+  );
+  const [sessionDataSource, setSessionDataSource] = useState<
+    DataSource | undefined
+  >();
+  const [uploadOpen, setUploadOpen] = useState(true);
+
+  const handleImportSessionStarted = useCallback((sessionDs: DataSource) => {
+    sessionDs.filter = { filter: 'vuuMsg != ""' };
+    setSessionDataSource(sessionDs);
+  }, []);
+
+  const handleImportSessionEnded = useCallback(() => {
+    setSessionDataSource(undefined);
+  }, []);
+
+  const errorTableConfig = useMemo<TableConfig>(
+    () => ({
+      columns: [
+        { name: "vuuRowNum", label: "Row", width: 80, serverDataType: "int" },
+        { name: "vuuMsg", label: "Error", width: 400, serverDataType: "string" },
+      ],
+    }),
+    [],
+  );
+
+  return (
+    <div style={{ padding: 12 }}>
+      <CsvUpload
+        dataSource={dataSource}
+        onCancel={() => setUploadOpen(false)}
+        onClose={() => setUploadOpen(false)}
+        onImportSessionStarted={handleImportSessionStarted}
+        onImportSessionEnded={handleImportSessionEnded}
+        open={uploadOpen}
+      >
+        {sessionDataSource ? (
+          <div style={{ height: 200 }}>
+            <Table config={errorTableConfig} dataSource={sessionDataSource} />
+          </div>
+        ) : null}
+      </CsvUpload>
+    </div>
+  );
+};
+
+export const CsvUploadWithErrorsOnlyPreview = () => (
+  <LocalDataSourceProvider>
+    <CsvUploadWithErrorsOnlyPreviewContent />
+  </LocalDataSourceProvider>
+);


### PR DESCRIPTION
- Add SessionType ("edit"|"import"|"export") type; thread sessionType through EditSession.begin → createSessionDataSource → createSessionTable RPC
- Import sessions get vuuRowNum column in session table schema at creation time
- Error rows sent to addRow as {vuuRowNum, vuuMsg} only; key falls back to vuuRowNum
- Fix: filterPredicate had no "!=" case — default returned () => true, passing all rows
- Fix: ArrayDataSource.getFilterPredicate uses dataMap positions to prevent wrong column evaluation after processNewColumns rebuilds #columnMap on restricted subscribe
- Add CsvUploadWithErrorsOnlyPreview showcase example