### PR TITLE
Use server-specific VUU WebSocket paths

### DIFF
--- a/vuu-ui/docs/authentication-refactor-proposal.md
+++ b/vuu-ui/docs/authentication-refactor-proposal.md
@@ -528,7 +528,9 @@ Module admin uses the portal VUU server because module discovery is hosted by
   "mfComponent": "ModuleAdmin",
   "mfUrl": "http://localhost:5008",
   "vuu": {
-    "connectionId": "portal"
+    "connectionId": "module-admin",
+    "restUrl": "https://localhost:8443/api/authn/module-admin",
+    "websocketUrl": "wss://localhost:8091/websocket-portal"
   }
 }
 ```
@@ -543,7 +545,7 @@ User admin uses its standalone VUU server:
   "vuu": {
     "connectionId": "user-admin",
     "restUrl": "https://localhost:8444/api/authn",
-    "websocketUrl": "wss://localhost:8092/websocket"
+    "websocketUrl": "wss://localhost:8092/websocket-user-admin"
   }
 }
 ```

--- a/vuu-ui/docs/multi-module-requirements.md
+++ b/vuu-ui/docs/multi-module-requirements.md
@@ -118,8 +118,8 @@ Host config MUST continue to support:
 {
   "ssl": true,
   "authUrl": "http://localhost:5001",
-  "restUrl": "https://localhost:8443",
-  "websocketUrl": "wss://localhost:8090/websocket"
+  "restUrl": "https://localhost:8443/api/authn",
+  "websocketUrl": "wss://localhost:8091/websocket-portal"
 }
 ```
 
@@ -145,8 +145,9 @@ Minimum required shape:
   "remoteEntry": "/basket-trading/remoteEntry.js",
   "exposedModule": "./Feature",
   "vuu": {
-    "connectionId": "basket",
-    "websocketUrl": "wss://localhost:8091/websocket"
+    "connectionId": "basket-trading",
+    "restUrl": "https://localhost:8445/api/authn",
+    "websocketUrl": "wss://localhost:8093/websocket-basket-trading"
   }
 }
 ```

--- a/vuu-ui/packages/core/test/auth/AuthenticationProvider.test.ts
+++ b/vuu-ui/packages/core/test/auth/AuthenticationProvider.test.ts
@@ -9,7 +9,7 @@ import { VuuTokenExchangeError } from "../../src/auth/VuuTokenExchange";
 const portalTarget = {
   connectionId: "portal",
   restUrl: "https://portal.example.test/api/authn",
-  websocketUrl: "wss://portal.example.test/websocket",
+  websocketUrl: "wss://portal.example.test/websocket-portal",
 };
 
 describe("normalizeVuuAuthTarget", () => {
@@ -31,14 +31,19 @@ describe("normalizeVuuAuthTarget", () => {
 
   it.each([
     {
+      connectionId: "module-admin",
+      restUrl: "https://localhost:8443/api/authn/module-admin",
+      websocketUrl: "wss://localhost:8091/websocket-portal",
+    },
+    {
       connectionId: "user-admin",
       restUrl: "https://localhost:8444/api/authn",
-      websocketUrl: "wss://localhost:8092/websocket",
+      websocketUrl: "wss://localhost:8092/websocket-user-admin",
     },
     {
       connectionId: "basket-trading",
       restUrl: "https://localhost:8445/api/authn",
-      websocketUrl: "wss://localhost:8093/websocket",
+      websocketUrl: "wss://localhost:8093/websocket-basket-trading",
     },
   ])("preserves registry endpoints for $connectionId", (connection) => {
     expect(normalizeVuuAuthTarget(connection, portalTarget)).toEqual(

--- a/vuu-ui/packages/core/test/auth/VuuTokenExchange.test.ts
+++ b/vuu-ui/packages/core/test/auth/VuuTokenExchange.test.ts
@@ -62,7 +62,7 @@ describe("exchangeVuuToken", () => {
     const moduleAdminTarget = {
       connectionId: "module-admin",
       restUrl: "https://localhost:8443/api/authn/module-admin",
-      websocketUrl: "wss://localhost:8090/websocket",
+      websocketUrl: "wss://localhost:8091/websocket-portal",
     };
     const fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ token }), {

--- a/vuu-ui/packages/core/test/connection-management/VuuConnectionRegistry.test.ts
+++ b/vuu-ui/packages/core/test/connection-management/VuuConnectionRegistry.test.ts
@@ -39,7 +39,43 @@ const moduleRegistry = {
       vuu: {
         connectionId: "user-admin",
         restUrl: "https://localhost:8444/api/authn",
-        websocketUrl: "wss://localhost:8092/websocket",
+        websocketUrl: "wss://localhost:8092/websocket-user-admin",
+      },
+    },
+    {
+      description: "Manage modules",
+      enabled: true,
+      id: 2,
+      location: "/Admin/Modules",
+      mfComponent: "ModuleAdmin",
+      mfScope: "moduleAdmin",
+      mfUrl: "http://localhost:5008",
+      name: "module-admin",
+      path: "/modules/admin",
+      title: "Manage modules",
+      version: 1,
+      vuu: {
+        connectionId: "module-admin",
+        restUrl: "https://localhost:8443/api/authn/module-admin",
+        websocketUrl: "wss://localhost:8091/websocket-portal",
+      },
+    },
+    {
+      description: "Trade baskets",
+      enabled: true,
+      id: 3,
+      location: "/Trading/Baskets",
+      mfComponent: "VuuBasketTradingFeature",
+      mfScope: "basketTrading",
+      mfUrl: "http://localhost:5005",
+      name: "basket-trading",
+      path: "/trading/baskets",
+      title: "Basket Trading",
+      version: 1,
+      vuu: {
+        connectionId: "basket-trading",
+        restUrl: "https://localhost:8445/api/authn",
+        websocketUrl: "wss://localhost:8093/websocket-basket-trading",
       },
     },
   ],
@@ -132,12 +168,12 @@ describe("VuuConnectionRegistry", () => {
     expect(connectionClient.destroyCount).toBe(1);
   });
 
-  it("creates a separate module-admin session on the portal server", async () => {
+  it("forwards the shared portal URL to separate portal and module-admin connections", async () => {
     const connectionClient = new TestConnectionClient();
     const portalTarget = {
       connectionId: "portal",
       restUrl: "https://localhost:8443/api/authn",
-      websocketUrl: "wss://localhost:8090/websocket",
+      websocketUrl: "wss://localhost:8091/websocket-portal",
     };
     const moduleAdminTarget = {
       connectionId: "module-admin",
@@ -196,17 +232,22 @@ describe("VuuConnectionRegistry", () => {
       {
         connectionId: "portal",
         restUrl: "https://localhost:8443/api/authn",
-        websocketUrl: "wss://localhost:8090/websocket",
+        websocketUrl: "wss://localhost:8091/websocket-portal",
       },
       {
         connectionId: "module-admin",
         restUrl: "https://localhost:8443/api/authn/module-admin",
-        websocketUrl: "wss://localhost:8090/websocket",
+        websocketUrl: "wss://localhost:8091/websocket-portal",
       },
       {
         connectionId: "basket-trading",
         restUrl: "https://localhost:8445/api/authn",
-        websocketUrl: "wss://localhost:8093/websocket",
+        websocketUrl: "wss://localhost:8093/websocket-basket-trading",
+      },
+      {
+        connectionId: "user-admin",
+        restUrl: "https://localhost:8444/api/authn",
+        websocketUrl: "wss://localhost:8092/websocket-user-admin",
       },
     ];
     const exchangeToken = vi.fn(
@@ -225,7 +266,7 @@ describe("VuuConnectionRegistry", () => {
       exchangeToken,
     });
 
-    const [portalResult, moduleAdminResult, basketResult] =
+    const [portalResult, moduleAdminResult, basketResult, userAdminResult] =
       await Promise.allSettled(
         targets.map((authTarget) => registry.acquire(authHandler, authTarget)),
       );
@@ -245,9 +286,29 @@ describe("VuuConnectionRegistry", () => {
       status: "fulfilled",
       value: { token: "basket-trading-token" },
     });
+    expect(userAdminResult).toMatchObject({
+      status: "fulfilled",
+      value: { token: "user-admin-token" },
+    });
     expect(
-      connectionClient.connections.map(({ connectionId }) => connectionId),
-    ).toEqual(["portal", "basket-trading"]);
+      connectionClient.connections.map(({ connectionId, options }) => ({
+        connectionId,
+        url: options.url,
+      })),
+    ).toEqual([
+      {
+        connectionId: "portal",
+        url: "wss://localhost:8091/websocket-portal",
+      },
+      {
+        connectionId: "basket-trading",
+        url: "wss://localhost:8093/websocket-basket-trading",
+      },
+      {
+        connectionId: "user-admin",
+        url: "wss://localhost:8092/websocket-user-admin",
+      },
+    ]);
 
     targets.forEach(({ connectionId }) => {
       registry.release(connectionId);

--- a/vuu-ui/portal-examples/portal-host/docs/module-federation-architecture.md
+++ b/vuu-ui/portal-examples/portal-host/docs/module-federation-architecture.md
@@ -62,3 +62,8 @@ VUU server authenticates server-side through its own **confidential** Keycloak
 client. Permissions are assigned independently for the portal and each remote
 module. `module-admin` shares the portal VUU server, while
 `user-admin` uses its standalone VUU server.
+
+The portal and module-admin logical connections both use
+`wss://localhost:8091/websocket-portal`. User-admin uses
+`wss://localhost:8092/websocket-user-admin`, and basket-trading uses
+`wss://localhost:8093/websocket-basket-trading`.

--- a/vuu-ui/portal-examples/portal-host/remote-modules-requirements.md
+++ b/vuu-ui/portal-examples/portal-host/remote-modules-requirements.md
@@ -118,8 +118,8 @@ Host config MUST continue to support:
 {
   "ssl": true,
   "authUrl": "http://localhost:5001",
-  "restUrl": "https://localhost:8443",
-  "websocketUrl": "wss://localhost:8090/websocket"
+  "restUrl": "https://localhost:8443/api/authn",
+  "websocketUrl": "wss://localhost:8091/websocket-portal"
 }
 ```
 
@@ -145,8 +145,9 @@ Minimum required shape:
   "remoteEntry": "/basket-trading/remoteEntry.js",
   "exposedModule": "./Feature",
   "vuu": {
-    "connectionId": "basket",
-    "websocketUrl": "wss://localhost:8091/websocket"
+    "connectionId": "basket-trading",
+    "restUrl": "https://localhost:8445/api/authn",
+    "websocketUrl": "wss://localhost:8093/websocket-basket-trading"
   }
 }
 ```

--- a/vuu-ui/portal-examples/portal-host/scripts/rsbuild.ts
+++ b/vuu-ui/portal-examples/portal-host/scripts/rsbuild.ts
@@ -13,7 +13,7 @@ const buildManifest = () => {
     ssl: true,
     authUrl: "https://localhost:8080",
     restUrl: "https://localhost:8443/api/authn",
-    websocketUrl: "wss://localhost:8091/websocket",
+    websocketUrl: "wss://localhost:8091/websocket-portal",
   };
 };
 
@@ -62,9 +62,9 @@ async function main() {
           },
           plugins: [
             useRsDoctor &&
-            new RsdoctorRspackPlugin({
-              // plugin options
-            }),
+              new RsdoctorRspackPlugin({
+                // plugin options
+              }),
             new ModuleFederationPlugin({
               name: "host",
               remoteType: "module",


### PR DESCRIPTION
## Summary
- point the portal host at `wss://localhost:8091/websocket-portal`
- update registry/auth connection fixtures for portal, module-admin, user-admin, and basket-trading server-specific paths
- verify portal and module-admin remain separate logical connections while sharing the portal endpoint
- document the active endpoint contract without changing URL-agnostic core connection code or legacy sample-app configuration

## Validation
- `npm exec vitest run packages/core/test/auth/AuthenticationProvider.test.ts packages/core/test/auth/VuuTokenExchange.test.ts packages/core/test/connection-management/VuuConnectionRegistry.test.ts` (18 tests passed)
- `npm --prefix portal-examples/portal-host run build`
- generated `dist_portal/portal-host/config.json` contains `wss://localhost:8091/websocket-portal`
- Biome check passed for changed TypeScript files

## Typecheck baseline
`npm run typecheck -- --pretty false` remains blocked by existing unrelated `ui-portal` errors in data editing, feature utilities/examples, and showcase code. A focused portal script typecheck reaches the existing missing declaration for `tools/rsbuild-plugin-inline-css/src/index.js`; the portal production build succeeds.