### PR TITLE
Fix session action tests after column rename

### DIFF
--- a/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
@@ -146,7 +146,7 @@ describe("VuuDataSource", () => {
           await dataSource.createSessionDataSource("Selected");
 
         expect(rpcRequest).toHaveBeenCalledWith({
-          params: { copyOption: "Selected" },
+          params: { copyOption: "Selected", sessionType: "edit" },
           rpcName: "createSessionTable",
           type: "RPC_REQUEST",
         });

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -43,7 +43,7 @@ function createDataSource() {
 }
 
 describe("sessionTableSchema", () => {
-  it("adds vuu_action as a string session-only column", () => {
+  it("adds vuuAction as a string session-only column", () => {
     const sessionSchema = sessionTableSchema({
       ...schema,
       columns: schema.columns.slice(0, 2),
@@ -53,7 +53,7 @@ describe("sessionTableSchema", () => {
       { name: "id", serverDataType: "string" },
       { name: "name", serverDataType: "string" },
       { name: "vuuMsg", serverDataType: "string" },
-      { name: "vuu_action", serverDataType: "string" },
+      { name: "vuuAction", serverDataType: "string" },
     ]);
   });
 
@@ -64,7 +64,7 @@ describe("sessionTableSchema", () => {
       sessionSchema.columns.filter(({ name }) => name === "vuuMsg"),
     ).toHaveLength(1);
     expect(
-      sessionSchema.columns.filter(({ name }) => name === "vuu_action"),
+      sessionSchema.columns.filter(({ name }) => name === "vuuAction"),
     ).toHaveLength(1);
   });
 
@@ -79,7 +79,7 @@ describe("sessionTableSchema", () => {
       sessionTableRow(["row-001", "Alice", "", ""], {
         ...schema,
         columns: schema.columns.concat({
-          name: "vuu_action",
+          name: "vuuAction",
           serverDataType: "string",
         }),
       }),

--- a/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/VuuModule.EditActions.test.ts
@@ -65,13 +65,13 @@ describe("VuuModule edit actions", () => {
     await sessionDataSource.deleteRow("row-002", "soft");
 
     expect(
-      sessionTable.findByKey("row-001")?.[sessionTable.map.vuu_action],
+      sessionTable.findByKey("row-001")?.[sessionTable.map.vuuAction],
     ).toBe("editCell");
     expect(
-      sessionTable.findByKey("row-002")?.[sessionTable.map.vuu_action],
+      sessionTable.findByKey("row-002")?.[sessionTable.map.vuuAction],
     ).toBe("deleteRow");
     expect(
-      sessionTable.findByKey("row-003")?.[sessionTable.map.vuu_action],
+      sessionTable.findByKey("row-003")?.[sessionTable.map.vuuAction],
     ).toBe("addRow");
   });
 
@@ -92,7 +92,7 @@ describe("VuuModule edit actions", () => {
     );
   });
 
-  it("uses vuu_action to undo inserts, edits, and deletes", async () => {
+  it("uses vuuAction to undo inserts, edits, and deletes", async () => {
     await sessionDataSource.editCell("row-001", "name", "Alicia");
     await sessionDataSource.deleteRow("row-002", "soft");
     await sessionDataSource.addRow({ id: "row-003", name: "Carol" });
@@ -105,10 +105,10 @@ describe("VuuModule edit actions", () => {
       "Alice",
     );
     expect(
-      sessionTable.findByKey("row-001")?.[sessionTable.map.vuu_action],
+      sessionTable.findByKey("row-001")?.[sessionTable.map.vuuAction],
     ).toBe("");
     expect(
-      sessionTable.findByKey("row-002")?.[sessionTable.map.vuu_action],
+      sessionTable.findByKey("row-002")?.[sessionTable.map.vuuAction],
     ).toBe("");
     expect(sessionTable.findByKey("row-003")).toBeUndefined();
     expect(insertResult).toEqual({
@@ -154,7 +154,7 @@ describe("VuuModule edit actions", () => {
     expect(sessionTable.findByKey("row-002")?.[sessionTable.map.name]).toBe(
       "Bob",
     );
-    expect(sessionTable.findByKey("row-002")?.[sessionTable.map.vuu_action]).toBe(
+    expect(sessionTable.findByKey("row-002")?.[sessionTable.map.vuuAction]).toBe(
       "deleteRow",
     );
   });

--- a/vuu-ui/packages/vuu-shell/src/left-nav/LeftNav.tsx
+++ b/vuu-ui/packages/vuu-shell/src/left-nav/LeftNav.tsx
@@ -25,7 +25,6 @@ import { LayoutList } from "../workspace-management";
 
 import leftNavCss from "./LeftNav.css";
 import { useFeatures } from "../feature-and-layout-provider";
-import { Button } from "@salt-ds/core";
 
 const classBase = "vuuLeftNav";
 


### PR DESCRIPTION
## Summary
- update session editing tests from the removed `vuu_action` column name to `vuuAction`
- align the tests added on `ui-portal` with the column rename already merged to `main`

## Validation
- `npx vitest run packages/vuu-data-test/test` — 42 tests passed