### PR TITLE
Separate connection management from authentication

### DIFF
--- a/vuu-ui/packages/core/docs/auth.md
+++ b/vuu-ui/packages/core/docs/auth.md
@@ -1,3 +1,6 @@
 # @vuu-ui/core authentication
 
 Authentication contracts and React integration for VUU UI applications.
+
+Connection lifecycle, connection sharing, and VUU session resolution live in
+`src/connection-management`.

--- a/vuu-ui/packages/core/docs/portal-design.md
+++ b/vuu-ui/packages/core/docs/portal-design.md
@@ -40,6 +40,8 @@ module instead of implicitly using the portal host's connection.
 ```text
 core/
 |-- src/
+|   |-- auth/
+|   |-- connection-management/
 |   |-- portal-header/
 |   |-- portal-nav/
 |   |-- portal-shell/

--- a/vuu-ui/packages/core/src/auth/AuthenticationProvider.tsx
+++ b/vuu-ui/packages/core/src/auth/AuthenticationProvider.tsx
@@ -24,7 +24,7 @@ import type {
 import {
   vuuConnectionRegistry,
   type VuuConnectionRegistry,
-} from "./VuuConnectionRegistry";
+} from "../connection-management/VuuConnectionRegistry";
 import type { VuuAuthTarget, VuuSession } from "./VuuTokenExchange";
 
 export class AuthenticationConfigurationError extends Error {

--- a/vuu-ui/packages/core/src/auth/VuuAuthHandler.ts
+++ b/vuu-ui/packages/core/src/auth/VuuAuthHandler.ts
@@ -1,6 +1,6 @@
 import type { AuthConfig } from "./AuthConfig";
 import type { AuthHandler } from "./AuthHandler";
-import { VUU_AUTH_TOKEN_STORAGE_KEY } from "./DirectVuuSessionResolver";
+import { VUU_AUTH_TOKEN_STORAGE_KEY } from "../connection-management/DirectVuuSessionResolver";
 import { parseVuuUserFromToken } from "./VuuUser";
 
 export class VuuAuthHandler implements AuthHandler {

--- a/vuu-ui/packages/core/src/auth/index.ts
+++ b/vuu-ui/packages/core/src/auth/index.ts
@@ -25,13 +25,6 @@ export type {
 export { KeycloakAuthHandler } from "./KeycloakAuthHandler";
 export { VuuAuthHandler } from './VuuAuthHandler';
 export {
-  DirectVuuSessionResolver,
-  VUU_AUTH_TOKEN_STORAGE_KEY,
-} from "./DirectVuuSessionResolver";
-export {
-  VuuConnectionRegistry, vuuConnectionRegistry, type VuuConnectionRegistryOptions
-} from "./VuuConnectionRegistry";
-export {
   authenticateWithUsernamePassword,
   VuuLoginHandler
 } from "./VuuLoginHandler";
@@ -39,10 +32,6 @@ export {
   exchangeVuuToken, VuuTokenExchangeError, type VuuAuthTarget,
   type VuuSession
 } from "./VuuTokenExchange";
-export {
-  IdentityTokenSessionResolver,
-  type VuuSessionResolver,
-} from "./VuuSessionResolver";
 export {
   parseVuuUserFromToken,
   type VuuUser

--- a/vuu-ui/packages/core/src/connection-management/DirectVuuSessionResolver.ts
+++ b/vuu-ui/packages/core/src/connection-management/DirectVuuSessionResolver.ts
@@ -1,6 +1,6 @@
-import type { AuthHandler } from "./AuthHandler";
-import { parseVuuUserFromToken } from "./VuuUser";
-import type { VuuAuthTarget } from "./VuuTokenExchange";
+import type { AuthHandler } from "../auth/AuthHandler";
+import { parseVuuUserFromToken } from "../auth/VuuUser";
+import type { VuuAuthTarget } from "../auth/VuuTokenExchange";
 import type { VuuSessionResolver } from "./VuuSessionResolver";
 
 export const VUU_AUTH_TOKEN_STORAGE_KEY = "vuu-auth-token";

--- a/vuu-ui/packages/core/src/connection-management/VuuConnectionRegistry.ts
+++ b/vuu-ui/packages/core/src/connection-management/VuuConnectionRegistry.ts
@@ -3,12 +3,12 @@ import {
   type ConnectionStatus,
   type VuuConnectionResult,
 } from "@vuu-ui/vuu-data-remote";
-import type { AuthHandler } from "./AuthHandler";
+import type { AuthHandler } from "../auth/AuthHandler";
 import {
   exchangeVuuToken,
   type VuuAuthTarget,
   type VuuSession,
-} from "./VuuTokenExchange";
+} from "../auth/VuuTokenExchange";
 import {
   IdentityTokenSessionResolver,
   type VuuSessionResolver,

--- a/vuu-ui/packages/core/src/connection-management/VuuSessionResolver.ts
+++ b/vuu-ui/packages/core/src/connection-management/VuuSessionResolver.ts
@@ -1,9 +1,9 @@
-import type { AuthHandler } from "./AuthHandler";
+import type { AuthHandler } from "../auth/AuthHandler";
 import {
   exchangeVuuToken,
   type VuuAuthTarget,
   type VuuSession,
-} from "./VuuTokenExchange";
+} from "../auth/VuuTokenExchange";
 
 export interface VuuSessionResolver {
   resolve(authHandler: AuthHandler, target: VuuAuthTarget): Promise<VuuSession>;

--- a/vuu-ui/packages/core/src/connection-management/index.ts
+++ b/vuu-ui/packages/core/src/connection-management/index.ts
@@ -1,0 +1,13 @@
+export {
+  DirectVuuSessionResolver,
+  VUU_AUTH_TOKEN_STORAGE_KEY,
+} from "./DirectVuuSessionResolver";
+export {
+  VuuConnectionRegistry,
+  vuuConnectionRegistry,
+  type VuuConnectionRegistryOptions,
+} from "./VuuConnectionRegistry";
+export {
+  IdentityTokenSessionResolver,
+  type VuuSessionResolver,
+} from "./VuuSessionResolver";

--- a/vuu-ui/packages/core/src/index.ts
+++ b/vuu-ui/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./auth";
+export * from "./connection-management";
 export { DataContext } from "./context-definitions/DataContext";
 export {
   DataProvider,

--- a/vuu-ui/packages/core/test/auth/VuuAuthHandler.test.ts
+++ b/vuu-ui/packages/core/test/auth/VuuAuthHandler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { DirectVuuSessionResolver } from "../../src/auth/DirectVuuSessionResolver";
+import { DirectVuuSessionResolver } from "../../src/connection-management/DirectVuuSessionResolver";
 import { VuuAuthHandler } from "../../src/auth/VuuAuthHandler";
 
 const config = {

--- a/vuu-ui/packages/core/test/connection-management/VuuConnectionRegistry.test.ts
+++ b/vuu-ui/packages/core/test/connection-management/VuuConnectionRegistry.test.ts
@@ -3,7 +3,7 @@ import type { AuthHandler } from "../../src/auth/AuthHandler";
 import {
   VuuConnectionRegistry,
   type VuuConnectionClient,
-} from "../../src/auth/VuuConnectionRegistry";
+} from "../../src/connection-management/VuuConnectionRegistry";
 import type {
   VuuAuthTarget,
   VuuSession,


### PR DESCRIPTION
## Summary
- add a dedicated `connection-management` folder to `@vuu-ui/core`
- move the VUU connection registry and session resolvers out of `auth`
- preserve existing package-root exports and update internal imports, tests, and documentation

## Validation
- core Vitest suite: 12 tests passed
- `@vuu-ui/core` build