### PR TITLE
feat(grid-layout): add phase 6 canonical snapshot contracts

### DIFF
--- a/vuu-ui/packages/grid-layout/src/GridSnapshot.ts
+++ b/vuu-ui/packages/grid-layout/src/GridSnapshot.ts
@@ -1,0 +1,76 @@
+export type GridId = string;
+export type GridItemId = string;
+export type StackId = string;
+export type ComponentInstanceId = string;
+
+export type GridTrackSize = `${number}fr` | `${number}px`;
+export type GridItemResizeable = "h" | "v" | "hv" | false;
+
+export interface GridTrackSnapshot {
+  readonly size: GridTrackSize;
+}
+
+export interface GridSpanSnapshot {
+  readonly span: number;
+  readonly start: number;
+}
+
+export interface GridItemSnapshot {
+  readonly column: GridSpanSnapshot;
+  readonly componentInstanceId?: ComponentInstanceId;
+  readonly contentVisible?: boolean;
+  readonly dropTarget?: boolean | string;
+  readonly header?: boolean;
+  readonly id: GridItemId;
+  readonly minHeight?: number;
+  readonly minWidth?: number;
+  readonly resizeable?: GridItemResizeable;
+  readonly row: GridSpanSnapshot;
+  readonly title?: string;
+}
+
+export interface GridStackSnapshot {
+  readonly id: StackId;
+  readonly itemIds: readonly GridItemId[];
+  readonly selectedItemId: GridItemId;
+}
+
+export interface GridSnapshot {
+  readonly columns: readonly GridTrackSnapshot[];
+  readonly gridId: GridId;
+  readonly items: readonly GridItemSnapshot[];
+  readonly revision: number;
+  readonly rows: readonly GridTrackSnapshot[];
+  readonly stacks: readonly GridStackSnapshot[];
+}
+
+export type GridSnapshotValidationCode =
+  | "DUPLICATE_ID"
+  | "EMPTY_ID"
+  | "INVALID_FIELD"
+  | "INVALID_REVISION"
+  | "INVALID_SPAN"
+  | "INVALID_STACK_MEMBERSHIP"
+  | "INVALID_STACK_POSITION"
+  | "INVALID_STACK_SELECTION"
+  | "INVALID_STRUCTURE"
+  | "INVALID_TRACK_REFERENCE"
+  | "MALFORMED_GRID_AREA"
+  | "MALFORMED_TRACK"
+  | "UNEXPECTED_FIELD";
+
+export interface GridSnapshotValidationIssue {
+  readonly code: GridSnapshotValidationCode;
+  readonly message: string;
+  readonly path: string;
+}
+
+export class GridSnapshotValidationError extends Error {
+  readonly issues: readonly GridSnapshotValidationIssue[];
+
+  constructor(issues: readonly GridSnapshotValidationIssue[]) {
+    super(issues.map(({ message, path }) => `${path}: ${message}`).join("; "));
+    this.name = "GridSnapshotValidationError";
+    this.issues = [...issues];
+  }
+}

--- a/vuu-ui/packages/grid-layout/src/grid-snapshot-adapters.ts
+++ b/vuu-ui/packages/grid-layout/src/grid-snapshot-adapters.ts
@@ -1,0 +1,559 @@
+import type {
+  GridLayoutChildItemDescriptor,
+  GridLayoutDescriptor,
+} from "./GridModel";
+import {
+  GridSnapshotValidationError,
+  type GridItemSnapshot,
+  type ComponentInstanceId,
+  type GridSnapshot,
+  type GridSnapshotValidationIssue,
+  type GridSpanSnapshot,
+  type GridStackSnapshot,
+  type GridTrackSnapshot,
+} from "./GridSnapshot";
+
+export interface GridLayoutDescriptorSnapshotOptions {
+  readonly gridId: string;
+  readonly revision?: number;
+}
+
+export interface GridLayoutDescriptorV1
+  extends Omit<GridLayoutDescriptor, "gridLayoutItems"> {
+  readonly gridLayoutItems?: Record<
+    string,
+    GridLayoutChildItemDescriptor & {
+      readonly componentId?: ComponentInstanceId;
+    }
+  >;
+}
+
+const TRACK_PATTERN = /^(?:\d+(?:\.\d+)?|\.\d+)(?:fr|px)$/;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const validateKnownFields = (
+  value: Record<string, unknown>,
+  fields: readonly string[],
+  path: string,
+  issues: GridSnapshotValidationIssue[],
+) => {
+  const knownFields = new Set(fields);
+  for (const field of Object.keys(value)) {
+    if (!knownFields.has(field)) {
+      issues.push({
+        code: "UNEXPECTED_FIELD",
+        message: `unexpected field "${field}"`,
+        path: path === "$" ? field : `${path}.${field}`,
+      });
+    }
+  }
+};
+
+const cloneTrack = ({ size }: GridTrackSnapshot): GridTrackSnapshot => ({
+  size,
+});
+
+const cloneSpan = ({ span, start }: GridSpanSnapshot): GridSpanSnapshot => ({
+  span,
+  start,
+});
+
+const cloneItem = ({
+  column,
+  componentInstanceId,
+  contentVisible,
+  dropTarget,
+  header,
+  id,
+  minHeight,
+  minWidth,
+  resizeable,
+  row,
+  title,
+}: GridItemSnapshot): GridItemSnapshot => ({
+  column: cloneSpan(column),
+  componentInstanceId,
+  contentVisible,
+  dropTarget,
+  header,
+  id,
+  minHeight,
+  minWidth,
+  resizeable,
+  row: cloneSpan(row),
+  title,
+});
+
+const cloneStack = ({
+  id,
+  itemIds,
+  selectedItemId,
+}: GridStackSnapshot): GridStackSnapshot => ({
+  id,
+  itemIds: [...itemIds],
+  selectedItemId,
+});
+
+const validateSpan = (
+  span: unknown,
+  trackCount: number,
+  path: string,
+  issues: GridSnapshotValidationIssue[],
+) => {
+  if (!isRecord(span)) {
+    issues.push({
+      code: "INVALID_STRUCTURE",
+      message: "span must be an object",
+      path,
+    });
+    return;
+  }
+  validateKnownFields(span, ["span", "start"], path, issues);
+  const { span: length, start } = span;
+  if (
+    !Number.isInteger(start) ||
+    !Number.isInteger(length) ||
+    typeof length !== "number" ||
+    length <= 0
+  ) {
+    issues.push({
+      code: "INVALID_SPAN",
+      message: "start and span must be integers and span must be positive",
+      path,
+    });
+    return;
+  }
+  if (
+    typeof start === "number" &&
+    (start <= 0 || start + length - 1 > trackCount)
+  ) {
+    issues.push({
+      code: "INVALID_TRACK_REFERENCE",
+      message: `range ${start}/${length} exceeds ${trackCount} tracks`,
+      path,
+    });
+  }
+};
+
+export const validateGridSnapshot = (
+  value: unknown,
+): readonly GridSnapshotValidationIssue[] => {
+  const issues: GridSnapshotValidationIssue[] = [];
+  if (!isRecord(value)) {
+    return [
+      {
+        code: "INVALID_STRUCTURE",
+        message: "snapshot must be an object",
+        path: "$",
+      },
+    ];
+  }
+  const { columns, gridId, items, revision, rows, stacks } = value;
+  validateKnownFields(
+    value,
+    ["columns", "gridId", "items", "revision", "rows", "stacks"],
+    "$",
+    issues,
+  );
+  if (typeof gridId !== "string" || !gridId) {
+    issues.push({
+      code: "EMPTY_ID",
+      message: "grid id must not be empty",
+      path: "gridId",
+    });
+  }
+  if (
+    typeof revision !== "number" ||
+    !Number.isInteger(revision) ||
+    revision < 0
+  ) {
+    issues.push({
+      code: "INVALID_REVISION",
+      message: "revision must be a non-negative integer",
+      path: "revision",
+    });
+  }
+
+  const validateTracks = (tracks: unknown, path: "columns" | "rows") => {
+    if (!Array.isArray(tracks)) {
+      issues.push({
+        code: "INVALID_STRUCTURE",
+        message: "tracks must be an array",
+        path,
+      });
+      return [];
+    }
+    tracks.forEach((track, index) => {
+      const size = isRecord(track) ? track.size : undefined;
+      if (isRecord(track)) {
+        validateKnownFields(track, ["size"], `${path}[${index}]`, issues);
+      }
+      if (typeof size !== "string" || !TRACK_PATTERN.test(size)) {
+        issues.push({
+          code: "MALFORMED_TRACK",
+          message: `unsupported track size "${String(size)}"`,
+          path: `${path}[${index}].size`,
+        });
+      }
+    });
+    return tracks;
+  };
+  const validatedColumns = validateTracks(columns, "columns");
+  const validatedRows = validateTracks(rows, "rows");
+
+  const ids = new Map<string, string>();
+  const addId = (id: unknown, path: string) => {
+    if (typeof id !== "string" || !id) {
+      issues.push({
+        code: "EMPTY_ID",
+        message: "id must not be empty",
+        path,
+      });
+      return;
+    }
+    const firstPath = ids.get(id);
+    if (firstPath) {
+      issues.push({
+        code: "DUPLICATE_ID",
+        message: `id "${id}" is already used at ${firstPath}`,
+        path,
+      });
+    } else {
+      ids.set(id, path);
+    }
+  };
+
+  const itemIds = new Set<string>();
+  const itemById = new Map<string, Record<string, unknown>>();
+  const validatedItems = Array.isArray(items) ? items : [];
+  if (!Array.isArray(items)) {
+    issues.push({
+      code: "INVALID_STRUCTURE",
+      message: "items must be an array",
+      path: "items",
+    });
+  }
+  validatedItems.forEach((item, index) => {
+    const path = `items[${index}]`;
+    if (!isRecord(item)) {
+      issues.push({
+        code: "INVALID_STRUCTURE",
+        message: "item must be an object",
+        path,
+      });
+      return;
+    }
+    validateKnownFields(
+      item,
+      [
+        "column",
+        "componentInstanceId",
+        "contentVisible",
+        "dropTarget",
+        "header",
+        "id",
+        "minHeight",
+        "minWidth",
+        "resizeable",
+        "row",
+        "title",
+      ],
+      path,
+      issues,
+    );
+    addId(item.id, `${path}.id`);
+    if (typeof item.id === "string") {
+      itemIds.add(item.id);
+      itemById.set(item.id, item);
+    }
+    validateSpan(
+      item.column,
+      validatedColumns.length,
+      `${path}.column`,
+      issues,
+    );
+    validateSpan(item.row, validatedRows.length, `${path}.row`, issues);
+    const optionalFields: ReadonlyArray<
+      readonly [string, (field: unknown) => boolean]
+    > = [
+      ["componentInstanceId", (field) => typeof field === "string"],
+      ["contentVisible", (field) => typeof field === "boolean"],
+      [
+        "dropTarget",
+        (field) => typeof field === "boolean" || typeof field === "string",
+      ],
+      ["header", (field) => typeof field === "boolean"],
+      [
+        "minHeight",
+        (field) =>
+          typeof field === "number" && Number.isFinite(field) && field >= 0,
+      ],
+      [
+        "minWidth",
+        (field) =>
+          typeof field === "number" && Number.isFinite(field) && field >= 0,
+      ],
+      [
+        "resizeable",
+        (field) =>
+          field === false || field === "h" || field === "v" || field === "hv",
+      ],
+      ["title", (field) => typeof field === "string"],
+    ];
+    for (const [fieldName, isValid] of optionalFields) {
+      const field = item[fieldName];
+      if (field !== undefined && !isValid(field)) {
+        issues.push({
+          code: "INVALID_FIELD",
+          message: `invalid ${fieldName}`,
+          path: `${path}.${fieldName}`,
+        });
+      }
+    }
+  });
+
+  const stackedItemIds = new Set<string>();
+  const validatedStacks = Array.isArray(stacks) ? stacks : [];
+  if (!Array.isArray(stacks)) {
+    issues.push({
+      code: "INVALID_STRUCTURE",
+      message: "stacks must be an array",
+      path: "stacks",
+    });
+  }
+  validatedStacks.forEach((stack, stackIndex) => {
+    const path = `stacks[${stackIndex}]`;
+    if (!isRecord(stack)) {
+      issues.push({
+        code: "INVALID_STRUCTURE",
+        message: "stack must be an object",
+        path,
+      });
+      return;
+    }
+    validateKnownFields(
+      stack,
+      ["id", "itemIds", "selectedItemId"],
+      path,
+      issues,
+    );
+    addId(stack.id, `${path}.id`);
+    if (!Array.isArray(stack.itemIds)) {
+      issues.push({
+        code: "INVALID_STRUCTURE",
+        message: "stack item ids must be an array",
+        path: `${path}.itemIds`,
+      });
+      return;
+    }
+    if (stack.itemIds.length < 2) {
+      issues.push({
+        code: "INVALID_STACK_MEMBERSHIP",
+        message: "a stack must contain at least two items",
+        path: `${path}.itemIds`,
+      });
+    }
+    const members = new Set<string>();
+    stack.itemIds.forEach((itemId, itemIndex) => {
+      const itemPath = `${path}.itemIds[${itemIndex}]`;
+      if (typeof itemId !== "string") {
+        issues.push({
+          code: "INVALID_STACK_MEMBERSHIP",
+          message: "stack item id must be a string",
+          path: itemPath,
+        });
+      } else if (
+        !itemIds.has(itemId) ||
+        members.has(itemId) ||
+        stackedItemIds.has(itemId)
+      ) {
+        issues.push({
+          code: "INVALID_STACK_MEMBERSHIP",
+          message: `item "${itemId}" is missing, duplicated, or belongs to another stack`,
+          path: itemPath,
+        });
+      }
+      if (typeof itemId === "string") {
+        members.add(itemId);
+        stackedItemIds.add(itemId);
+      }
+    });
+    if (
+      typeof stack.selectedItemId !== "string" ||
+      !members.has(stack.selectedItemId)
+    ) {
+      issues.push({
+        code: "INVALID_STACK_SELECTION",
+        message: `selected item "${String(stack.selectedItemId)}" is not a stack member`,
+        path: `${path}.selectedItemId`,
+      });
+    }
+    const [firstItemId, ...otherItemIds] = members;
+    const firstItem = itemById.get(firstItemId);
+    const hasSameSpan = (left: unknown, right: unknown) =>
+      isRecord(left) &&
+      isRecord(right) &&
+      left.start === right.start &&
+      left.span === right.span;
+    if (
+      firstItem &&
+      otherItemIds.some((itemId) => {
+        const item = itemById.get(itemId);
+        return (
+          !item ||
+          !hasSameSpan(firstItem.column, item.column) ||
+          !hasSameSpan(firstItem.row, item.row)
+        );
+      })
+    ) {
+      issues.push({
+        code: "INVALID_STACK_POSITION",
+        message: "all stack members must occupy the same grid area",
+        path: `${path}.itemIds`,
+      });
+    }
+  });
+
+  return issues;
+};
+
+const assertValidSnapshot = (snapshot: GridSnapshot) => {
+  const issues = validateGridSnapshot(snapshot);
+  if (issues.length > 0) {
+    throw new GridSnapshotValidationError(issues);
+  }
+};
+
+export const normalizeGridSnapshot = (snapshot: GridSnapshot): GridSnapshot => {
+  assertValidSnapshot(snapshot);
+  return {
+    columns: snapshot.columns.map(cloneTrack),
+    gridId: snapshot.gridId,
+    items: snapshot.items.map(cloneItem),
+    revision: snapshot.revision,
+    rows: snapshot.rows.map(cloneTrack),
+    stacks: snapshot.stacks.map(cloneStack),
+  };
+};
+
+const parseGridArea = (
+  gridArea: string,
+  path: string,
+  issues: GridSnapshotValidationIssue[],
+): { column: GridSpanSnapshot; row: GridSpanSnapshot } => {
+  const lines = gridArea.split("/").map((value) => Number(value));
+  if (lines.length !== 4 || lines.some((value) => !Number.isInteger(value))) {
+    issues.push({
+      code: "MALFORMED_GRID_AREA",
+      message: `grid area "${gridArea}" must contain four integer grid lines`,
+      path,
+    });
+    return {
+      column: { span: Number.NaN, start: Number.NaN },
+      row: { span: Number.NaN, start: Number.NaN },
+    };
+  }
+  const [rowStart, columnStart, rowEnd, columnEnd] = lines;
+  return {
+    column: { span: columnEnd - columnStart, start: columnStart },
+    row: { span: rowEnd - rowStart, start: rowStart },
+  };
+};
+
+export const gridLayoutDescriptorToSnapshot = (
+  descriptor: GridLayoutDescriptorV1,
+  { gridId, revision = 0 }: GridLayoutDescriptorSnapshotOptions,
+): GridSnapshot => {
+  const issues: GridSnapshotValidationIssue[] = [];
+  const stackMembers = new Map<string, GridItemSnapshot[]>();
+  const items = Object.entries(descriptor.gridLayoutItems ?? {}).map(
+    ([id, item]): GridItemSnapshot => {
+      const { componentId, gridArea, stackId, ...metadata } = item;
+      const snapshotItem = {
+        ...metadata,
+        componentInstanceId: componentId,
+        id,
+        ...parseGridArea(gridArea, `gridLayoutItems.${id}.gridArea`, issues),
+      };
+      if (stackId) {
+        const members = stackMembers.get(stackId) ?? [];
+        members.push(snapshotItem);
+        stackMembers.set(stackId, members);
+      }
+      return snapshotItem;
+    },
+  );
+  const stacks = [...stackMembers].map(
+    ([id, members]): GridStackSnapshot => ({
+      id,
+      itemIds: members.map(({ id: itemId }) => itemId),
+      selectedItemId:
+        members.find(({ contentVisible }) => contentVisible)?.id ??
+        members[0]?.id ??
+        "",
+    }),
+  );
+  const stackedItemIds = new Set(stacks.flatMap(({ itemIds }) => itemIds));
+  const snapshot: GridSnapshot = {
+    columns: descriptor.cols.map((size) => ({ size })),
+    gridId,
+    items: items.map((item) => {
+      if (stackedItemIds.has(item.id)) {
+        const { contentVisible: _contentVisible, ...stackedItem } = item;
+        return stackedItem;
+      }
+      return item;
+    }),
+    revision,
+    rows: descriptor.rows.map((size) => ({ size })),
+    stacks,
+  };
+  issues.push(...validateGridSnapshot(snapshot));
+  if (issues.length > 0) {
+    throw new GridSnapshotValidationError(issues);
+  }
+  return normalizeGridSnapshot(snapshot);
+};
+
+const toDescriptorItem = (
+  item: GridItemSnapshot,
+  stack: GridStackSnapshot | undefined,
+): GridLayoutChildItemDescriptor => ({
+  ...(item.componentInstanceId === undefined
+    ? {}
+    : { componentId: item.componentInstanceId }),
+  contentVisible: stack
+    ? stack.selectedItemId === item.id
+    : item.contentVisible,
+  dropTarget: item.dropTarget,
+  gridArea: `${item.row.start}/${item.column.start}/${item.row.start + item.row.span}/${item.column.start + item.column.span}`,
+  header: item.header,
+  minHeight: item.minHeight,
+  minWidth: item.minWidth,
+  resizeable: item.resizeable,
+  stackId: stack?.id,
+  title: item.title,
+});
+
+export const gridSnapshotToGridLayoutDescriptor = (
+  snapshot: GridSnapshot,
+): GridLayoutDescriptorV1 => {
+  const normalized = normalizeGridSnapshot(snapshot);
+  const stackByItemId = new Map(
+    normalized.stacks.flatMap((stack) =>
+      stack.itemIds.map((itemId) => [itemId, stack] as const),
+    ),
+  );
+  return {
+    cols: normalized.columns.map(({ size }) => size),
+    gridLayoutItems: Object.fromEntries(
+      normalized.items.map((item) => [
+        item.id,
+        toDescriptorItem(item, stackByItemId.get(item.id)),
+      ]),
+    ),
+    rows: normalized.rows.map(({ size }) => size),
+  };
+};

--- a/vuu-ui/packages/grid-layout/src/index.ts
+++ b/vuu-ui/packages/grid-layout/src/index.ts
@@ -18,6 +18,30 @@ export {
   type SerializedGridLayout,
 } from "./GridLayoutProvider";
 export { GridLayoutStackedItem } from "./GridLayoutStackedtem";
+export {
+  gridLayoutDescriptorToSnapshot,
+  gridSnapshotToGridLayoutDescriptor,
+  normalizeGridSnapshot,
+  validateGridSnapshot,
+  type GridLayoutDescriptorSnapshotOptions,
+  type GridLayoutDescriptorV1,
+} from "./grid-snapshot-adapters";
+export {
+  GridSnapshotValidationError,
+  type ComponentInstanceId,
+  type GridId,
+  type GridItemId,
+  type GridItemResizeable,
+  type GridItemSnapshot,
+  type GridSnapshot,
+  type GridSnapshotValidationCode,
+  type GridSnapshotValidationIssue,
+  type GridSpanSnapshot,
+  type GridStackSnapshot,
+  type GridTrackSize,
+  type GridTrackSnapshot,
+  type StackId,
+} from "./GridSnapshot";
 export type {
   GridLayoutChangeHandler,
   GridLayoutDescriptor,

--- a/vuu-ui/packages/grid-layout/test/GridModel.scenarios.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridModel.scenarios.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { GridLayoutModel } from "../src/GridLayoutModel";
 import { GridModel } from "../src/GridModel";
 import {
+  gridLayoutDescriptorToSnapshot,
+  gridSnapshotToGridLayoutDescriptor,
+  normalizeGridSnapshot,
+  validateGridSnapshot,
+} from "../src/grid-snapshot-adapters";
+import {
+  GridSnapshotValidationError,
+  type GridSnapshot,
+} from "../src/GridSnapshot";
+import {
   descriptor,
   expectedItem,
   item,
@@ -545,6 +555,243 @@ describe("GridModel declarative layout scenarios", () => {
       "10px",
       "10px",
     ]);
+  });
+
+  describe("canonical snapshots", () => {
+    const expectStableDescriptor = (
+      gridId: string,
+      value: ReturnType<typeof descriptor>,
+    ) => {
+      const snapshot = gridLayoutDescriptorToSnapshot(value, { gridId });
+      expect(gridSnapshotToGridLayoutDescriptor(snapshot)).toEqual(value);
+    };
+
+    it("round-trips simple grids, spans, resize metadata, stacks, and placeholders", () => {
+      expectStableDescriptor(
+        "simple",
+        descriptor(["1fr", "240px"], ["80px", "1fr"], {
+          header: item("1/1/2/3", {
+            dropTarget: "workspace",
+            header: true,
+            minHeight: 48,
+            minWidth: 120,
+            resizeable: "h",
+            title: "Header",
+          }),
+          left: item("2/1/3/2"),
+          right: item("2/2/3/3", { resizeable: "hv" }),
+        }),
+      );
+      expectStableDescriptor(
+        "stack",
+        descriptor(["1fr"], ["1fr"], {
+          alpha: item("1/1/2/2", {
+            contentVisible: false,
+            stackId: "stack-1",
+            title: "Alpha",
+          }),
+          beta: item("1/1/2/2", {
+            contentVisible: true,
+            stackId: "stack-1",
+            title: "Beta",
+          }),
+        }),
+      );
+      expectStableDescriptor(
+        "legacy-placeholder",
+        descriptor(["1fr"], ["1fr"], {
+          "generated-placeholder-id": item("1/1/2/2", {
+            resizeable: "hv",
+          }),
+        }),
+      );
+      const withComponentId = descriptor(["1fr"], ["1fr"], {
+        main: {
+          ...item("1/1/2/2"),
+          componentId: "component-1",
+        },
+      });
+      const componentSnapshot = gridLayoutDescriptorToSnapshot(
+        withComponentId,
+        {
+          gridId: "component-identity",
+        },
+      );
+      expect(componentSnapshot.items[0].componentInstanceId).toBe(
+        "component-1",
+      );
+      expect(gridSnapshotToGridLayoutDescriptor(componentSnapshot)).toEqual(
+        withComponentId,
+      );
+    });
+
+    it.each([
+      {
+        code: "DUPLICATE_ID",
+        mutate: (snapshot: GridSnapshot): GridSnapshot => ({
+          ...snapshot,
+          items: [...snapshot.items, snapshot.items[0]],
+        }),
+      },
+      {
+        code: "INVALID_SPAN",
+        mutate: (snapshot: GridSnapshot): GridSnapshot => ({
+          ...snapshot,
+          items: [
+            {
+              ...snapshot.items[0],
+              column: { span: 0, start: 1 },
+            },
+          ],
+        }),
+      },
+      {
+        code: "INVALID_TRACK_REFERENCE",
+        mutate: (snapshot: GridSnapshot): GridSnapshot => ({
+          ...snapshot,
+          items: [
+            {
+              ...snapshot.items[0],
+              row: { span: 1, start: 2 },
+            },
+          ],
+        }),
+      },
+      {
+        code: "INVALID_STACK_MEMBERSHIP",
+        mutate: (snapshot: GridSnapshot): GridSnapshot => ({
+          ...snapshot,
+          stacks: [
+            {
+              id: "stack",
+              itemIds: ["main", "missing"],
+              selectedItemId: "main",
+            },
+          ],
+        }),
+      },
+      {
+        code: "INVALID_STACK_SELECTION",
+        mutate: (snapshot: GridSnapshot): GridSnapshot => ({
+          ...snapshot,
+          items: [
+            snapshot.items[0],
+            {
+              ...snapshot.items[0],
+              id: "secondary",
+            },
+          ],
+          stacks: [
+            {
+              id: "stack",
+              itemIds: ["main", "secondary"],
+              selectedItemId: "missing",
+            },
+          ],
+        }),
+      },
+      {
+        code: "INVALID_STACK_POSITION",
+        mutate: (snapshot: GridSnapshot): GridSnapshot => ({
+          ...snapshot,
+          items: [
+            snapshot.items[0],
+            {
+              ...snapshot.items[0],
+              column: { span: 1, start: 2 },
+              id: "secondary",
+            },
+          ],
+          columns: [{ size: "1fr" }, { size: "1fr" }],
+          stacks: [
+            {
+              id: "stack",
+              itemIds: ["main", "secondary"],
+              selectedItemId: "main",
+            },
+          ],
+        }),
+      },
+      {
+        code: "MALFORMED_TRACK",
+        mutate: (snapshot: GridSnapshot): GridSnapshot => ({
+          ...snapshot,
+          columns: [{ size: "auto" as "1fr" }],
+        }),
+      },
+    ])("reports typed $code validation failures", ({ code, mutate }) => {
+      const valid = gridLayoutDescriptorToSnapshot(
+        descriptor(["1fr"], ["1fr"], { main: item("1/1/2/2") }),
+        { gridId: "invalid-cases" },
+      );
+      const invalid = mutate(valid);
+      expect(validateGridSnapshot(invalid)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ code })]),
+      );
+      try {
+        normalizeGridSnapshot(invalid);
+        expect.unreachable("expected snapshot validation to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(GridSnapshotValidationError);
+        expect((error as GridSnapshotValidationError).issues).toEqual(
+          expect.arrayContaining([expect.objectContaining({ code })]),
+        );
+      }
+    });
+
+    it("reports malformed legacy grid areas as typed validation failures", () => {
+      expect(() =>
+        gridLayoutDescriptorToSnapshot(
+          descriptor(["1fr"], ["1fr"], { main: item("not-a-grid-area") }),
+          { gridId: "malformed-area" },
+        ),
+      ).toThrow(GridSnapshotValidationError);
+    });
+
+    it("returns structured issues for malformed persisted input", () => {
+      expect(validateGridSnapshot({ revision: "latest" })).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: "EMPTY_ID" }),
+          expect.objectContaining({ code: "INVALID_REVISION" }),
+          expect.objectContaining({ code: "INVALID_STRUCTURE" }),
+        ]),
+      );
+      const snapshot = gridLayoutDescriptorToSnapshot(
+        descriptor(["1fr"], ["1fr"], { main: item("1/1/2/2") }),
+        { gridId: "unexpected-field" },
+      );
+      expect(
+        validateGridSnapshot({
+          ...snapshot,
+          items: [{ ...snapshot.items[0], minWidht: 100 }],
+        }),
+      ).toEqual([
+        expect.objectContaining({
+          code: "UNEXPECTED_FIELD",
+          path: "items[0].minWidht",
+        }),
+      ]);
+    });
+
+    it("returns snapshots detached from later model and descriptor changes", () => {
+      const initial = descriptor(["1fr"], ["1fr"], {
+        main: item("1/1/2/2", { title: "Initial" }),
+      });
+      const model = new GridModel("detached", initial);
+      const snapshot = gridLayoutDescriptorToSnapshot(
+        model.toGridLayoutDescriptor(),
+        { gridId: model.id, revision: 7 },
+      );
+
+      model.updateChildTitle("main", "Changed");
+      initial.cols[0] = "200px";
+
+      expect(snapshot).toMatchObject({
+        columns: [{ size: "1fr" }],
+        items: [{ title: "Initial" }],
+        revision: 7,
+      });
+    });
   });
 
   it("redistributes through overlapping aggregate minimums", () => {

--- a/vuu-ui/packages/grid-layout/test/model-scenario-harness.ts
+++ b/vuu-ui/packages/grid-layout/test/model-scenario-harness.ts
@@ -2,6 +2,11 @@ import type { GridLayoutSplitDirection } from "@vuu-ui/vuu-utils";
 import { expect } from "vitest";
 import { GridLayoutModel } from "../src/GridLayoutModel";
 import {
+  gridLayoutDescriptorToSnapshot,
+  gridSnapshotToGridLayoutDescriptor,
+  normalizeGridSnapshot,
+} from "../src/grid-snapshot-adapters";
+import {
   GridModel,
   GridModelChildItem,
   type GridLayoutChildItemDescriptor,
@@ -288,6 +293,13 @@ const descriptorState = (descriptor: GridLayoutDescriptor) => ({
   rows: descriptor.rows,
 });
 
+export const snapshotState = (model: GridModel) =>
+  normalizeGridSnapshot(
+    gridLayoutDescriptorToSnapshot(model.toGridLayoutDescriptor(), {
+      gridId: model.id,
+    }),
+  );
+
 export const assertModelInvariants = (model: GridModel) => {
   const { colCount, rowCount } = model.tracks;
   for (const { column, id, row } of model.childItems) {
@@ -344,6 +356,10 @@ export const assertModelInvariants = (model: GridModel) => {
   }
 
   const serialized = model.toGridLayoutDescriptor();
+  const snapshot = snapshotState(model);
+  expect(descriptorState(gridSnapshotToGridLayoutDescriptor(snapshot))).toEqual(
+    descriptorState(serialized),
+  );
   const roundTripped = new GridModel(`${model.id}-round-trip`, serialized);
   expect(descriptorState(roundTripped.toGridLayoutDescriptor())).toEqual(
     descriptorState(serialized),


### PR DESCRIPTION
## Phase 6, increment 1

Stacked on `heswell-copilot-finish-grid-layout-tests` and depends on #2341. This PR does not modify #2341.

## Scope

- Add readonly canonical grid, track, item, stack, component-instance, and revision snapshot contracts.
- Add detached normalization plus typed, structured validation for malformed structure/fields/tracks, duplicate IDs, invalid spans and track references, and inconsistent stack membership, selection, or geometry.
- Add bidirectional v1 `GridLayoutDescriptor` adapters, including component identity, existing IDs, track strings, `resizeable` wire spelling, headers, titles, drop-target metadata, minimum sizes, legacy placeholders, and current stack selection semantics.
- Route every existing GridModel scenario through the public canonical adapter and add focused stability, failure, and detachment coverage.

## Compatibility guarantees

Production runtime, rendering, commands, persistence writers, palette, and consumers remain unchanged. Dragging, detached content, hover/splitter state, and measured dimensions are excluded from the persisted contract. Runtime-generated stack wrappers and splitters are not persisted; legacy placeholder descriptors remain adapter-compatible without becoming a distinct canonical source of truth.

## Validation

- `vitest run packages/grid-layout/test/GridModel.scenarios.test.ts`: 38 passed, 2 existing todos
- targeted Biome check: passed
- `@heswell/grid-layout` build: passed
- root typecheck attempted; it remains blocked by pre-existing errors outside this package in `vuu-data-react`, `vuu-utils`, portal examples, sample apps, and showcase. The declaration traversal reported no errors in changed GridLayout files.