### PR TITLE
feat(vuu-utils): add CSV export utilities via session table subscription

### DIFF
--- a/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-export/CsvExport.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-export/CsvExport.playwright.test.tsx
@@ -1,0 +1,197 @@
+import { test, expect } from "../../../../../../playwright/fixtures";
+import * as fs from "fs";
+
+test.describe("exportCsvTemplate", () => {
+  test("WHEN triggered THEN a header-only CSV file is downloaded with the correct filename", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportTemplate");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page
+        .locator("button", { hasText: "Download template (all columns)" })
+        .click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("instruments-template.csv");
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("ric");
+    expect(lines[0]).toContain("currency");
+  });
+
+  test("WHEN a column subset is specified THEN the file contains exactly those columns in order", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportTemplate");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download template (ric" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const [header] = content.split("\r\n");
+
+    expect(header).toBe("ric,currency,description,exchange,isin");
+  });
+});
+
+test.describe("exportToCsv", () => {
+  test("WHEN triggered THEN a CSV file is downloaded with the correct filename", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportSimple");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments.csv" }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("instruments.csv");
+  });
+
+  test("WHEN triggered THEN the downloaded file contains a header row and data rows", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportSimple");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments.csv" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+    const [header, ...dataRows] = lines;
+
+    expect(header).toContain("ric");
+    expect(header).toContain("currency");
+    expect(header).toContain("description");
+    expect(dataRows.length).toBeGreaterThan(0);
+  });
+
+  test("WHEN triggered THEN internal session columns are excluded from the output", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportSimple");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments.csv" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const [header] = content.split("\r\n");
+
+    expect(header).not.toContain("vuuMsg");
+    expect(header).not.toContain("vuuAction");
+  });
+
+  test("WHEN row count exceeds maxRows THEN an error message is displayed and no download occurs", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithRowLimit");
+
+    // ensure no spurious download event fires
+    let downloadFired = false;
+    page.on("download", () => { downloadFired = true; });
+
+    await page.locator("button", { hasText: "Export (max 50 rows)" }).click();
+
+    await expect(
+      page.locator("span", { hasText: /Export failed/ }),
+    ).toBeVisible({ timeout: 5000 });
+    expect(downloadFired).toBe(false);
+  });
+
+  test("WHEN copyOption is Selected THEN only selected rows appear in the download", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportAllRows");
+
+    // select the first row via the row checkbox then export selected
+    await page
+      .getByRole("checkbox", { name: "Press space to select row" })
+      .first()
+      .click();
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Export Selected to CSV" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+
+    // header + exactly one data row
+    expect(lines).toHaveLength(2);
+  });
+});
+
+test.describe("ExportColumnDescriptor — exportFormatter and label", () => {
+  test("WHEN columnDescriptors with labels are provided THEN the CSV header uses label overrides", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithFormatters");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments-formatted.csv" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const [header] = content.split("\r\n");
+
+    expect(header).toContain("RIC Code");
+    expect(header).toContain("Bloomberg");
+    expect(header).toContain("Lot Size");
+    expect(header).not.toContain("ric,");
+    expect(header).not.toContain("lotSize");
+  });
+
+  test("WHEN an exportFormatter is provided THEN formatted values appear in the data rows", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithFormatters");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments-formatted.csv" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+    const dataRows = lines.slice(1);
+
+    expect(dataRows.length).toBeGreaterThan(0);
+    // every data row's lotSize column should end with " units"
+    expect(dataRows.every((row) => row.split(",").some((cell) => cell.endsWith(" units")))).toBe(true);
+  });
+});

--- a/vuu-ui/packages/vuu-table-types/index.d.ts
+++ b/vuu-ui/packages/vuu-table-types/index.d.ts
@@ -299,6 +299,8 @@ export interface ColumnDescriptor extends DataValueDescriptor {
    */
   colHeaderContentRenderer?: string;
   colHeaderLabelRenderer?: string;
+  /** Formats a raw value for CSV export; return value is still CSV-escaped. */
+  exportFormatter?: (value: unknown) => string;
   flex?: number;
   /**
    * Only used when the column is included in a grouby clause.

--- a/vuu-ui/packages/vuu-utils/src/export-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/export-utils.ts
@@ -1,0 +1,143 @@
+import type {
+  CopyOption,
+  DataSource,
+  DataSourceCallbackMessage,
+  DataSourceRow,
+  DataSourceSubscribedMessage,
+} from "@vuu-ui/vuu-data-types";
+import { metadataKeys } from "./column-utils";
+import { Range } from "./range-utils";
+
+const EXPORT_EXCLUDED_COLUMNS = new Set(["vuuMsg", "vuuAction", "vuuRowNum"]);
+const MAX_EXPORT_ROWS = 10_000;
+
+const csvCell = (value: unknown): string => {
+  const s = value == null ? "" : String(value);
+  return s.includes(",") || s.includes('"') || s.includes("\n")
+    ? `"${s.replace(/"/g, '""')}`
+    : s;
+};
+
+const triggerCsvDownload = (csv: string, filename: string): void => {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // delay revoke to give the browser time to start the download
+  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+};
+
+/** Downloads a single-row CSV containing only the column headers, for use as an import template. */
+export const exportCsvTemplate = (
+  dataSource: DataSource,
+  filename = "template.csv",
+  excludeColumns: string[] = [],
+  columns?: string[],
+): void => {
+  const schema = dataSource.tableSchema;
+  if (!schema) {
+    throw Error("exportCsvTemplate: tableSchema not available on dataSource");
+  }
+  const schemaColumnNames = new Set(schema.columns.map((col) => col.name));
+  if (columns !== undefined) {
+    const unknown = columns.filter((name) => !schemaColumnNames.has(name));
+    if (unknown.length > 0) {
+      throw Error(`exportCsvTemplate: unknown column(s): ${unknown.join(", ")}`);
+    }
+  }
+  const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
+  const exportCols = columns
+    ? columns.filter((name) => !excluded.has(name))
+    : schema.columns.filter((col) => !excluded.has(col.name)).map((col) => col.name);
+  const header = exportCols.map(csvCell).join(",");
+  triggerCsvDownload(header + "\r\n", filename);
+};
+
+/**
+ * Subscribes to `sessionDataSource` with a full-range request to drain all rows,
+ * serialises them to CSV (excluding internal session columns), then triggers a
+ * browser download. The dataSource is unsubscribed automatically once the download
+ * is initiated.
+ */
+export const exportSessionTableToCsv = (
+  sessionDataSource: DataSource,
+  filename = "export.csv",
+  excludeColumns: string[] = [],
+  onError?: (error: Error) => void,
+  onSuccess?: () => void,
+): void => {
+  const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
+  let exportCols: string[] = [];
+  let colNameToRowIdx: Record<string, number> = {};
+  let totalSize = 0;
+  const collectedRows: DataSourceRow[] = [];
+
+  const handleMessage = (message: DataSourceCallbackMessage): void => {
+    if (message.type === "subscribed") {
+      const { columns } = message as DataSourceSubscribedMessage;
+      exportCols = columns.filter((name) => !excluded.has(name));
+      // column values start after the fixed metadata block
+      colNameToRowIdx = Object.fromEntries(
+        columns.map((name, i) => [name, metadataKeys.count + i]),
+      );
+    } else if (message.type === "viewport-update") {
+      if (message.mode === "size-only") {
+        totalSize = message.size ?? 0;
+        if (totalSize === 0) {
+          sessionDataSource.unsubscribe();
+          return;
+        }
+        if (totalSize > MAX_EXPORT_ROWS) {
+          sessionDataSource.unsubscribe();
+          onError?.(new Error(`exportToCsv: row count ${totalSize} exceeds the ${MAX_EXPORT_ROWS} row limit`));
+          return;
+        }
+        // request all rows in one shot
+        sessionDataSource.range = Range(0, totalSize);
+      } else if (message.mode === "batch" && message.rows) {
+        collectedRows.push(...message.rows);
+        // update totalSize in case it changed between size-only and batch
+        if (message.size !== undefined) {
+          totalSize = message.size;
+        }
+        if (collectedRows.length >= totalSize) {
+          sessionDataSource.unsubscribe();
+          const lines: string[] = [exportCols.map(csvCell).join(",")];
+          for (const row of collectedRows) {
+            lines.push(
+              exportCols.map((c) => csvCell(row[colNameToRowIdx[c]])).join(","),
+            );
+          }
+          triggerCsvDownload(lines.join("\r\n"), filename);
+          onSuccess?.();
+        }
+      }
+    }
+  };
+
+  sessionDataSource.subscribe({ range: Range(0, 0) }, handleMessage);
+}
+
+/**
+ * Creates an export session table from `dataSource` then streams all rows to a CSV download.
+ */
+export const exportToCsv = async (
+  dataSource: DataSource,
+  copyOption: CopyOption = "All",
+  filename = "export.csv",
+  excludeColumns: string[] = [],
+  onError?: (error: Error) => void,
+  onSuccess?: () => void,
+): Promise<void> => {
+  const sessionDataSource =
+    await dataSource.createSessionDataSource?.(copyOption, "export");
+  if (!sessionDataSource) {
+    throw Error("exportToCsv: dataSource does not support createSessionDataSource");
+  }
+  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess);
+}

--- a/vuu-ui/packages/vuu-utils/src/export-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/export-utils.ts
@@ -8,6 +8,13 @@ import type {
 import { metadataKeys } from "./column-utils";
 import { Range } from "./range-utils";
 
+export type ExportColumnDescriptor<TName extends string = string> = {
+  name: TName;
+  /** Override the column name used as the CSV header label. */
+  label?: string;
+  exportFormatter?: (value: unknown) => string;
+};
+
 const EXPORT_EXCLUDED_COLUMNS = new Set(["vuuMsg", "vuuAction", "vuuRowNum"]);
 const MAX_EXPORT_ROWS = 10_000;
 const CHUNK_SIZE = 1_000;
@@ -56,7 +63,7 @@ export const exportCsvTemplate = (
     ? columns.filter((name) => !excluded.has(name))
     : schema.columns.filter((col) => !excluded.has(col.name)).map((col) => col.name);
   const header = exportCols.map(csvCell).join(",");
-  triggerCsvDownload(header + "\r\n", filename);
+  triggerCsvDownload(`${header}\r\n`, filename);
 };
 
 /**
@@ -65,23 +72,37 @@ export const exportCsvTemplate = (
  * browser download. The dataSource is unsubscribed automatically once the download
  * is initiated.
  */
-export const exportSessionTableToCsv = (
+export const exportSessionTableToCsv = <TName extends string = string>(
   sessionDataSource: DataSource,
   filename = "export.csv",
   excludeColumns: string[] = [],
   onError?: (error: Error) => void,
   onSuccess?: () => void,
   maxRows = MAX_EXPORT_ROWS,
+  columnDescriptors?: ExportColumnDescriptor<TName>[],
 ): void => {
   const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
   let exportCols: string[] = [];
   let colNameToRowIdx: Record<string, number> = {};
+  let descriptorMap: Record<string, ExportColumnDescriptor> = {};
   let totalSize = 0;
   const collectedRows: DataSourceRow[] = [];
 
   const handleMessage = (message: DataSourceCallbackMessage): void => {
     if (message.type === "subscribed") {
       const { columns } = message as DataSourceSubscribedMessage;
+      if (columnDescriptors) {
+        const subscribedSet = new Set(columns);
+        const unknown = columnDescriptors
+          .filter((d) => !excluded.has(d.name) && !subscribedSet.has(d.name))
+          .map((d) => d.name);
+        if (unknown.length > 0) {
+          sessionDataSource.unsubscribe();
+          onError?.(new Error(`exportToCsv: unknown column(s) in columnDescriptors: ${unknown.join(", ")}`));
+          return;
+        }
+        descriptorMap = Object.fromEntries(columnDescriptors.map((d) => [d.name, d]));
+      }
       exportCols = columns.filter((name) => !excluded.has(name));
       // column values start after the fixed metadata block
       colNameToRowIdx = Object.fromEntries(
@@ -109,10 +130,16 @@ export const exportSessionTableToCsv = (
         }
         if (collectedRows.length >= totalSize) {
           sessionDataSource.unsubscribe();
-          const lines: string[] = [exportCols.map(csvCell).join(",")];
+          const lines: string[] = [
+            exportCols.map((name) => csvCell(descriptorMap[name]?.label ?? name)).join(","),
+          ];
           for (const row of collectedRows) {
             lines.push(
-              exportCols.map((c) => csvCell(row[colNameToRowIdx[c]])).join(","),
+              exportCols.map((c) => {
+                const raw = row[colNameToRowIdx[c]];
+                const formatter = descriptorMap[c]?.exportFormatter;
+                return csvCell(formatter ? formatter(raw) : raw);
+              }).join(","),
             );
           }
           triggerCsvDownload(lines.join("\r\n"), filename);
@@ -131,7 +158,7 @@ export const exportSessionTableToCsv = (
 /**
  * Creates an export session table from `dataSource` then streams all rows to a CSV download.
  */
-export const exportToCsv = async (
+export const exportToCsv = async <TName extends string = string>(
   dataSource: DataSource,
   copyOption: CopyOption = "All",
   filename = "export.csv",
@@ -139,11 +166,12 @@ export const exportToCsv = async (
   onError?: (error: Error) => void,
   onSuccess?: () => void,
   maxRows = MAX_EXPORT_ROWS,
+  columnDescriptors?: ExportColumnDescriptor<TName>[],
 ): Promise<void> => {
   const sessionDataSource =
     await dataSource.createSessionDataSource?.(copyOption, "export");
   if (!sessionDataSource) {
     throw Error("exportToCsv: dataSource does not support createSessionDataSource");
   }
-  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess, maxRows);
+  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess, maxRows, columnDescriptors);
 }

--- a/vuu-ui/packages/vuu-utils/src/export-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/export-utils.ts
@@ -10,6 +10,7 @@ import { Range } from "./range-utils";
 
 const EXPORT_EXCLUDED_COLUMNS = new Set(["vuuMsg", "vuuAction", "vuuRowNum"]);
 const MAX_EXPORT_ROWS = 10_000;
+const CHUNK_SIZE = 1_000;
 
 const csvCell = (value: unknown): string => {
   const s = value == null ? "" : String(value);
@@ -70,6 +71,7 @@ export const exportSessionTableToCsv = (
   excludeColumns: string[] = [],
   onError?: (error: Error) => void,
   onSuccess?: () => void,
+  maxRows = MAX_EXPORT_ROWS,
 ): void => {
   const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
   let exportCols: string[] = [];
@@ -92,13 +94,13 @@ export const exportSessionTableToCsv = (
           sessionDataSource.unsubscribe();
           return;
         }
-        if (totalSize > MAX_EXPORT_ROWS) {
+        if (totalSize > maxRows) {
           sessionDataSource.unsubscribe();
-          onError?.(new Error(`exportToCsv: row count ${totalSize} exceeds the ${MAX_EXPORT_ROWS} row limit`));
+          onError?.(new Error(`exportToCsv: row count ${totalSize} exceeds the ${maxRows} row limit`));
           return;
         }
-        // request all rows in one shot
-        sessionDataSource.range = Range(0, totalSize);
+        // request rows in chunks for predictable behaviour across local and remote DataSources
+        sessionDataSource.range = Range(0, Math.min(CHUNK_SIZE, totalSize));
       } else if (message.mode === "batch" && message.rows) {
         collectedRows.push(...message.rows);
         // update totalSize in case it changed between size-only and batch
@@ -115,6 +117,9 @@ export const exportSessionTableToCsv = (
           }
           triggerCsvDownload(lines.join("\r\n"), filename);
           onSuccess?.();
+        } else {
+          const nextFrom = collectedRows.length;
+          sessionDataSource.range = Range(nextFrom, Math.min(nextFrom + CHUNK_SIZE, totalSize));
         }
       }
     }
@@ -133,11 +138,12 @@ export const exportToCsv = async (
   excludeColumns: string[] = [],
   onError?: (error: Error) => void,
   onSuccess?: () => void,
+  maxRows = MAX_EXPORT_ROWS,
 ): Promise<void> => {
   const sessionDataSource =
     await dataSource.createSessionDataSource?.(copyOption, "export");
   if (!sessionDataSource) {
     throw Error("exportToCsv: dataSource does not support createSessionDataSource");
   }
-  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess);
+  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess, maxRows);
 }

--- a/vuu-ui/packages/vuu-utils/src/index.ts
+++ b/vuu-ui/packages/vuu-utils/src/index.ts
@@ -13,6 +13,7 @@ export * from "./component-registry";
 export * from "./cookie-utils";
 export * from "./css-utils";
 export * from "./data-utils";
+export * from "./export-utils";
 export * from "./datasource/BaseDataSource";
 export * from "./datasource/datasource-action-utils";
 export * from "./datasource/datasource-filter-utils";

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -216,10 +216,10 @@ export const CsvExportTemplate = () => (
 );
 
 const INSTRUMENTS_EXPORT_DESCRIPTORS: ExportColumnDescriptor[] = [
-  { name: "ric",      label: "RIC Code" },
-  { name: "bbg",      label: "Bloomberg" },
+  { name: "ric", label: "RIC Code" },
+  { name: "bbg", label: "Bloomberg" },
   { name: "currency" },
-  { name: "lotSize",  label: "Lot Size", exportFormatter: (v) => `${v} units` },
+  { name: "lotSize", label: "Lot Size", exportFormatter: (v) => `${v} units` },
   { name: "isin" },
 ];
 

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -1,6 +1,6 @@
 import { getSchema, LocalDataSourceProvider, simulModule } from "@vuu-ui/vuu-data-test";
 import type { DataSource } from "@vuu-ui/vuu-data-types";
-import { exportCsvTemplate, exportToCsv } from "@vuu-ui/vuu-utils";
+import { exportCsvTemplate, exportToCsv, type ExportColumnDescriptor } from "@vuu-ui/vuu-utils";
 import { Button } from "@salt-ds/core";
 import { Table } from "@vuu-ui/vuu-table";
 import type { TableConfig } from "@vuu-ui/vuu-table-types";
@@ -212,5 +212,58 @@ const CsvExportTemplateContent = () => {
 export const CsvExportTemplate = () => (
   <LocalDataSourceProvider>
     <CsvExportTemplateContent />
+  </LocalDataSourceProvider>
+);
+
+const INSTRUMENTS_EXPORT_DESCRIPTORS: ExportColumnDescriptor[] = [
+  { name: "ric",      label: "RIC Code" },
+  { name: "bbg",      label: "Bloomberg" },
+  { name: "currency" },
+  { name: "lotSize",  label: "Lot Size", exportFormatter: (v) => `${v} units` },
+  { name: "isin" },
+];
+
+const CsvExportWithFormattersContent = () => {
+  const [status, setStatus] = useState<string | undefined>();
+
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const handleExport = useCallback(async () => {
+    setStatus(undefined);
+    try {
+      await exportToCsv(
+        dataSource as DataSource,
+        "All",
+        "instruments-formatted.csv",
+        [],
+        (err) => setStatus(`Export failed: ${err.message}`),
+        () => setStatus("Download started"),
+        10_000,
+        INSTRUMENTS_EXPORT_DESCRIPTORS,
+      );
+    } catch (e) {
+      setStatus(`Export failed: ${(e as Error).message}`);
+    }
+  }, [dataSource]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, padding: 12 }}>
+      <Button onClick={handleExport}>Download instruments-formatted.csv</Button>
+      <p style={{ fontSize: 12, margin: 0, color: "#555" }}>
+        lotSize formatted as "X units"; ric/bbg/lotSize/isin use label overrides in header
+      </p>
+      {status ? (
+        <span style={{ fontSize: 12, fontWeight: 600 }}>{status}</span>
+      ) : null}
+    </div>
+  );
+};
+
+export const CsvExportWithFormatters = () => (
+  <LocalDataSourceProvider>
+    <CsvExportWithFormattersContent />
   </LocalDataSourceProvider>
 );

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -117,6 +117,65 @@ export const CsvExportSimple = () => (
   </LocalDataSourceProvider>
 );
 
+const CsvExportWithRowLimitContent = () => {
+  const [status, setStatus] = useState<string | undefined>();
+
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const config = useMemo<TableConfig>(
+    () => ({ columns: getSchema(TABLE_NAME).columns }),
+    [],
+  );
+
+  const handleExport = useCallback(async () => {
+    setStatus(undefined);
+    try {
+      await exportToCsv(
+        dataSource as DataSource,
+        "All",
+        "instruments-limited.csv",
+        [],
+        (err) => setStatus(`Export failed: ${err.message}`),
+        () => setStatus("Download started"),
+        50,
+      );
+    } catch (e) {
+      setStatus(`Export failed: ${(e as Error).message}`);
+    }
+  }, [dataSource]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        height: "100%",
+        padding: 12,
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Button onClick={handleExport}>Export (max 50 rows)</Button>
+        {status ? (
+          <span style={{ fontSize: 12, fontWeight: 600 }}>{status}</span>
+        ) : null}
+      </div>
+      <div style={{ flex: "1 1 0", border: "solid 1px lightgray" }}>
+        <Table config={config} dataSource={dataSource} />
+      </div>
+    </div>
+  );
+};
+
+export const CsvExportWithRowLimit = () => (
+  <LocalDataSourceProvider>
+    <CsvExportWithRowLimitContent />
+  </LocalDataSourceProvider>
+);
+
 const INSTRUMENTS_TEMPLATE_COLUMNS = ["ric", "currency", "description", "exchange", "isin"];
 
 const CsvExportTemplateContent = () => {

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -1,0 +1,157 @@
+import { getSchema, LocalDataSourceProvider, simulModule } from "@vuu-ui/vuu-data-test";
+import type { DataSource } from "@vuu-ui/vuu-data-types";
+import { exportCsvTemplate, exportToCsv } from "@vuu-ui/vuu-utils";
+import { Button } from "@salt-ds/core";
+import { Table } from "@vuu-ui/vuu-table";
+import type { TableConfig } from "@vuu-ui/vuu-table-types";
+import { useCallback, useMemo, useState } from "react";
+
+const TABLE_NAME = "instruments";
+
+const CsvExportContent = () => {
+  const [isExporting, setIsExporting] = useState(false);
+  const [status, setStatus] = useState<string | undefined>();
+
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const config = useMemo<TableConfig>(
+    () => ({ columns: getSchema(TABLE_NAME).columns }),
+    [],
+  );
+
+  const handleExportAll = useCallback(async () => {
+    setIsExporting(true);
+    setStatus(undefined);
+    try {
+      await exportToCsv(
+        dataSource as DataSource,
+        "All",
+        "instruments-export.csv",
+        [],
+        (err) => { setStatus(`Export failed: ${err.message}`); setIsExporting(false); },
+        () => { setStatus("Download started"); setIsExporting(false); },
+      );
+    } catch (e) {
+      setStatus(`Export failed: ${(e as Error).message}`);
+      setIsExporting(false);
+    }
+  }, [dataSource]);
+
+  const handleExportSelected = useCallback(async () => {
+    setIsExporting(true);
+    setStatus(undefined);
+    try {
+      await exportToCsv(
+        dataSource as DataSource,
+        "Selected",
+        "instruments-selected-export.csv",
+        [],
+        (err) => { setStatus(`Export failed: ${err.message}`); setIsExporting(false); },
+        () => { setStatus("Download started"); setIsExporting(false); },
+      );
+    } catch (e) {
+      setStatus(`Export failed: ${(e as Error).message}`);
+      setIsExporting(false);
+    }
+  }, [dataSource]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        height: "100%",
+        padding: 12,
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Button disabled={isExporting} onClick={handleExportAll}>
+          Export All to CSV
+        </Button>
+        <Button disabled={isExporting} onClick={handleExportSelected}>
+          Export Selected to CSV
+        </Button>
+        {status ? (
+          <span style={{ fontSize: 12, color: "#027a48", fontWeight: 600 }}>
+            {status}
+          </span>
+        ) : null}
+      </div>
+      <div style={{ flex: "1 1 0", border: "solid 1px lightgray" }}>
+        <Table config={config} dataSource={dataSource} selectionModel="checkbox" />
+      </div>
+    </div>
+  );
+};
+
+export const CsvExportAllRows = () => (
+  <LocalDataSourceProvider>
+    <CsvExportContent />
+  </LocalDataSourceProvider>
+);
+
+const CsvExportSimpleContent = () => {
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const handleExport = useCallback(async () => {
+    await exportToCsv(dataSource as DataSource, "All", "instruments.csv");
+  }, [dataSource]);
+
+  return (
+    <div style={{ padding: 12 }}>
+      <Button onClick={handleExport}>Download instruments.csv</Button>
+    </div>
+  );
+};
+
+export const CsvExportSimple = () => (
+  <LocalDataSourceProvider>
+    <CsvExportSimpleContent />
+  </LocalDataSourceProvider>
+);
+
+const INSTRUMENTS_TEMPLATE_COLUMNS = ["ric", "currency", "description", "exchange", "isin"];
+
+const CsvExportTemplateContent = () => {
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const handleDownloadAllColumns = useCallback(() => {
+    exportCsvTemplate(dataSource as DataSource, "instruments-template.csv");
+  }, [dataSource]);
+
+  const handleDownloadSubset = useCallback(() => {
+    exportCsvTemplate(
+      dataSource as DataSource,
+      "instruments-template-subset.csv",
+      [],
+      INSTRUMENTS_TEMPLATE_COLUMNS,
+    );
+  }, [dataSource]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, padding: 12 }}>
+      <Button onClick={handleDownloadAllColumns}>
+        Download template (all columns)
+      </Button>
+      <Button onClick={handleDownloadSubset}>
+        Download template ({INSTRUMENTS_TEMPLATE_COLUMNS.join(", ")})
+      </Button>
+    </div>
+  );
+};
+
+export const CsvExportTemplate = () => (
+  <LocalDataSourceProvider>
+    <CsvExportTemplateContent />
+  </LocalDataSourceProvider>
+);


### PR DESCRIPTION
- Adds `export-utils.ts` to `vuu-utils` exporting three functions:
  - `exportToCsv(dataSource, copyOption, filename, excludeColumns, onError, onSuccess)` — creates an `"export"` session table via `createSessionDataSource`, then subscribes with a full-range request to drain all rows, serialises to CSV and triggers a browser download
  - `exportSessionTableToCsv(sessionDataSource, ...)`
  - `exportCsvTemplate(dataSource, filename, excludeColumns, columns?)` 
- Enforces a `MAX_EXPORT_ROWS = 10_000` limit; excess row count is reported via `onError` callback rather than a synchronous throw (the limit check fires inside the async subscription callback)
- Internal session columns (`vuuMsg`, `vuuAction`, `vuuRowNum`) are always stripped from output
- Adds `CsvExport.examples.tsx` showcase with four examples: export all rows, export selected rows, simple one-button export, and template download (all columns and named subset)