### PR TITLE
feat(grid-layout): add typed legacy commands

### DIFF
--- a/vuu-ui/packages/grid-layout/src/GridCommand.ts
+++ b/vuu-ui/packages/grid-layout/src/GridCommand.ts
@@ -1,0 +1,719 @@
+import type { GridLayoutSplitDirection } from "@vuu-ui/vuu-utils";
+import { GridLayoutModel, type GridItemRemoveReason } from "./GridLayoutModel";
+import {
+  type GridModel,
+  GridModelChildItem,
+  type GridTrackResizeConstraint,
+  type TrackSize,
+  type TrackType,
+} from "./GridModel";
+import type {
+  GridItemId,
+  GridItemResizeable,
+  GridSpanSnapshot,
+  StackId,
+} from "./GridSnapshot";
+
+export interface GridCommandItem {
+  readonly column: GridSpanSnapshot;
+  readonly contentVisible?: boolean;
+  readonly dropTarget?: boolean | string;
+  readonly header?: boolean;
+  readonly id: GridItemId;
+  readonly minHeight?: number;
+  readonly minWidth?: number;
+  readonly resizeable?: GridItemResizeable;
+  readonly row: GridSpanSnapshot;
+  readonly title?: string;
+}
+
+export interface GridCommandResizeConstraint {
+  readonly minimum: number;
+  readonly trackIndices: readonly number[];
+}
+
+export type GridTrackResize =
+  | {
+      readonly contraTrackIndex: number;
+      readonly delta: number;
+      readonly distribution: "adjacent";
+      readonly measuredSizes?: readonly number[];
+      readonly resizedTrackIndex: number;
+      readonly track: TrackType;
+    }
+  | {
+      readonly afterConstraints?: readonly GridCommandResizeConstraint[];
+      readonly afterTrackIndices: readonly number[];
+      readonly beforeConstraints?: readonly GridCommandResizeConstraint[];
+      readonly beforeTrackIndices: readonly number[];
+      readonly delta: number;
+      readonly distribution: "proportional";
+      readonly initialSizes?: readonly number[];
+      readonly measuredSizes?: readonly number[];
+      readonly track: TrackType;
+    };
+
+export type GridCommand =
+  | { readonly item: GridCommandItem; readonly type: "add-item" }
+  | {
+      readonly itemId: GridItemId;
+      readonly position: GridLayoutSplitDirection;
+      readonly targetId: GridItemId;
+      readonly type: "move-item";
+    }
+  | {
+      readonly itemId: GridItemId;
+      readonly targetId: GridItemId;
+      readonly type: "replace-item";
+    }
+  | {
+      readonly itemId: GridItemId;
+      readonly reason: GridItemRemoveReason;
+      readonly type: "remove-item";
+    }
+  | {
+      readonly index: number;
+      readonly size: TrackSize;
+      readonly track: TrackType;
+      readonly type: "resize-track";
+    }
+  | ({ readonly type: "resize-tracks" } & GridTrackResize)
+  | {
+      readonly itemId: GridItemId;
+      readonly targetId: GridItemId;
+      readonly type: "create-stack";
+    }
+  | {
+      readonly item: GridCommandItem;
+      readonly stackId: StackId;
+      readonly type: "add-stack-item";
+    }
+  | {
+      readonly itemId: GridItemId;
+      readonly stackId: StackId;
+      readonly type: "remove-stack-item";
+    }
+  | {
+      readonly itemId: GridItemId;
+      readonly stackId: StackId;
+      readonly type: "select-stack-item";
+    }
+  | {
+      readonly activate?: boolean;
+      readonly itemId: GridItemId;
+      readonly position: "after" | "before";
+      readonly stackId: StackId;
+      readonly targetItemId: GridItemId;
+      readonly type: "reorder-stack-item";
+    }
+  | {
+      readonly itemId: GridItemId;
+      readonly title: string;
+      readonly type: "rename-item";
+    }
+  | { readonly type: "regenerate-placeholders" };
+
+export type GridCommandErrorCode =
+  | "DUPLICATE_ITEM_ID"
+  | "INVALID_ITEM"
+  | "INVALID_TARGET"
+  | "ITEM_NOT_FOUND"
+  | "MEASUREMENT_REQUIRED"
+  | "NON_RESIZABLE"
+  | "STACK_NOT_FOUND"
+  | "TAB_NOT_FOUND"
+  | "TRACK_NOT_FOUND"
+  | "UNSUPPORTED_ACTION";
+
+export interface GridCommandError {
+  readonly code: GridCommandErrorCode;
+  readonly message: string;
+}
+
+export type GridCommandResult =
+  | { readonly command: GridCommand["type"]; readonly ok: true }
+  | {
+      readonly command: GridCommand["type"];
+      readonly error: GridCommandError;
+      readonly ok: false;
+    };
+
+export class GridCommandExecutionError extends Error {
+  readonly code: GridCommandErrorCode;
+
+  constructor({ code, message }: GridCommandError) {
+    super(message);
+    this.name = "GridCommandExecutionError";
+    this.code = code;
+  }
+}
+
+const assertNever = (value: never): never => {
+  throw Error(`Unhandled GridCommand: ${JSON.stringify(value)}`);
+};
+
+const success = (command: GridCommand): GridCommandResult => ({
+  command: command.type,
+  ok: true,
+});
+
+const failure = (
+  command: GridCommand,
+  code: GridCommandErrorCode,
+  message: string,
+): GridCommandResult => ({
+  command: command.type,
+  error: { code, message },
+  ok: false,
+});
+
+const toPosition = ({ span, start }: GridSpanSnapshot) => ({
+  end: start + span,
+  start,
+});
+
+const toChildItem = (
+  item: GridCommandItem,
+  stackId?: StackId,
+): GridModelChildItem =>
+  new GridModelChildItem({
+    ...item,
+    column: toPosition(item.column),
+    row: toPosition(item.row),
+    stackId,
+  });
+
+const toConstraints = (
+  constraints: readonly GridCommandResizeConstraint[] | undefined,
+): GridTrackResizeConstraint[] =>
+  constraints?.map(({ minimum, trackIndices }) => ({
+    minimum,
+    trackIndices: [...trackIndices],
+  })) ?? [];
+
+export class LegacyGridCommandExecutor {
+  constructor(
+    private readonly gridModel: GridModel,
+    private readonly gridLayoutModel = new GridLayoutModel(gridModel),
+  ) {}
+
+  execute(command: GridCommand): GridCommandResult {
+    switch (command.type) {
+      case "add-item": {
+        const invalid = this.validateNewItem(command, command.item);
+        if (invalid) {
+          return invalid;
+        }
+        this.gridModel.addChildItem(toChildItem(command.item));
+        return success(command);
+      }
+      case "move-item": {
+        const invalid = this.validatePair(
+          command,
+          command.itemId,
+          command.targetId,
+        );
+        if (invalid) {
+          return invalid;
+        }
+        const stackedMember = this.rejectStackMember(
+          command,
+          command.itemId,
+          command.targetId,
+        );
+        if (stackedMember) {
+          return stackedMember;
+        }
+        if (
+          !this.gridLayoutModel.canSplitGridItem(
+            command.targetId,
+            command.position,
+          )
+        ) {
+          return failure(
+            command,
+            "NON_RESIZABLE",
+            `Grid item #${command.targetId} cannot be split ${command.position}`,
+          );
+        }
+        this.gridLayoutModel.dropSplitGridItem(
+          command.itemId,
+          command.targetId,
+          command.position,
+        );
+        return success(command);
+      }
+      case "replace-item": {
+        const invalid = this.validatePair(
+          command,
+          command.itemId,
+          command.targetId,
+        );
+        if (invalid) {
+          return invalid;
+        }
+        const stackedMember = this.rejectStackMember(
+          command,
+          command.itemId,
+          command.targetId,
+        );
+        if (stackedMember) {
+          return stackedMember;
+        }
+        this.gridLayoutModel.dropReplaceGridItem(
+          command.itemId,
+          command.targetId,
+        );
+        return success(command);
+      }
+      case "remove-item": {
+        const invalid = this.requireItem(command, command.itemId);
+        if (invalid) {
+          return invalid;
+        }
+        this.gridLayoutModel.removeGridItem(command.itemId, command.reason);
+        return success(command);
+      }
+      case "resize-track": {
+        const invalid = this.requireTracks(command, command.track, [
+          command.index,
+        ]);
+        if (invalid) {
+          return invalid;
+        }
+        this.gridModel.tracks.resizeTo(
+          command.track,
+          command.index,
+          command.size,
+        );
+        return success(command);
+      }
+      case "resize-tracks": {
+        if (!Number.isFinite(command.delta)) {
+          return failure(
+            command,
+            "INVALID_ITEM",
+            "Grid track resize delta must be finite",
+          );
+        }
+        if (
+          command.distribution === "adjacent" &&
+          command.resizedTrackIndex === command.contraTrackIndex
+        ) {
+          return failure(
+            command,
+            "INVALID_TARGET",
+            "Adjacent track resize requires two distinct tracks",
+          );
+        }
+        const indices =
+          command.distribution === "adjacent"
+            ? [command.resizedTrackIndex, command.contraTrackIndex]
+            : [
+                ...command.beforeTrackIndices,
+                ...command.afterTrackIndices,
+                ...(command.beforeConstraints ?? []).flatMap(
+                  ({ trackIndices }) => trackIndices,
+                ),
+                ...(command.afterConstraints ?? []).flatMap(
+                  ({ trackIndices }) => trackIndices,
+                ),
+              ];
+        if (
+          command.distribution === "proportional" &&
+          command.initialSizes &&
+          (command.initialSizes.length !==
+            this.gridModel.tracks.getTracks(command.track).length ||
+            command.initialSizes.some(
+              (size) => !Number.isFinite(size) || size < 0,
+            ))
+        ) {
+          return failure(
+            command,
+            "INVALID_ITEM",
+            `Initial ${command.track} sizes must contain one non-negative value per track`,
+          );
+        }
+        const invalid =
+          this.requireTracks(command, command.track, indices) ??
+          this.validateResizeCommand(command) ??
+          this.applyMeasurements(
+            command,
+            command.track,
+            indices,
+            command.measuredSizes,
+          );
+        if (invalid) {
+          return invalid;
+        }
+        if (command.distribution === "adjacent") {
+          this.gridModel.tracks.resizeBy(
+            command.track,
+            command.resizedTrackIndex,
+            command.contraTrackIndex,
+            command.delta,
+          );
+        } else {
+          this.gridModel.tracks.resizeGroupsProportionally(
+            command.track,
+            [...command.beforeTrackIndices],
+            [...command.afterTrackIndices],
+            command.delta,
+            toConstraints(command.beforeConstraints),
+            toConstraints(command.afterConstraints),
+            command.initialSizes ? [...command.initialSizes] : undefined,
+          );
+        }
+        return success(command);
+      }
+      case "create-stack": {
+        const invalid = this.validatePair(
+          command,
+          command.itemId,
+          command.targetId,
+        );
+        if (invalid) {
+          return invalid;
+        }
+        if (
+          this.gridModel.getChildItem(command.itemId, true).stackId ||
+          this.gridModel.getChildItem(command.targetId, true).stackId
+        ) {
+          return failure(
+            command,
+            "INVALID_TARGET",
+            "A new stack requires two unstacked items",
+          );
+        }
+        this.gridModel.stackChildItems(command.targetId, command.itemId);
+        return success(command);
+      }
+      case "add-stack-item": {
+        const invalid =
+          this.requireStack(command, command.stackId) ??
+          this.validateNewItem(command, command.item);
+        if (invalid) {
+          return invalid;
+        }
+        const stack = this.gridModel.getChildItem(command.stackId, true);
+        this.gridModel.addChildItem(
+          toChildItem(
+            {
+              ...command.item,
+              column: {
+                span: stack.column.end - stack.column.start,
+                start: stack.column.start,
+              },
+              row: {
+                span: stack.row.end - stack.row.start,
+                start: stack.row.start,
+              },
+            },
+            command.stackId,
+          ),
+        );
+        return success(command);
+      }
+      case "remove-stack-item": {
+        const invalid = this.requireTab(
+          command,
+          command.stackId,
+          command.itemId,
+        );
+        if (invalid) {
+          return invalid;
+        }
+        this.gridLayoutModel.removeGridItem(command.itemId, "close");
+        return success(command);
+      }
+      case "select-stack-item": {
+        const invalid = this.requireTab(
+          command,
+          command.stackId,
+          command.itemId,
+        );
+        if (invalid) {
+          return invalid;
+        }
+        this.gridModel
+          .getTabState(command.stackId)
+          .setActiveTabById(command.itemId);
+        return success(command);
+      }
+      case "reorder-stack-item": {
+        const invalid =
+          this.requireTab(command, command.stackId, command.itemId) ??
+          this.requireTab(command, command.stackId, command.targetItemId);
+        if (invalid) {
+          return invalid;
+        }
+        if (command.itemId === command.targetItemId) {
+          return failure(
+            command,
+            "INVALID_TARGET",
+            "A tab cannot be reordered relative to itself",
+          );
+        }
+        this.gridModel
+          .getTabState(command.stackId)
+          .moveTabById(
+            command.itemId,
+            command.targetItemId,
+            command.position,
+            command.activate ?? false,
+          );
+        return success(command);
+      }
+      case "rename-item": {
+        const invalid = this.requireItem(command, command.itemId);
+        if (invalid) {
+          return invalid;
+        }
+        this.gridModel.updateChildTitle(command.itemId, command.title);
+        return success(command);
+      }
+      case "regenerate-placeholders":
+        this.gridModel.createPlaceholders();
+        return success(command);
+      default:
+        return assertNever(command);
+    }
+  }
+
+  private applyMeasurements(
+    command: GridCommand,
+    trackType: TrackType,
+    indices: readonly number[],
+    measuredSizes: readonly number[] | undefined,
+  ): GridCommandResult | undefined {
+    const tracks = this.gridModel.tracks.getTracks(trackType);
+    if (measuredSizes) {
+      if (
+        measuredSizes.length !== tracks.length ||
+        measuredSizes.some((size) => !Number.isFinite(size) || size < 0)
+      ) {
+        return failure(
+          command,
+          "INVALID_ITEM",
+          `Measured ${trackType} sizes must contain one non-negative value per track`,
+        );
+      }
+
+      measuredSizes.forEach((size, index) => {
+        tracks[index].measuredValue = size;
+      });
+      indices.forEach((index) => {
+        if (tracks[index].isFraction) {
+          tracks[index].convertUnitsToPixels();
+        }
+      });
+    }
+    if (
+      indices.some(
+        (index) => tracks[index].isFraction && !tracks[index].isMeasured,
+      )
+    ) {
+      return failure(
+        command,
+        "MEASUREMENT_REQUIRED",
+        `Fractional ${trackType} resize requires measuredSizes`,
+      );
+    }
+  }
+
+  private validateResizeCommand(
+    command: Extract<GridCommand, { type: "resize-tracks" }>,
+  ): GridCommandResult | undefined {
+    const tracks = this.gridModel.tracks.getTracks(command.track);
+    if (command.distribution === "adjacent") {
+      const currentSize = (index: number) =>
+        command.measuredSizes?.[index] ??
+        (tracks[index].isFraction ? undefined : tracks[index].numericValue);
+      const resizedSize = currentSize(command.resizedTrackIndex);
+      const contraSize = currentSize(command.contraTrackIndex);
+      if (
+        (resizedSize !== undefined && resizedSize + command.delta < 0) ||
+        (contraSize !== undefined && contraSize - command.delta < 0)
+      ) {
+        return failure(
+          command,
+          "INVALID_ITEM",
+          "Adjacent track resize cannot produce a negative track size",
+        );
+      }
+      return;
+    }
+
+    const before = new Set(command.beforeTrackIndices);
+    const after = new Set(command.afterTrackIndices);
+    if (
+      before.size !== command.beforeTrackIndices.length ||
+      after.size !== command.afterTrackIndices.length ||
+      [...before].some((index) => after.has(index))
+    ) {
+      return failure(
+        command,
+        "INVALID_TARGET",
+        "Proportional track resize groups must contain unique, disjoint tracks",
+      );
+    }
+    for (const [constraints, group] of [
+      [command.beforeConstraints ?? [], before],
+      [command.afterConstraints ?? [], after],
+    ] as const) {
+      for (const { minimum, trackIndices } of constraints) {
+        if (
+          !Number.isFinite(minimum) ||
+          minimum < 0 ||
+          trackIndices.some((index) => !group.has(index))
+        ) {
+          return failure(
+            command,
+            "INVALID_ITEM",
+            "Grid track resize constraints must reference their own group and have non-negative minimums",
+          );
+        }
+      }
+    }
+  }
+
+  private requireItem(
+    command: GridCommand,
+    itemId: GridItemId,
+  ): GridCommandResult | undefined {
+    if (!this.gridModel.getChildItem(itemId)) {
+      return failure(
+        command,
+        "ITEM_NOT_FOUND",
+        `[GridModel] GridItem #${itemId} not found`,
+      );
+    }
+  }
+
+  private requireStack(
+    command: GridCommand,
+    stackId: StackId,
+  ): GridCommandResult | undefined {
+    const stack = this.gridModel.getChildItem(stackId);
+    if (!stack || stack.type !== "stacked-content") {
+      return failure(
+        command,
+        "STACK_NOT_FOUND",
+        `Grid stack #${stackId} not found`,
+      );
+    }
+  }
+
+  private requireTab(
+    command: GridCommand,
+    stackId: StackId,
+    itemId: GridItemId,
+  ): GridCommandResult | undefined {
+    const invalidStack = this.requireStack(command, stackId);
+    if (invalidStack) {
+      return invalidStack;
+    }
+    const tab = this.gridModel
+      .getTabState(stackId)
+      .tabs.find(({ id }) => id === itemId);
+    if (!tab) {
+      return failure(
+        command,
+        "TAB_NOT_FOUND",
+        `Grid tab #${itemId} not found in stack #${stackId}`,
+      );
+    }
+  }
+
+  private requireTracks(
+    command: GridCommand,
+    trackType: TrackType,
+    indices: readonly number[],
+  ): GridCommandResult | undefined {
+    const trackCount = this.gridModel.tracks.getTracks(trackType).length;
+    const missing = indices.find(
+      (index) => !Number.isInteger(index) || index < 0 || index >= trackCount,
+    );
+    if (missing !== undefined) {
+      return failure(
+        command,
+        "TRACK_NOT_FOUND",
+        `Grid ${trackType} track #${missing} not found`,
+      );
+    }
+  }
+
+  private validateNewItem(
+    command: GridCommand,
+    item: GridCommandItem,
+  ): GridCommandResult | undefined {
+    if (this.gridModel.getChildItem(item.id)) {
+      return failure(
+        command,
+        "DUPLICATE_ITEM_ID",
+        `Grid item #${item.id} already exists`,
+      );
+    }
+    const { colCount, rowCount } = this.gridModel.tracks;
+    if (
+      !item.id ||
+      !Number.isInteger(item.column.start) ||
+      !Number.isInteger(item.column.span) ||
+      !Number.isInteger(item.row.start) ||
+      !Number.isInteger(item.row.span) ||
+      item.column.start < 1 ||
+      item.row.start < 1 ||
+      item.column.span < 1 ||
+      item.row.span < 1 ||
+      item.column.start + item.column.span > colCount + 1 ||
+      item.row.start + item.row.span > rowCount + 1
+    ) {
+      return failure(
+        command,
+        "INVALID_ITEM",
+        `Grid item #${item.id} has invalid grid coordinates`,
+      );
+    }
+  }
+
+  private validatePair(
+    command: GridCommand,
+    itemId: GridItemId,
+    targetId: GridItemId,
+  ): GridCommandResult | undefined {
+    const invalid =
+      this.requireItem(command, itemId) ?? this.requireItem(command, targetId);
+    if (invalid) {
+      return invalid;
+    }
+    if (itemId === targetId) {
+      return failure(
+        command,
+        "INVALID_TARGET",
+        `Grid item #${itemId} cannot target itself`,
+      );
+    }
+  }
+
+  private rejectStackMember(
+    command: GridCommand,
+    ...itemIds: GridItemId[]
+  ): GridCommandResult | undefined {
+    const stackedMember = itemIds
+      .map((itemId) => this.gridModel.getChildItem(itemId, true))
+      .find(({ stackId }) => stackId !== undefined);
+    if (stackedMember) {
+      return failure(
+        command,
+        "INVALID_TARGET",
+        `Stack member #${stackedMember.id} must be moved through a stack command`,
+      );
+    }
+  }
+}
+
+export const throwForGridCommandFailure = (result: GridCommandResult): void => {
+  if (!result.ok) {
+    throw new GridCommandExecutionError(result.error);
+  }
+};

--- a/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
@@ -39,6 +39,12 @@ export type GridLayoutSwitchTabAction = {
   toId: string;
 };
 
+export type GridLayoutSelectTabAction = {
+  type: "select-tab";
+  itemId: string;
+  stackId: string;
+};
+
 export type GridLayoutTrackAction = {
   type: "resize-grid-column" | "resize-grid-row";
   trackIndex: number;
@@ -50,6 +56,7 @@ export type GridLayoutAction =
   // | GridLayoutInsertTabAction
   | GridLayoutAddTabbedChildAction
   | GridLayoutSwitchTabAction
+  | GridLayoutSelectTabAction
   | GridLayoutTrackAction
   | GridLayoutRenameTabAction;
 

--- a/vuu-ui/packages/grid-layout/src/GridLayoutStackedtem.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutStackedtem.tsx
@@ -17,7 +17,11 @@ import {
   useEffect,
 } from "react";
 import { useDragContext } from "./drag-drop-next/DragDropProviderNext";
-import { type ComponentTemplate, useGridModel } from "./GridLayoutContext";
+import {
+  type ComponentTemplate,
+  useGridLayoutDispatch,
+  useGridModel,
+} from "./GridLayoutContext";
 import type { GridLayoutItemProps } from "./GridLayoutItem";
 import { resolveMinimumGridItemSize } from "./GridModel";
 import { TabMenu } from "./TabMenu";
@@ -82,13 +86,14 @@ export const GridLayoutStackedItem = ({
   });
 
   const { getTabState } = useGridModel();
+  const dispatch = useGridLayoutDispatch();
   const tabState = getTabState(id, "create");
 
   const handleTabSelectionChange = useCallback(
     (_: SyntheticEvent | null, value: string) => {
-      tabState.setActiveTab(value);
+      dispatch({ type: "select-tab", itemId: value, stackId: id });
     },
-    [tabState],
+    [dispatch, id],
   );
 
   const className = cx(classBaseItem, "vuuGridLayoutItem", {
@@ -126,7 +131,7 @@ export const GridLayoutStackedItem = ({
       >
         <Tabs
           onChange={handleTabSelectionChange}
-          value={tabState.tabs[tabState.active]?.label ?? null}
+          value={tabState.tabs[tabState.active]?.id ?? null}
         >
           <TabBar divider>
             <TabList
@@ -141,8 +146,8 @@ export const GridLayoutStackedItem = ({
                   data-grid-layout-item-id={gridLayoutItemId}
                   data-label={label}
                   draggable
-                  value={label}
-                  key={label}
+                  value={gridLayoutItemId}
+                  key={gridLayoutItemId}
                 >
                   <TabTrigger>{label}</TabTrigger>
                   {showMenu ? (

--- a/vuu-ui/packages/grid-layout/src/GridModel.ts
+++ b/vuu-ui/packages/grid-layout/src/GridModel.ts
@@ -403,6 +403,11 @@ export class TabState extends EventEmitter<TabStateTabEvents> {
     this.emit("active-change", this);
   }
 
+  setActiveTabById(id: string) {
+    this.active = this.tabs.findIndex((tab) => tab.id === id);
+    this.emit("active-change", this);
+  }
+
   /**
    * A Tab is detached when a drag operation commences. It is removed from Tabstrip, but associated component
    * remains in DOM. The 'next' tab is selected and the associated TabPanel made visible. The tab panel associated
@@ -460,6 +465,29 @@ export class TabState extends EventEmitter<TabStateTabEvents> {
     this.emit("tabs-change", this.id, this.active, this.tabs);
   }
 
+  moveTabById(
+    tabId: string,
+    targetId: string,
+    position: "after" | "before",
+    activateTab = false,
+  ) {
+    const activeTabId = this.activeTab.id;
+    const newTabs = this.tabs.slice();
+    const indexOfMovedTab = newTabs.findIndex(({ id }) => id === tabId);
+    const [movedTab] = newTabs.splice(indexOfMovedTab, 1);
+    const indexOfTargetTab = newTabs.findIndex(({ id }) => id === targetId);
+    newTabs.splice(
+      position === "after" ? indexOfTargetTab + 1 : indexOfTargetTab,
+      0,
+      movedTab,
+    );
+    this.tabs = newTabs;
+    this.active = this.tabs.findIndex(
+      ({ id }) => id === (activateTab ? tabId : activeTabId),
+    );
+    this.emit("tabs-change", this.id, this.active, this.tabs);
+  }
+
   addTab(tab: TabStateTab, dropPosition?: DropPosition) {
     if (dropPosition) {
       const { position, target } = dropPosition;
@@ -479,9 +507,13 @@ export class TabState extends EventEmitter<TabStateTabEvents> {
   }
 
   removeTab(id: string) {
-    const { label: activeLabel } = this.activeTab;
+    const activeTabId = this.activeTab.id;
+    const previousActive = this.active;
     this.tabs = this.tabs.filter((tab) => tab.id !== id);
-    this.active = this.indexOfTab(activeLabel);
+    this.active =
+      activeTabId === id
+        ? Math.min(previousActive, this.tabs.length - 1)
+        : this.tabs.findIndex((tab) => tab.id === activeTabId);
     if (this.tabs.length === 1) {
       this.emit("tabs-removed", this.id);
     } else {

--- a/vuu-ui/packages/grid-layout/src/index.ts
+++ b/vuu-ui/packages/grid-layout/src/index.ts
@@ -5,6 +5,18 @@ export type {
 export { DragDropProviderNext } from "./drag-drop-next/DragDropProviderNext";
 export { GridLayout, type GridResizeDistribution } from "./GridLayout";
 export {
+  GridCommandExecutionError,
+  LegacyGridCommandExecutor,
+  throwForGridCommandFailure,
+  type GridCommand,
+  type GridCommandError,
+  type GridCommandErrorCode,
+  type GridCommandItem,
+  type GridCommandResizeConstraint,
+  type GridCommandResult,
+  type GridTrackResize,
+} from "./GridCommand";
+export {
   useGridLayoutDispatch,
   useGridLayoutDragStartHandler,
   useGridModel,

--- a/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
@@ -69,6 +69,11 @@ import {
 } from "./react-element-utils";
 import { GridLayoutDragStartHandler } from "./useDraggable";
 import { LayoutJSON } from "./componentToJson";
+import {
+  GridCommandExecutionError,
+  LegacyGridCommandExecutor,
+  throwForGridCommandFailure,
+} from "./GridCommand";
 
 export type GridLayoutHookProps = {
   children: ReactNode;
@@ -83,6 +88,13 @@ type NonContentGridItems = {
   splitters: ISplitter[];
   placeholders: GridModelChildItem[];
   stackedItems: GridModelChildItem[];
+};
+
+const assertNeverGridLayoutAction = (action: never): never => {
+  throw new GridCommandExecutionError({
+    code: "UNSUPPORTED_ACTION",
+    message: `Unsupported GridLayoutAction: ${JSON.stringify(action)}`,
+  });
 };
 
 /**
@@ -188,6 +200,10 @@ export const useGridLayout = ({
   );
   const dragStartLayoutRef = useRef<GridLayoutDescriptor | undefined>(
     undefined,
+  );
+  const commandExecutor = useMemo(
+    () => new LegacyGridCommandExecutor(gridModel, gridLayoutModel),
+    [gridLayoutModel, gridModel],
   );
 
   const saveGridLayout = useCallback<GridLayoutChangeHandler>(
@@ -668,11 +684,27 @@ export const useGridLayout = ({
   const dispatchGridLayoutAction = useCallback<GridLayoutDispatch>(
     (action) => {
       switch (action.type) {
-        case "close":
-          removeGridItem(action.id, "close");
+        case "close": {
+          throwForGridCommandFailure(
+            commandExecutor.execute({
+              itemId: action.id,
+              reason: "close",
+              type: "remove-item",
+            }),
+          );
+          setChildren((children) =>
+            children.filter((child) => child.props.id !== action.id),
+          );
           break;
+        }
         case "rename-tab":
-          gridModel.updateChildTitle(action.id, action.title);
+          throwForGridCommandFailure(
+            commandExecutor.execute({
+              itemId: action.id,
+              title: action.title,
+              type: "rename-item",
+            }),
+          );
           break;
         case "add-tabbed-child":
           {
@@ -682,17 +714,25 @@ export const useGridLayout = ({
             const { column, row } = gridModel.getChildItem(stackId, true);
 
             const newChildId = uuid();
-            const gridModelChildItem = new GridModelChildItem({
-              id: newChildId,
-              column,
-              dropTarget: dropTarget || undefined,
-              header: layoutOptions?.newChildItem.header,
-              resizeable: "hv",
-              row,
-              stackId,
-              title: title ?? componentTemplate.label ?? "New Item",
-            });
-            gridModel.addChildItem(gridModelChildItem);
+            throwForGridCommandFailure(
+              commandExecutor.execute({
+                item: {
+                  id: newChildId,
+                  column: {
+                    span: column.end - column.start,
+                    start: column.start,
+                  },
+                  dropTarget: dropTarget || undefined,
+                  header: layoutOptions?.newChildItem.header,
+                  resizeable: "hv",
+                  row: { span: row.end - row.start, start: row.start },
+                  title: title ?? componentTemplate.label ?? "New Item",
+                },
+                stackId,
+                type: "add-stack-item",
+              }),
+            );
+            const gridModelChildItem = gridModel.getChildItem(newChildId, true);
 
             const component = layoutFromJson({
               ...componentJSON,
@@ -700,31 +740,61 @@ export const useGridLayout = ({
             } as LayoutJSON);
             addChildComponent(component, gridModelChildItem);
 
-            const tabState = gridModel.getTabState(stackId);
-            tabState.setActiveTab(title ?? gridModelChildItem.title);
+            throwForGridCommandFailure(
+              commandExecutor.execute({
+                itemId: newChildId,
+                stackId,
+                type: "select-stack-item",
+              }),
+            );
             gridModel.notifyChange();
           }
           break;
         case "resize-grid-column":
-          {
-            gridModel.tracks.resizeTo(
-              "column",
-              action.trackIndex,
-              action.value,
-            );
-          }
-          break;
-        default:
-          throw Error(
-            `[useGridLayout] dispatchGridLayoutAction unknown action type '${action.type}'`,
+          throwForGridCommandFailure(
+            commandExecutor.execute({
+              index: action.trackIndex,
+              size: action.value,
+              track: "column",
+              type: "resize-track",
+            }),
           );
+          break;
+        case "resize-grid-row":
+          throwForGridCommandFailure(
+            commandExecutor.execute({
+              index: action.trackIndex,
+              size: action.value,
+              track: "row",
+              type: "resize-track",
+            }),
+          );
+          break;
+        case "select-tab":
+          throwForGridCommandFailure(
+            commandExecutor.execute({
+              itemId: action.itemId,
+              stackId: action.stackId,
+              type: "select-stack-item",
+            }),
+          );
+          break;
+        case "switch-tab":
+          throw new GridCommandExecutionError({
+            code: "UNSUPPORTED_ACTION",
+            message:
+              "GridLayoutAction 'switch-tab' has no supported legacy semantics",
+          });
+        default:
+          return assertNeverGridLayoutAction(action);
       }
     },
     [
       addChildComponent,
+      commandExecutor,
       gridModel,
       layoutOptions?.newChildItem.header,
-      removeGridItem,
+      setChildren,
     ],
   );
 

--- a/vuu-ui/packages/grid-layout/test/GridCommand.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridCommand.test.ts
@@ -1,0 +1,539 @@
+import { describe, expect, it } from "vitest";
+import {
+  GridCommandExecutionError,
+  LegacyGridCommandExecutor,
+  throwForGridCommandFailure,
+  type GridCommand,
+  type GridCommandItem,
+} from "../src/GridCommand";
+import { GridModel } from "../src/GridModel";
+import {
+  descriptor,
+  item,
+  normalizeModel,
+  snapshotState,
+} from "./model-scenario-harness";
+
+const commandItem = (
+  id: string,
+  gridArea = "1/1/2/2",
+  title?: string,
+): GridCommandItem => {
+  const [rowStart, columnStart, rowEnd, columnEnd] = gridArea
+    .split("/")
+    .map(Number);
+  return {
+    column: { span: columnEnd - columnStart, start: columnStart },
+    id,
+    row: { span: rowEnd - rowStart, start: rowStart },
+    title,
+  };
+};
+
+const execute = (model: GridModel, command: GridCommand) =>
+  new LegacyGridCommandExecutor(model).execute(command);
+
+describe("LegacyGridCommandExecutor", () => {
+  it.each([
+    "north",
+    "south",
+    "east",
+    "west",
+  ] as const)("maps add-item and %s move-item to the legacy split engine", (position) => {
+    const model = new GridModel(
+      `split-${position}`,
+      descriptor(["1fr"], ["1fr"], {
+        target: item("1/1/2/2", { resizeable: "hv" }),
+      }),
+    );
+
+    expect(
+      execute(model, { item: commandItem("source"), type: "add-item" }),
+    ).toEqual({ command: "add-item", ok: true });
+    expect(
+      execute(model, {
+        itemId: "source",
+        position,
+        targetId: "target",
+        type: "move-item",
+      }),
+    ).toEqual({ command: "move-item", ok: true });
+
+    expect(
+      snapshotState(model)
+        .items.map(({ id }) => id)
+        .toSorted(),
+    ).toEqual(["source", "target"]);
+    expect(
+      position === "east" || position === "west"
+        ? model.tracks.columns
+        : model.tracks.rows,
+    ).toEqual(["1fr", "1fr"]);
+  });
+
+  it("maps replace, remove and placeholder regeneration", () => {
+    const model = new GridModel(
+      "lifecycle",
+      descriptor(["1fr", "1fr"], ["1fr"], {
+        left: item("1/1/2/2"),
+        right: item("1/2/2/3"),
+      }),
+    );
+
+    expect(
+      execute(model, { item: commandItem("replacement"), type: "add-item" }),
+    ).toMatchObject({ ok: true });
+    expect(
+      execute(model, {
+        itemId: "replacement",
+        targetId: "right",
+        type: "replace-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      execute(model, {
+        itemId: "left",
+        reason: "close",
+        type: "remove-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(execute(model, { type: "regenerate-placeholders" })).toMatchObject({
+      ok: true,
+    });
+    expect(model.toGridLayoutDescriptor()).toMatchObject(
+      descriptor(["1fr"], ["1fr"], {
+        replacement: item("1/1/2/2", {
+          contentVisible: true,
+          resizeable: false,
+        }),
+      }),
+    );
+  });
+
+  it("maps direct, adjacent and proportional track resize inputs", () => {
+    const model = new GridModel(
+      "resize",
+      descriptor(["100px", "100px"], ["100px", "100px", "200px"]),
+    );
+
+    expect(
+      execute(model, {
+        index: 0,
+        size: "125px",
+        track: "column",
+        type: "resize-track",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      execute(model, {
+        contraTrackIndex: 1,
+        delta: 25,
+        distribution: "adjacent",
+        resizedTrackIndex: 0,
+        track: "column",
+        type: "resize-tracks",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      execute(model, {
+        afterConstraints: [
+          { minimum: 80, trackIndices: [1] },
+          { minimum: 80, trackIndices: [2] },
+        ],
+        afterTrackIndices: [1, 2],
+        beforeConstraints: [{ minimum: 80, trackIndices: [0] }],
+        beforeTrackIndices: [0],
+        delta: -120,
+        distribution: "proportional",
+        initialSizes: [100, 100, 200],
+        track: "row",
+        type: "resize-tracks",
+      }),
+    ).toMatchObject({ ok: true });
+
+    expect(model.tracks.columns).toEqual(["150px", "75px"]);
+    expect(model.tracks.rows).toEqual(["220px", "80px", "100px"]);
+  });
+
+  it("maps stack create, add, select, reorder, rename and remove semantics", () => {
+    const model = new GridModel(
+      "stack",
+      descriptor(["1fr"], ["1fr"], {
+        alpha: item("1/1/2/2", { title: "Alpha" }),
+        beta: item("1/1/2/2", { title: "Beta" }),
+      }),
+    );
+    const executor = new LegacyGridCommandExecutor(model);
+
+    expect(
+      executor.execute({
+        itemId: "beta",
+        targetId: "alpha",
+        type: "create-stack",
+      }),
+    ).toMatchObject({ ok: true });
+    const stackId = model.childItems.find(
+      ({ type }) => type === "stacked-content",
+    )?.id;
+    expect(stackId).toBeDefined();
+    if (!stackId) {
+      return;
+    }
+
+    expect(
+      executor.execute({
+        item: commandItem("gamma", "1/1/2/2", "Gamma"),
+        stackId,
+        type: "add-stack-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      executor.execute({
+        itemId: "gamma",
+        stackId,
+        type: "select-stack-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      executor.execute({
+        activate: true,
+        itemId: "gamma",
+        position: "before",
+        stackId,
+        targetItemId: "alpha",
+        type: "reorder-stack-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      executor.execute({
+        itemId: "gamma",
+        title: "Gamma renamed",
+        type: "rename-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      executor.execute({
+        itemId: "beta",
+        stackId,
+        type: "remove-stack-item",
+      }),
+    ).toMatchObject({ ok: true });
+
+    expect(model.getTabState(stackId).tabs).toEqual([
+      { id: "gamma", label: "Gamma renamed" },
+      { id: "alpha", label: "Alpha" },
+    ]);
+    expect(model.getTabState(stackId).activeTab.id).toBe("gamma");
+    expect(normalizeModel(model).tabs[0].tabs).toEqual(["gamma", "alpha"]);
+  });
+
+  it("uses tab IDs when duplicate titles are selected and reordered", () => {
+    const model = new GridModel(
+      "duplicate-tab-titles",
+      descriptor(["1fr"], ["1fr"], {
+        alpha: item("1/1/2/2", { title: "Same" }),
+        beta: item("1/1/2/2", { title: "Same" }),
+      }),
+    );
+    const executor = new LegacyGridCommandExecutor(model);
+    executor.execute({
+      itemId: "beta",
+      targetId: "alpha",
+      type: "create-stack",
+    });
+
+    const stackId = model.childItems.find(
+      ({ type }) => type === "stacked-content",
+    )?.id;
+    expect(stackId).toBeDefined();
+    if (!stackId) {
+      return;
+    }
+
+    expect(
+      executor.execute({
+        itemId: "beta",
+        stackId,
+        type: "select-stack-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(model.getTabState(stackId).activeTab.id).toBe("beta");
+    expect(
+      executor.execute({
+        itemId: "beta",
+        position: "before",
+        stackId,
+        targetItemId: "alpha",
+        type: "reorder-stack-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(model.getTabState(stackId).tabs.map(({ id }) => id)).toEqual([
+      "beta",
+      "alpha",
+    ]);
+  });
+
+  it("aligns added stack items to the stack coordinates", () => {
+    const model = new GridModel(
+      "stack-position",
+      descriptor(["1fr", "1fr"], ["1fr"], {
+        alpha: item("1/2/2/3"),
+        beta: item("1/2/2/3"),
+      }),
+    );
+    const executor = new LegacyGridCommandExecutor(model);
+    executor.execute({
+      itemId: "beta",
+      targetId: "alpha",
+      type: "create-stack",
+    });
+    const stackId = model.childItems.find(
+      ({ type }) => type === "stacked-content",
+    )?.id;
+    expect(stackId).toBeDefined();
+    if (!stackId) {
+      return;
+    }
+
+    expect(
+      executor.execute({
+        item: commandItem("gamma", "1/1/2/2"),
+        stackId,
+        type: "add-stack-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(model.getChildItem("gamma", true).gridArea).toBe("1/2/2/3");
+  });
+
+  it("removes the active item from a three-item stack without partial failure", () => {
+    const model = new GridModel(
+      "remove-active-tab",
+      descriptor(["1fr"], ["1fr"], {
+        alpha: item("1/1/2/2"),
+        beta: item("1/1/2/2"),
+      }),
+    );
+    const executor = new LegacyGridCommandExecutor(model);
+    executor.execute({
+      itemId: "beta",
+      targetId: "alpha",
+      type: "create-stack",
+    });
+    const stackId = model.childItems.find(
+      ({ type }) => type === "stacked-content",
+    )?.id;
+    expect(stackId).toBeDefined();
+    if (!stackId) {
+      return;
+    }
+    executor.execute({
+      item: commandItem("gamma"),
+      stackId,
+      type: "add-stack-item",
+    });
+    executor.execute({
+      itemId: "beta",
+      stackId,
+      type: "select-stack-item",
+    });
+
+    expect(
+      executor.execute({
+        itemId: "beta",
+        stackId,
+        type: "remove-stack-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(model.getTabState(stackId).tabs.map(({ id }) => id)).toEqual([
+      "alpha",
+      "gamma",
+    ]);
+    expect(model.getTabState(stackId).activeTab.id).toBe("gamma");
+  });
+
+  it("returns stable typed failures without mutating canonical state", () => {
+    const model = new GridModel(
+      "invalid",
+      descriptor(["1fr"], ["1fr"], {
+        source: item("1/1/2/2"),
+        target: item("1/1/2/2", { resizeable: false }),
+      }),
+    );
+    const before = snapshotState(model);
+    const commands: Array<[GridCommand, string]> = [
+      [{ item: commandItem("source"), type: "add-item" }, "DUPLICATE_ITEM_ID"],
+      [{ item: commandItem("", "1/1/2/2"), type: "add-item" }, "INVALID_ITEM"],
+      [
+        { itemId: "missing", reason: "close", type: "remove-item" },
+        "ITEM_NOT_FOUND",
+      ],
+      [
+        {
+          itemId: "source",
+          position: "east",
+          targetId: "target",
+          type: "move-item",
+        },
+        "NON_RESIZABLE",
+      ],
+      [
+        {
+          index: 2,
+          size: "10px",
+          track: "column",
+          type: "resize-track",
+        },
+        "TRACK_NOT_FOUND",
+      ],
+      [
+        {
+          item: commandItem("third"),
+          stackId: "missing",
+          type: "add-stack-item",
+        },
+        "STACK_NOT_FOUND",
+      ],
+      [
+        {
+          contraTrackIndex: 0,
+          delta: 10,
+          distribution: "adjacent",
+          resizedTrackIndex: 0,
+          track: "column",
+          type: "resize-tracks",
+        },
+        "INVALID_TARGET",
+      ],
+    ];
+
+    for (const [command, code] of commands) {
+      expect(execute(model, command)).toMatchObject({
+        error: { code },
+        ok: false,
+      });
+    }
+    expect(snapshotState(model)).toEqual(before);
+  });
+
+  it("rejects invalid stack tabs and targets with stable codes", () => {
+    const model = new GridModel(
+      "invalid-stack",
+      descriptor(["1fr"], ["1fr"], {
+        alpha: item("1/1/2/2"),
+        beta: item("1/1/2/2"),
+      }),
+    );
+    const executor = new LegacyGridCommandExecutor(model);
+    executor.execute({
+      itemId: "beta",
+      targetId: "alpha",
+      type: "create-stack",
+    });
+    const stackId = model.childItems.find(
+      ({ type }) => type === "stacked-content",
+    )?.id;
+    expect(stackId).toBeDefined();
+    if (!stackId) {
+      return;
+    }
+    const before = snapshotState(model);
+
+    expect(
+      executor.execute({
+        itemId: "missing",
+        stackId,
+        type: "select-stack-item",
+      }),
+    ).toMatchObject({ error: { code: "TAB_NOT_FOUND" }, ok: false });
+    expect(
+      executor.execute({
+        itemId: "alpha",
+        position: "before",
+        stackId,
+        targetItemId: "alpha",
+        type: "reorder-stack-item",
+      }),
+    ).toMatchObject({ error: { code: "INVALID_TARGET" }, ok: false });
+    expect(snapshotState(model)).toEqual(before);
+    expect(
+      executor.execute({
+        itemId: "alpha",
+        position: "east",
+        targetId: stackId,
+        type: "move-item",
+      }),
+    ).toMatchObject({ error: { code: "INVALID_TARGET" }, ok: false });
+  });
+
+  it("requires explicit measurement data for fractional resize commands", () => {
+    const model = new GridModel(
+      "measured-resize",
+      descriptor(["1fr", "1fr"], ["1fr"]),
+    );
+
+    expect(
+      execute(model, {
+        contraTrackIndex: 1,
+        delta: 10,
+        distribution: "adjacent",
+        resizedTrackIndex: 0,
+        track: "column",
+        type: "resize-tracks",
+      }),
+    ).toMatchObject({
+      error: { code: "MEASUREMENT_REQUIRED" },
+      ok: false,
+    });
+
+    expect(
+      execute(model, {
+        contraTrackIndex: 1,
+        delta: 10,
+        distribution: "adjacent",
+        measuredSizes: [100, 100],
+        resizedTrackIndex: 0,
+        track: "column",
+        type: "resize-tracks",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(model.tracks.columns).toEqual(["110px", "90px"]);
+  });
+
+  it("rejects invalid proportional constraints before resizing", () => {
+    const model = new GridModel(
+      "invalid-constraints",
+      descriptor(["100px"], ["100px", "100px"]),
+    );
+    const before = snapshotState(model);
+
+    expect(
+      execute(model, {
+        afterConstraints: [{ minimum: 10, trackIndices: [2] }],
+        afterTrackIndices: [1],
+        beforeTrackIndices: [0],
+        delta: 10,
+        distribution: "proportional",
+        track: "row",
+        type: "resize-tracks",
+      }),
+    ).toMatchObject({ error: { code: "TRACK_NOT_FOUND" }, ok: false });
+    expect(snapshotState(model)).toEqual(before);
+  });
+
+  it("surfaces typed command failures to compatibility dispatchers", () => {
+    const result = execute(
+      new GridModel("errors", descriptor(["1fr"], ["1fr"])),
+      { itemId: "missing", reason: "close", type: "remove-item" },
+    );
+
+    expect(() => throwForGridCommandFailure(result)).toThrow(
+      GridCommandExecutionError,
+    );
+    try {
+      throwForGridCommandFailure(result);
+      expect.unreachable("expected command failure");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "ITEM_NOT_FOUND" });
+    }
+  });
+});

--- a/vuu-ui/packages/grid-layout/test/GridModel.scenarios.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridModel.scenarios.test.ts
@@ -351,7 +351,6 @@ const scenarios: LayoutScenario[] = [
       lowerLeft: item("2/1/3/2"),
       lowerRight: item("2/2/3/3"),
     }),
-    operations: [{ type: "round-trip" }],
     expected: {
       cols: [...twoTracks],
       rows: [...twoTracks],
@@ -369,7 +368,7 @@ const scenarios: LayoutScenario[] = [
   {
     name: "multi-operation split replace remove and placeholder sequence",
     initial: descriptor([...oneTrack], [...oneTrack], {
-      first: item("1/1/2/2"),
+      first: item("1/1/2/2", { resizeable: "hv" }),
     }),
     operations: [
       { type: "add", id: "second" },

--- a/vuu-ui/packages/grid-layout/test/model-scenario-harness.ts
+++ b/vuu-ui/packages/grid-layout/test/model-scenario-harness.ts
@@ -1,6 +1,11 @@
 import type { GridLayoutSplitDirection } from "@vuu-ui/vuu-utils";
 import { expect } from "vitest";
-import { GridLayoutModel } from "../src/GridLayoutModel";
+import {
+  LegacyGridCommandExecutor,
+  type GridCommand,
+  type GridCommandItem,
+  type GridCommandResult,
+} from "../src/GridCommand";
 import {
   gridLayoutDescriptorToSnapshot,
   gridSnapshotToGridLayoutDescriptor,
@@ -52,8 +57,7 @@ type ScenarioOperation =
       position: "before" | "after";
       activate?: boolean;
     }
-  | { type: "regenerate-placeholders" }
-  | { type: "round-trip" };
+  | { type: "regenerate-placeholders" };
 
 export type ExpectedScenarioError = {
   message: string | RegExp;
@@ -122,102 +126,94 @@ const resolveItem = (model: GridModel, ref: ItemRef): GridModelChildItem => {
   return result;
 };
 
-const addItem = (model: GridModel, operation: AddOperation) => {
+const resolveItemId = (model: GridModel, ref: ItemRef) =>
+  typeof ref === "string" ? ref : resolveItem(model, ref).id;
+
+const commandItem = (operation: AddOperation): GridCommandItem => {
   const [rowStart, columnStart, rowEnd, columnEnd] = (
     operation.gridArea ?? "1/1/2/2"
   )
     .split("/")
     .map(Number);
-  model.addChildItem(
-    new GridModelChildItem({
-      column: { start: columnStart, end: columnEnd },
-      id: operation.id,
-      resizeable: operation.resizeable,
-      row: { start: rowStart, end: rowEnd },
-      title: operation.title,
-    }),
-  );
+  return {
+    column: { span: columnEnd - columnStart, start: columnStart },
+    id: operation.id,
+    resizeable: operation.resizeable,
+    row: { span: rowEnd - rowStart, start: rowStart },
+    title: operation.title,
+  };
+};
+
+const toCommand = (
+  currentModel: GridModel,
+  operation: ScenarioOperation,
+): GridCommand => {
+  switch (operation.type) {
+    case "add":
+      return { item: commandItem(operation), type: "add-item" };
+    case "split":
+      return {
+        itemId: resolveItemId(currentModel, operation.dropped),
+        position: operation.direction,
+        targetId: resolveItemId(currentModel, operation.target),
+        type: "move-item",
+      };
+    case "replace":
+      return {
+        itemId: resolveItemId(currentModel, operation.dropped),
+        targetId: resolveItemId(currentModel, operation.target),
+        type: "replace-item",
+      };
+    case "remove":
+      return {
+        itemId: resolveItemId(currentModel, operation.item),
+        reason: "close",
+        type: "remove-item",
+      };
+    case "resize-track":
+      return {
+        index: operation.index,
+        size: operation.size,
+        track: operation.trackType,
+        type: "resize-track",
+      };
+    case "stack":
+      return {
+        itemId: resolveItemId(currentModel, operation.item),
+        targetId: resolveItemId(currentModel, operation.target),
+        type: "create-stack",
+      };
+    case "select-tab": {
+      const stack = resolveItem(currentModel, operation.stack);
+      return {
+        itemId: operation.tab,
+        stackId: stack.id,
+        type: "select-stack-item",
+      };
+    }
+    case "move-tab": {
+      const stack = resolveItem(currentModel, operation.stack);
+      return {
+        activate: operation.activate,
+        itemId: operation.tab,
+        position: operation.position,
+        stackId: stack.id,
+        targetItemId: operation.target,
+        type: "reorder-stack-item",
+      };
+    }
+    case "regenerate-placeholders":
+      return { type: "regenerate-placeholders" };
+  }
 };
 
 const executeOperation = (
   currentModel: GridModel,
   operation: ScenarioOperation,
-): GridModel => {
-  const layoutModel = new GridLayoutModel(currentModel);
-  switch (operation.type) {
-    case "add":
-      addItem(currentModel, operation);
-      break;
-    case "split":
-      layoutModel.dropSplitGridItem(
-        resolveItem(currentModel, operation.dropped).id,
-        resolveItem(currentModel, operation.target).id,
-        operation.direction,
-      );
-      break;
-    case "replace":
-      layoutModel.dropReplaceGridItem(
-        resolveItem(currentModel, operation.dropped).id,
-        resolveItem(currentModel, operation.target).id,
-      );
-      break;
-    case "remove":
-      layoutModel.removeGridItem(
-        resolveItem(currentModel, operation.item).id,
-        "close",
-      );
-      break;
-    case "resize-track":
-      currentModel.tracks.resizeTo(
-        operation.trackType,
-        operation.index,
-        operation.size,
-      );
-      break;
-    case "stack":
-      currentModel.stackChildItems(
-        resolveItem(currentModel, operation.target).id,
-        resolveItem(currentModel, operation.item).id,
-      );
-      break;
-    case "select-tab": {
-      const stack = resolveItem(currentModel, operation.stack);
-      const tab = currentModel
-        .getTabState(stack.id)
-        .tabs.find(({ id }) => id === operation.tab);
-      if (!tab) {
-        throw Error(`Scenario tab #${operation.tab} not found`);
-      }
-      currentModel.getTabState(stack.id).setActiveTab(tab.label);
-      break;
-    }
-    case "move-tab": {
-      const stack = resolveItem(currentModel, operation.stack);
-      const tabState = currentModel.getTabState(stack.id);
-      const tab = tabState.tabs.find(({ id }) => id === operation.tab);
-      const target = tabState.tabs.find(({ id }) => id === operation.target);
-      if (!tab || !target) {
-        throw Error("Scenario move-tab source or target not found");
-      }
-      currentModel.moveItemWithinTabs(
-        stack.id,
-        tab,
-        { position: operation.position, target: target.label },
-        operation.activate ?? false,
-      );
-      break;
-    }
-    case "regenerate-placeholders":
-      currentModel.createPlaceholders();
-      break;
-    case "round-trip":
-      return new GridModel(
-        currentModel.id,
-        currentModel.toGridLayoutDescriptor(),
-      );
-  }
-  return currentModel;
-};
+): GridCommandResult =>
+  new LegacyGridCommandExecutor(currentModel).execute(
+    toCommand(currentModel, operation),
+  );
 
 const aliasesFor = (model: GridModel) => {
   const aliases = new Map<string, string>();
@@ -367,14 +363,20 @@ export const assertModelInvariants = (model: GridModel) => {
 };
 
 export const runScenario = (scenario: LayoutScenario) => {
-  let model = new GridModel(`scenario-${scenario.name}`, scenario.initial);
+  const model = new GridModel(`scenario-${scenario.name}`, scenario.initial);
   for (const step of scenario.operations ?? []) {
     if (isExpectedError(step)) {
-      expect(() => executeOperation(model, step.operation)).toThrow(
-        step.message,
-      );
+      const result = executeOperation(model, step.operation);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        if (typeof step.message === "string") {
+          expect(result.error.message).toBe(step.message);
+        } else {
+          expect(result.error.message).toMatch(step.message);
+        }
+      }
     } else {
-      model = executeOperation(model, step);
+      expect(executeOperation(model, step)).toMatchObject({ ok: true });
     }
   }
   assertModelInvariants(model);


### PR DESCRIPTION
## Summary

Phase 6 increment 2 adds a public, closed `GridCommand` contract and a single `LegacyGridCommandExecutor` adapter over the existing mutable `GridModel`/`GridLayoutModel` engine.

This follows merged #2369 and is part of the stack headed by #2341.

- covers item add/remove, four-direction split/move, centre replacement, direct/adjacent/proportional row and column resizing, stack create/add/remove/select/reorder/rename, and placeholder regeneration
- returns stable typed command failures and uses exhaustive `never` guards
- routes the model scenario harness and straightforward GridLayout/tab actions through the executor while preserving existing `GridLayoutAction` signatures
- keeps generated placeholder/stack aliases test-only and compares post-command canonical snapshots/descriptors with existing scenario expectations
- preserves the legacy mutable engine, rendering source of truth, persistence shape, and geometry algorithms

## Behavior preservation

No controller/store, `useSyncExternalStore`, persistence codec/schema, rendering architecture, or geometry extraction is introduced. Complex drag/drop coordination and drag rollback remain on the existing paths for the later drag coordinator increment. The declared legacy `switch-tab` action now fails explicitly with `UNSUPPORTED_ACTION` rather than silently falling through.

## Validation

- `vitest`: 53 passed, 2 existing todos preserved
- targeted Biome check/lint: passed
- `@heswell/grid-layout` package build: passed
- targeted tab Playwright test: blocked before mount by unrelated existing showcase build failures (`UserSettingsPanel` export and missing `feature-filter-table`)
- root typecheck: 36 unrelated existing errors, 0 under `packages/grid-layout`