### PR TITLE
Handle target-scoped remote token exchange failures

### DIFF
--- a/vuu-ui/packages/core/src/auth/AuthenticationProvider.tsx
+++ b/vuu-ui/packages/core/src/auth/AuthenticationProvider.tsx
@@ -25,7 +25,12 @@ import {
   vuuConnectionRegistry,
   type VuuConnectionRegistry,
 } from "../connection-management/VuuConnectionRegistry";
-import type { VuuAuthTarget, VuuSession } from "./VuuTokenExchange";
+import { VuuTokenExchangeError } from "./VuuTokenExchange";
+import type {
+  VuuAuthTarget,
+  VuuSession,
+  VuuTokenExchangeFailure,
+} from "./VuuTokenExchange";
 
 export class AuthenticationConfigurationError extends Error {
   constructor(message: string) {
@@ -35,14 +40,22 @@ export class AuthenticationConfigurationError extends Error {
 }
 
 export class VuuConnectionError extends Error {
+  readonly failure?: VuuTokenExchangeFailure;
+  readonly status?: number;
+
   constructor(
     readonly connectionId: string,
     cause: unknown,
   ) {
-    super(`VUU connection authentication failed for ${connectionId}`, {
+    const detail = cause instanceof Error ? `: ${cause.message}` : "";
+    super(`VUU connection authentication failed for ${connectionId}${detail}`, {
       cause,
     });
     this.name = "VuuConnectionError";
+    if (cause instanceof VuuTokenExchangeError) {
+      this.failure = cause.failure;
+      this.status = cause.status;
+    }
   }
 }
 

--- a/vuu-ui/packages/core/src/auth/VuuTokenExchange.ts
+++ b/vuu-ui/packages/core/src/auth/VuuTokenExchange.ts
@@ -15,13 +15,48 @@ export interface VuuSession {
   user: User;
 }
 
+export type VuuTokenExchangeFailure =
+  | "authentication-rejected"
+  | "authorization-denied"
+  | "service-unavailable"
+  | "exchange-failed";
+
+const getFailure = (status?: number): VuuTokenExchangeFailure => {
+  switch (status) {
+    case 401:
+      return "authentication-rejected";
+    case 403:
+      return "authorization-denied";
+    case 503:
+      return "service-unavailable";
+    default:
+      return "exchange-failed";
+  }
+};
+
+const getFailureMessage = (target: VuuAuthTarget, status: number) => {
+  switch (status) {
+    case 401:
+      return `VUU token exchange rejected for ${target.connectionId} (401)`;
+    case 403:
+      return `VUU authorization denied for ${target.connectionId} (403)`;
+    case 503:
+      return `VUU token exchange unavailable for ${target.connectionId} (503)`;
+    default:
+      return `VUU token exchange failed for ${target.connectionId} (${status})`;
+  }
+};
+
 export class VuuTokenExchangeError extends Error {
+  readonly failure: VuuTokenExchangeFailure;
+
   constructor(
     message: string,
     readonly status?: number,
   ) {
     super(message);
     this.name = "VuuTokenExchangeError";
+    this.failure = getFailure(status);
   }
 }
 
@@ -31,11 +66,11 @@ export const exchangeVuuToken = async (
 ): Promise<VuuSession> => {
   const response = await fetch(target.restUrl, {
     headers: { Authorization: `Bearer ${identityToken}` },
-    method: 'POST'
+    method: "POST",
   });
   if (!response.ok) {
     throw new VuuTokenExchangeError(
-      `VUU token exchange failed for ${target.connectionId}`,
+      getFailureMessage(target, response.status),
       response.status,
     );
   }

--- a/vuu-ui/packages/core/src/auth/index.ts
+++ b/vuu-ui/packages/core/src/auth/index.ts
@@ -30,6 +30,7 @@ export {
 } from "./VuuLoginHandler";
 export {
   exchangeVuuToken, VuuTokenExchangeError, type VuuAuthTarget,
+  type VuuTokenExchangeFailure,
   type VuuSession
 } from "./VuuTokenExchange";
 export {

--- a/vuu-ui/packages/core/src/connection-management/VuuConnectionRegistry.ts
+++ b/vuu-ui/packages/core/src/connection-management/VuuConnectionRegistry.ts
@@ -6,6 +6,7 @@ import {
 import type { AuthHandler } from "../auth/AuthHandler";
 import {
   exchangeVuuToken,
+  VuuTokenExchangeError,
   type VuuAuthTarget,
   type VuuSession,
 } from "../auth/VuuTokenExchange";
@@ -251,6 +252,7 @@ export class VuuConnectionRegistry {
       return entry.reconnectPromise;
     }
     entry.reconnectPromise = (async () => {
+      let lastError: Error | undefined;
       for (const interval of this.#retryIntervals) {
         await new Promise((resolve) => setTimeout(resolve, interval * 1000));
         if (entry.refCount === 0 || entry.intentionalDisconnect) {
@@ -259,14 +261,28 @@ export class VuuConnectionRegistry {
         try {
           await this.#authenticateAndConnect(entry);
           return;
-        } catch {
-          // Retry with a fresh identity and VUU token.
+        } catch (error) {
+          lastError =
+            error instanceof Error
+              ? error
+              : new Error(
+                  `VUU connection ${entry.target.connectionId} failed to reconnect`,
+                  { cause: error },
+                );
+          if (
+            error instanceof VuuTokenExchangeError &&
+            error.failure === "authorization-denied"
+          ) {
+            break;
+          }
         }
       }
       entry.state = "failed";
-      const error = Error(
-        `VUU connection ${entry.target.connectionId} failed to reconnect`,
-      );
+      const error =
+        lastError ??
+        Error(
+          `VUU connection ${entry.target.connectionId} failed to reconnect`,
+        );
       entry.errorListeners.forEach((listener) => {
         listener(error);
       });

--- a/vuu-ui/packages/core/test/auth/AuthenticationProvider.test.ts
+++ b/vuu-ui/packages/core/test/auth/AuthenticationProvider.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   AuthenticationConfigurationError,
   normalizeVuuAuthTarget,
+  VuuConnectionError,
 } from "../../src/auth/AuthenticationProvider";
+import { VuuTokenExchangeError } from "../../src/auth/VuuTokenExchange";
 
 const portalTarget = {
   connectionId: "portal",
@@ -25,5 +27,37 @@ describe("normalizeVuuAuthTarget", () => {
         "Connection orders must define restUrl and websocketUrl",
       ),
     );
+  });
+
+  it.each([
+    {
+      connectionId: "user-admin",
+      restUrl: "https://localhost:8444/api/authn",
+      websocketUrl: "wss://localhost:8092/websocket",
+    },
+    {
+      connectionId: "basket-trading",
+      restUrl: "https://localhost:8445/api/authn",
+      websocketUrl: "wss://localhost:8093/websocket",
+    },
+  ])("preserves registry endpoints for $connectionId", (connection) => {
+    expect(normalizeVuuAuthTarget(connection, portalTarget)).toEqual(
+      connection,
+    );
+  });
+
+  it("preserves typed authorization denial details for a remote connection", () => {
+    const cause = new VuuTokenExchangeError(
+      "VUU authorization denied for module-admin (403)",
+      403,
+    );
+
+    expect(new VuuConnectionError("module-admin", cause)).toMatchObject({
+      connectionId: "module-admin",
+      failure: "authorization-denied",
+      message:
+        "VUU connection authentication failed for module-admin: VUU authorization denied for module-admin (403)",
+      status: 403,
+    });
   });
 });

--- a/vuu-ui/packages/core/test/auth/VuuTokenExchange.test.ts
+++ b/vuu-ui/packages/core/test/auth/VuuTokenExchange.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   exchangeVuuToken,
-  VuuTokenExchangeError,
   type VuuAuthTarget,
 } from "../../src/auth/VuuTokenExchange";
 
@@ -40,14 +39,44 @@ describe("exchangeVuuToken", () => {
     });
   });
 
-  it("surfaces the failed endpoint and response status", async () => {
+  it.each([
+    [401, "authentication-rejected", "token exchange rejected"],
+    [403, "authorization-denied", "authorization denied"],
+    [503, "service-unavailable", "token exchange unavailable"],
+  ] as const)("distinguishes a %i response as %s", async (status, failure, message) => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(new Response(null, { status: 401 })),
+      vi.fn().mockResolvedValue(new Response(null, { status })),
     );
 
-    await expect(exchangeVuuToken("expired", target)).rejects.toEqual(
-      new VuuTokenExchangeError("VUU token exchange failed for orders", 401),
+    const exchange = exchangeVuuToken("identity-token", target);
+    await expect(exchange).rejects.toMatchObject({
+      failure,
+      name: "VuuTokenExchangeError",
+      status,
+    });
+    await expect(exchange).rejects.toThrow(message);
+  });
+
+  it("forwards a profile-specific authentication endpoint", async () => {
+    const moduleAdminTarget = {
+      connectionId: "module-admin",
+      restUrl: "https://localhost:8443/api/authn/module-admin",
+      websocketUrl: "wss://localhost:8090/websocket",
+    };
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ token }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    await exchangeVuuToken("identity-token", moduleAdminTarget);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://localhost:8443/api/authn/module-admin",
+      expect.any(Object),
     );
   });
 });

--- a/vuu-ui/packages/core/test/connection-management/VuuConnectionRegistry.test.ts
+++ b/vuu-ui/packages/core/test/connection-management/VuuConnectionRegistry.test.ts
@@ -8,6 +8,7 @@ import type {
   VuuAuthTarget,
   VuuSession,
 } from "../../src/auth/VuuTokenExchange";
+import { VuuTokenExchangeError } from "../../src/auth/VuuTokenExchange";
 
 const target: VuuAuthTarget = {
   connectionId: "orders",
@@ -45,14 +46,22 @@ const moduleRegistry = {
 };
 
 class TestConnectionClient implements VuuConnectionClient {
+  connections: Array<{
+    connectionId: string;
+    options: { token: string; url: string };
+  }> = [];
   connectCount = 0;
   destroyCount = 0;
   connected = false;
   listener?: (status: "disconnected") => void;
 
-  async connectWithLoginResponseTo() {
+  async connectWithLoginResponseTo(
+    connectionId: string,
+    options: { token: string; url: string },
+  ) {
     this.connectCount += 1;
     this.connected = true;
+    this.connections.push({ connectionId, options });
     return {
       loginResponse: {
         moduleRegistry,
@@ -123,8 +132,138 @@ describe("VuuConnectionRegistry", () => {
     expect(connectionClient.destroyCount).toBe(1);
   });
 
-  it("re-authenticates a shared connection after disconnection", async () => {
+  it("creates a separate module-admin session on the portal server", async () => {
     const connectionClient = new TestConnectionClient();
+    const portalTarget = {
+      connectionId: "portal",
+      restUrl: "https://localhost:8443/api/authn",
+      websocketUrl: "wss://localhost:8090/websocket",
+    };
+    const moduleAdminTarget = {
+      connectionId: "module-admin",
+      restUrl: "https://localhost:8443/api/authn/module-admin",
+      websocketUrl: portalTarget.websocketUrl,
+    };
+    const exchangeToken = vi.fn(
+      async (_identityToken: string, authTarget: VuuAuthTarget) => ({
+        ...session,
+        token: `${authTarget.connectionId}-token`,
+      }),
+    );
+    const registry = new VuuConnectionRegistry({
+      connectionClient,
+      exchangeToken,
+    });
+
+    const [portalSession, moduleAdminSession] = await Promise.all([
+      registry.acquire(authHandler, portalTarget),
+      registry.acquire(authHandler, moduleAdminTarget),
+    ]);
+
+    expect(portalSession.token).toBe("portal-token");
+    expect(moduleAdminSession.token).toBe("module-admin-token");
+    expect(exchangeToken).toHaveBeenCalledTimes(2);
+    expect(exchangeToken).toHaveBeenCalledWith(
+      "identity-token",
+      moduleAdminTarget,
+    );
+    expect(connectionClient.connections).toEqual([
+      {
+        connectionId: "portal",
+        options: {
+          token: "portal-token",
+          url: portalTarget.websocketUrl,
+        },
+      },
+      {
+        connectionId: "module-admin",
+        options: {
+          token: "module-admin-token",
+          url: portalTarget.websocketUrl,
+        },
+      },
+    ]);
+    expect(registry.getRefCount("portal")).toBe(1);
+    expect(registry.getRefCount("module-admin")).toBe(1);
+
+    registry.release("portal");
+    registry.release("module-admin");
+  });
+
+  it("isolates a denied remote from concurrent connections", async () => {
+    const connectionClient = new TestConnectionClient();
+    const targets = [
+      {
+        connectionId: "portal",
+        restUrl: "https://localhost:8443/api/authn",
+        websocketUrl: "wss://localhost:8090/websocket",
+      },
+      {
+        connectionId: "module-admin",
+        restUrl: "https://localhost:8443/api/authn/module-admin",
+        websocketUrl: "wss://localhost:8090/websocket",
+      },
+      {
+        connectionId: "basket-trading",
+        restUrl: "https://localhost:8445/api/authn",
+        websocketUrl: "wss://localhost:8093/websocket",
+      },
+    ];
+    const exchangeToken = vi.fn(
+      async (_identityToken: string, authTarget: VuuAuthTarget) => {
+        if (authTarget.connectionId === "module-admin") {
+          throw new VuuTokenExchangeError(
+            "VUU authorization denied for module-admin (403)",
+            403,
+          );
+        }
+        return { ...session, token: `${authTarget.connectionId}-token` };
+      },
+    );
+    const registry = new VuuConnectionRegistry({
+      connectionClient,
+      exchangeToken,
+    });
+
+    const [portalResult, moduleAdminResult, basketResult] =
+      await Promise.allSettled(
+        targets.map((authTarget) => registry.acquire(authHandler, authTarget)),
+      );
+
+    expect(portalResult).toMatchObject({
+      status: "fulfilled",
+      value: { token: "portal-token" },
+    });
+    expect(moduleAdminResult).toMatchObject({
+      reason: {
+        failure: "authorization-denied",
+        status: 403,
+      },
+      status: "rejected",
+    });
+    expect(basketResult).toMatchObject({
+      status: "fulfilled",
+      value: { token: "basket-trading-token" },
+    });
+    expect(
+      connectionClient.connections.map(({ connectionId }) => connectionId),
+    ).toEqual(["portal", "basket-trading"]);
+
+    targets.forEach(({ connectionId }) => {
+      registry.release(connectionId);
+    });
+  });
+
+  it("gets a fresh identity and exchanges for the same target on reconnect", async () => {
+    const connectionClient = new TestConnectionClient();
+    const reconnectAuthHandler: AuthHandler = {
+      authenticate: vi.fn(),
+      getIdentityToken: vi
+        .fn()
+        .mockResolvedValueOnce("identity-token-1")
+        .mockResolvedValueOnce("identity-token-2"),
+      logout: vi.fn(),
+    };
     const exchangeToken = vi.fn().mockResolvedValue(session);
     const registry = new VuuConnectionRegistry({
       connectionClient,
@@ -132,13 +271,57 @@ describe("VuuConnectionRegistry", () => {
       retryIntervals: [0],
     });
 
+    await registry.acquire(reconnectAuthHandler, target);
+    connectionClient.connected = false;
+    connectionClient.listener?.("disconnected");
+    await new Promise((resolve) => setTimeout(resolve, 1));
+
+    expect(reconnectAuthHandler.getIdentityToken).toHaveBeenCalledTimes(2);
+    expect(exchangeToken.mock.calls).toEqual([
+      ["identity-token-1", target],
+      ["identity-token-2", target],
+    ]);
+    expect(exchangeToken).toHaveBeenCalledTimes(2);
+    expect(connectionClient.connectCount).toBe(2);
+    expect(connectionClient.connections).toEqual([
+      {
+        connectionId: target.connectionId,
+        options: { token: session.token, url: target.websocketUrl },
+      },
+      {
+        connectionId: target.connectionId,
+        options: { token: session.token, url: target.websocketUrl },
+      },
+    ]);
+
+    registry.release(target.connectionId);
+  });
+
+  it("reports a reconnect authorization denial without retrying it", async () => {
+    const connectionClient = new TestConnectionClient();
+    const authorizationError = new VuuTokenExchangeError(
+      "VUU authorization denied for orders (403)",
+      403,
+    );
+    const exchangeToken = vi
+      .fn()
+      .mockResolvedValueOnce(session)
+      .mockRejectedValue(authorizationError);
+    const registry = new VuuConnectionRegistry({
+      connectionClient,
+      exchangeToken,
+      retryIntervals: [0, 0],
+    });
+    const errorListener = vi.fn();
+
     await registry.acquire(authHandler, target);
+    registry.subscribe(target.connectionId, vi.fn(), errorListener);
     connectionClient.connected = false;
     connectionClient.listener?.("disconnected");
     await new Promise((resolve) => setTimeout(resolve, 1));
 
     expect(exchangeToken).toHaveBeenCalledTimes(2);
-    expect(connectionClient.connectCount).toBe(2);
+    expect(errorListener).toHaveBeenCalledWith(authorizationError);
 
     registry.release(target.connectionId);
   });


### PR DESCRIPTION
## Summary
- classify VUU token exchange failures so 401 authentication rejection, 403 authorization denial, and 503 service unavailability remain distinct
- preserve typed exchange errors through connection-level errors and reconnect notifications; authorization-denied reconnects stop retrying while other failures retain retry behavior
- prove registry-driven routing creates separate `portal` and `module-admin` sessions even when they share the portal WebSocket, while forwarding `/api/authn/module-admin`
- cover standalone `user-admin` and `basket-trading` endpoints, concurrent remote isolation, and fresh identity/target exchange on reconnect

No module names are hard-coded in production routing, and browser behavior remains an identity-token POST to the target VUU `/api/authn` endpoint; no confidential Keycloak exchange or client secret is introduced.

## Validation
- `npm test --workspace=@vuu-ui/core` (21 tests passed)
- `npx vitest run packages/vuu-shell/test/module-registry/getRegisteredModules.test.ts` (2 tests passed)
- `npm run build --workspace=@vuu-ui/core`
- Biome check for all changed source/test files

The repository-wide typecheck and core type-declaration build remain blocked by existing `ui-portal` errors in `vuu-data-react`, `vuu-utils`, portal examples, sample apps, and showcase code; none involve the changed files.

## Backend contract assumptions
- registry metadata supplies `connectionId`, `restUrl`, and `websocketUrl` per remote
- module-admin uses `connectionId: module-admin`, `restUrl: https://localhost:8443/api/authn/module-admin`, and the portal WebSocket URL
- user-admin and basket-trading continue supplying their standalone authentication and WebSocket endpoints
- target `/api/authn` endpoints accept the portal identity bearer token and return `{ token }`; 401, 403, and 503 retain their standard meanings

## Documentation
`vuu-ui/docs/keycloak-remote-token-exchange.md` is not present on the latest `ui-portal`, so this PR does not duplicate or create it. The Phase 2 document should be reconciled when it lands on the branch.