### PR TITLE
Support session tables whose schema diverges from the source view table

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/DESIGN.md
+++ b/vuu-ui/packages/vuu-data-editing/DESIGN.md
@@ -67,38 +67,55 @@ default the session data source is built from the view data source config, which
 would carry view-only columns — and any filter, `groupBy`, `sort`, or
 aggregations that reference them — onto a table that does not have them.
 
-`editColumns` and `editTable` describe the edit table when it differs:
+`EditSession` and `useEditableTable` are deliberately unaware of this: neither
+accepts a schema, an expected table, or any other transport-specific
+configuration. `useEditableTable`'s contract is exactly:
 
 ```ts
 useEditableTable({
   dataSource: viewDataSource, // subscribed; carries the createSessionTable RPC
-  editTable: EDIT_TABLE, // stable VuuTable
-  editColumns: EDIT_COLUMNS, // stable string[]
   isEditMode,
   onCancel,
   onSave,
 });
 ```
 
-Both are forwarded to `createSessionDataSource` / `beginEditSession` as a
-`SessionDataSourceOverrides` argument. Given `columns`, the data source builds
-the session config from `sessionDataSourceConfig` rather than inheriting the
-view config; `table` is checked against the module of the server-assigned
-session table. The session table name itself is always server-generated.
+Divergence is instead configured where the view data source is constructed, via
+an opaque `session` property:
 
-These overrides only affect how the session data source is constructed. Which
-data source subsequent operations target is unchanged — see [RPC
+```ts
+new VuuDataSource({
+  table: VIEW_TABLE,
+  columns: VIEW_COLUMNS,
+  session: {
+    table: EDIT_TABLE, // stable VuuTable
+    columns: EDIT_COLUMNS, // stable string[]
+  },
+});
+```
+
+`createSessionDataSource` / `beginEditSession` apply this internally: given
+`session.columns`, the session config is built from `sessionDataSourceConfig`
+rather than inheriting the view config; `session.table` is checked against the
+module of the server-assigned session table. A call-time
+`SessionDataSourceOverrides` argument (used by `CsvUpload`/`exportToCsv`, whose
+target data source is often shared and not under the caller's construction
+control) always takes precedence over the data source's own `session` config
+when both are present. `EditSession.begin()` never supplies one — it calls
+`createSessionDataSource(copyOption, sessionType)` with no third argument, so
+for editing the effective overrides are always whatever the data source was
+constructed with. The session table name itself is always server-generated.
+
+This only affects how the session data source is constructed. Which data
+source subsequent operations target is unchanged — see [RPC
 routing](#rpc-routing).
 
-Because both are `useMemo` dependencies of the `EditSession`, they must be
-stable references; a new array or object each render recreates the session.
-
 Once the session table schema arrives, `reconcileWithSessionSchema` prunes
-`rowDefaults` entries that the edit table does not have, warns about
-`editColumns` missing from the schema, and discards pending edits if the key
-column differs — row edits, deletes, and undo state are all keyed by row key and
-cannot cross a key-column change. The hook invokes it on `subscribed`, since a
-remote session table has no schema at the point `begin()` resolves.
+`rowDefaults` entries that the edit table does not have, and discards pending
+edits if the key column differs — row edits, deletes, and undo state are all
+keyed by row key and cannot cross a key-column change. The hook invokes it on
+`subscribed`, since a remote session table has no schema at the point `begin()`
+resolves.
 
 The hook returns `editSchema` and `columnsDiverge` for consumers rendering a
 single `Table` across both modes: the returned `dataSource` swaps column sets on

--- a/vuu-ui/packages/vuu-data-editing/DESIGN.md
+++ b/vuu-ui/packages/vuu-data-editing/DESIGN.md
@@ -26,6 +26,87 @@ ignores callbacks from obsolete data-source bindings.
 `DataEditingProvider` makes the session available to nested controls, while
 `EditButtons` reflects session state in the available editing actions.
 
+## RPC routing
+
+`EditSession` resolves the target of every editing RPC through its `dataSource`
+getter:
+
+```ts
+get dataSource() {
+  return this.#sessionDataSource ?? this.#sourceTableDataSource;
+}
+```
+
+`#sessionDataSource` is assigned by `begin()`, so before an edit session starts
+these operations address the source table, and once the lifecycle is `active`
+they all address the session table:
+
+| Method | Target once active |
+| ------ | ------------------ |
+| `deleteSelectedRows` | session data source |
+| `addRow` / `addNewRow` | session data source |
+| `commit` → `editCell` | session data source |
+| `undoRowChange` | session data source |
+| `end` → `endEditSession` | session data source |
+
+`begin()` is the one deliberate exception: it calls
+`createSessionDataSource` / `beginEditSession` on `#sourceTableDataSource`
+directly rather than through the getter, because the session table does not yet
+exist. The `createSessionTable` handler is therefore resolved against the source
+table's viewport, and the source data source must be subscribed before edit mode
+is entered.
+
+For a remote `VuuDataSource`, the session instance issues its RPCs against its
+own viewport, so it must have completed its subscription first — which is what
+`isEditSessionReady` gates on.
+
+## Divergent edit tables
+
+The edit (session) table does not always share the view table's schema. By
+default the session data source is built from the view data source config, which
+would carry view-only columns — and any filter, `groupBy`, `sort`, or
+aggregations that reference them — onto a table that does not have them.
+
+`editColumns` and `editTable` describe the edit table when it differs:
+
+```ts
+useEditableTable({
+  dataSource: viewDataSource, // subscribed; carries the createSessionTable RPC
+  editTable: EDIT_TABLE, // stable VuuTable
+  editColumns: EDIT_COLUMNS, // stable string[]
+  isEditMode,
+  onCancel,
+  onSave,
+});
+```
+
+Both are forwarded to `createSessionDataSource` / `beginEditSession` as a
+`SessionDataSourceOverrides` argument. Given `columns`, the data source builds
+the session config from `sessionDataSourceConfig` rather than inheriting the
+view config; `table` is checked against the module of the server-assigned
+session table. The session table name itself is always server-generated.
+
+These overrides only affect how the session data source is constructed. Which
+data source subsequent operations target is unchanged — see [RPC
+routing](#rpc-routing).
+
+Because both are `useMemo` dependencies of the `EditSession`, they must be
+stable references; a new array or object each render recreates the session.
+
+Once the session table schema arrives, `reconcileWithSessionSchema` prunes
+`rowDefaults` entries that the edit table does not have, warns about
+`editColumns` missing from the schema, and discards pending edits if the key
+column differs — row edits, deletes, and undo state are all keyed by row key and
+cannot cross a key-column change. The hook invokes it on `subscribed`, since a
+remote session table has no schema at the point `begin()` resolves.
+
+The hook returns `editSchema` and `columnsDiverge` for consumers rendering a
+single `Table` across both modes: the returned `dataSource` swaps column sets on
+entering edit mode, so column descriptors must be rebuilt rather than reused.
+This matters for cell editing in particular: `editCell` sends a column name to
+the session table, so it must come from the edit schema. `rowDefaults` naming
+view-only columns are dropped by `reconcileWithSessionSchema` rather than sent.
+
 ## Files
 
 | File                          | Responsibility                                                                                                                     |

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -6,15 +6,10 @@ import type {
   EditApi,
   EditSessionMode,
   SchemaColumn,
-  SessionDataSourceOverrides,
   SessionType,
   UndoRowChangeResult,
 } from "@vuu-ui/vuu-data-types";
-import type {
-  RpcResult,
-  VuuRowDataItemType,
-  VuuTable,
-} from "@vuu-ui/vuu-protocol-types";
+import type { RpcResult, VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
 import { EventEmitter, isRpcError, StaleUpdateError } from "@vuu-ui/vuu-utils";
 
 export type EditState = "clean" | "dirty" | "invalid" | "stale";
@@ -30,13 +25,6 @@ export type EditSessionConstructorProps = {
   deleteMode?: DeleteRowMode;
   /** @default "createSessionDataSource" */
   editSessionApi?: EditSessionApi;
-  /**
-   * Columns of the edit (session) table, when it differs from the view table. If omitted,
-   * the session datasource inherits the view datasource columns.
-   */
-  editColumns?: string[];
-  /** Expected edit (session) table, used to validate the table returned by the server. */
-  editTable?: VuuTable;
   /** Default column values merged into every addRow call for absent columns. Pass a stable reference. */
   rowDefaults?: RowDefaultDataItemValues;
 };
@@ -111,8 +99,6 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   #cellCommitRevisions = new Map<string, Map<string, number>>();
   #deleteMode: DeleteRowMode;
   #editSessionApi: EditSessionApi;
-  #editColumns?: string[];
-  #editTable?: VuuTable;
   #rowDefaults: RowDefaultDataItemValues;
   #sourceTableDataSource?: EditApi;
   #sessionDataSource?: DataSource;
@@ -131,16 +117,12 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     dataSource,
     deleteMode = "soft",
     editSessionApi = "createSessionDataSource",
-    editColumns,
-    editTable,
     rowDefaults = {},
   }: EditSessionConstructorProps) {
     super();
     this.#sourceTableDataSource = dataSource;
     this.#deleteMode = deleteMode;
     this.#editSessionApi = editSessionApi;
-    this.#editColumns = editColumns;
-    this.#editTable = editTable;
     this.#rowDefaults = rowDefaults;
   }
 
@@ -549,20 +531,14 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
 
       try {
         const sourceDataSource = this.#sourceTableDataSource;
-        const overrides: SessionDataSourceOverrides | undefined =
-          this.#editColumns || this.#editTable
-            ? { columns: this.#editColumns, table: this.#editTable }
-            : undefined;
         const sessionDataSource =
           this.#editSessionApi === "beginEditSession"
             ? await sourceDataSource?.beginEditSession?.(
                 toEditSessionMode(copyOption),
-                overrides,
               )
             : await sourceDataSource?.createSessionDataSource?.(
                 copyOption,
                 sessionType,
-                overrides,
               );
         if (!sessionDataSource) {
           throw new Error(
@@ -608,17 +584,6 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
       );
       for (const key of unknown) {
         delete this.#rowDefaults[key];
-      }
-    }
-
-    if (this.#editColumns) {
-      const missing = this.#editColumns.filter(
-        (column) => !columnNames.has(column),
-      );
-      if (missing.length > 0) {
-        console.warn(
-          `[EditSession] editColumns not present in session table schema: ${missing.join(", ")}`,
-        );
       }
     }
 

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -6,10 +6,15 @@ import type {
   EditApi,
   EditSessionMode,
   SchemaColumn,
+  SessionDataSourceOverrides,
   SessionType,
   UndoRowChangeResult,
 } from "@vuu-ui/vuu-data-types";
-import type { RpcResult, VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
+import type {
+  RpcResult,
+  VuuRowDataItemType,
+  VuuTable,
+} from "@vuu-ui/vuu-protocol-types";
 import { EventEmitter, isRpcError, StaleUpdateError } from "@vuu-ui/vuu-utils";
 
 export type EditState = "clean" | "dirty" | "invalid" | "stale";
@@ -25,6 +30,13 @@ export type EditSessionConstructorProps = {
   deleteMode?: DeleteRowMode;
   /** @default "createSessionDataSource" */
   editSessionApi?: EditSessionApi;
+  /**
+   * Columns of the edit (session) table, when it differs from the view table. If omitted,
+   * the session datasource inherits the view datasource columns.
+   */
+  editColumns?: string[];
+  /** Expected edit (session) table, used to validate the table returned by the server. */
+  editTable?: VuuTable;
   /** Default column values merged into every addRow call for absent columns. Pass a stable reference. */
   rowDefaults?: RowDefaultDataItemValues;
 };
@@ -99,6 +111,8 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   #cellCommitRevisions = new Map<string, Map<string, number>>();
   #deleteMode: DeleteRowMode;
   #editSessionApi: EditSessionApi;
+  #editColumns?: string[];
+  #editTable?: VuuTable;
   #rowDefaults: RowDefaultDataItemValues;
   #sourceTableDataSource?: EditApi;
   #sessionDataSource?: DataSource;
@@ -117,12 +131,16 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     dataSource,
     deleteMode = "soft",
     editSessionApi = "createSessionDataSource",
+    editColumns,
+    editTable,
     rowDefaults = {},
   }: EditSessionConstructorProps) {
     super();
     this.#sourceTableDataSource = dataSource;
     this.#deleteMode = deleteMode;
     this.#editSessionApi = editSessionApi;
+    this.#editColumns = editColumns;
+    this.#editTable = editTable;
     this.#rowDefaults = rowDefaults;
   }
 
@@ -531,12 +549,21 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
 
       try {
         const sourceDataSource = this.#sourceTableDataSource;
+        const overrides: SessionDataSourceOverrides | undefined =
+          this.#editColumns || this.#editTable
+            ? { columns: this.#editColumns, table: this.#editTable }
+            : undefined;
         const sessionDataSource =
           this.#editSessionApi === "beginEditSession"
             ? await sourceDataSource?.beginEditSession?.(
                 toEditSessionMode(copyOption),
+                overrides,
               )
-            : await sourceDataSource?.createSessionDataSource?.(copyOption, sessionType);
+            : await sourceDataSource?.createSessionDataSource?.(
+                copyOption,
+                sessionType,
+                overrides,
+              );
         if (!sessionDataSource) {
           throw new Error(
             `[EditSession] datasource does not support ${this.#editSessionApi}`,
@@ -547,23 +574,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
         this.#setStale(false);
         this.#setLifecycle({ status: "active", sessionDataSource });
 
-        if (Object.keys(this.#rowDefaults).length > 0) {
-          const schema = sessionDataSource.tableSchema;
-          if (schema) {
-            const columnNames = new Set(schema.columns.map((c: SchemaColumn) => c.name));
-            const unknown = Object.keys(this.#rowDefaults).filter(
-              (key) => !columnNames.has(key),
-            );
-            if (unknown.length > 0) {
-              console.warn(
-                `[EditSession] rowDefaults contains columns not in table schema, removing: ${unknown.join(", ")}`,
-              );
-              for (const key of unknown) {
-                delete this.#rowDefaults[key];
-              }
-            }
-          }
-        }
+        this.reconcileWithSessionSchema();
 
         return sessionDataSource;
       } catch (cause) {
@@ -573,6 +584,54 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
       }
 
     });
+  }
+
+  /**
+   * Safe to call repeatedly - schema of a remote session table typically arrives
+   * after begin() resolves, so callers re-invoke this once 'subscribed' fires.
+   */
+  reconcileWithSessionSchema() {
+    const sessionSchema = this.#sessionDataSource?.tableSchema;
+    if (sessionSchema === undefined) {
+      return;
+    }
+
+    const columnNames = new Set(
+      sessionSchema.columns.map((c: SchemaColumn) => c.name),
+    );
+    const unknown = Object.keys(this.#rowDefaults).filter(
+      (key) => !columnNames.has(key),
+    );
+    if (unknown.length > 0) {
+      console.warn(
+        `[EditSession] rowDefaults contains columns not in table schema, removing: ${unknown.join(", ")}`,
+      );
+      for (const key of unknown) {
+        delete this.#rowDefaults[key];
+      }
+    }
+
+    if (this.#editColumns) {
+      const missing = this.#editColumns.filter(
+        (column) => !columnNames.has(column),
+      );
+      if (missing.length > 0) {
+        console.warn(
+          `[EditSession] editColumns not present in session table schema: ${missing.join(", ")}`,
+        );
+      }
+    }
+
+    const sourceKey = (this.#sourceTableDataSource as Partial<DataSource>)
+      ?.tableSchema?.key;
+    if (sourceKey !== undefined && sourceKey !== sessionSchema.key) {
+      // Row edits, deletes and undo state are keyed by row key, so they cannot
+      // be carried across tables with different key columns.
+      console.warn(
+        `[EditSession] source table key '${sourceKey}' differs from session table key '${sessionSchema.key}', discarding pending edits`,
+      );
+      this.#clearEdits();
+    }
   }
 
   get dataSource() {

--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -32,6 +32,14 @@ export interface EditableTableHookProps {
   addRowsCount?: number;
   deleteMode?: DeleteRowMode;
   editSessionApi?: EditSessionApi;
+  /**
+   * Columns of the edit (session) table, where it differs from the view table.
+   * If omitted, the session datasource inherits the view datasource columns.
+   * Pass a stable reference - a new array triggers EditSession recreation.
+   */
+  editColumns?: string[];
+  /** Expected edit (session) table, used to validate the table returned by the server. */
+  editTable?: VuuTable;
   copyOption?: CopyOption;
   isEditMode: boolean;
   onCancel: () => void;
@@ -50,6 +58,8 @@ export const useEditableTable = ({
   dataSource: dataSourceProp,
   deleteMode = "soft",
   editSessionApi = "createSessionDataSource",
+  editColumns,
+  editTable,
   copyOption = "All",
   isEditMode,
   onCancel,
@@ -78,8 +88,23 @@ export const useEditableTable = ({
   // The editSession will be made available to all the edit controls in scope
   // by wrapping the edit component with a DataEditingProvider.
   const editSession = useMemo(
-    () => new EditSession({ dataSource: sourceDataSource as EditApi, deleteMode, editSessionApi, rowDefaults }),
-    [deleteMode, editSessionApi, rowDefaults, sourceDataSource],
+    () =>
+      new EditSession({
+        dataSource: sourceDataSource as EditApi,
+        deleteMode,
+        editSessionApi,
+        editColumns,
+        editTable,
+        rowDefaults,
+      }),
+    [
+      deleteMode,
+      editColumns,
+      editSessionApi,
+      editTable,
+      rowDefaults,
+      sourceDataSource,
+    ],
   );
   const [lifecycle, setLifecycle] = useState<EditLifecycle>(
     editSession.lifecycle,
@@ -137,8 +162,11 @@ export const useEditableTable = ({
       return;
     }
 
-    const handleSubscribed = () =>
+    const handleSubscribed = () => {
+      // Session table schema is only available once subscribed.
+      editSession.reconcileWithSessionSchema();
       setSubscribedSessionDataSource(sessionDataSource);
+    };
 
     setSubscribedSessionDataSource(undefined);
     sessionDataSource.on("subscribed", handleSubscribed);
@@ -151,7 +179,7 @@ export const useEditableTable = ({
 
     return () =>
       sessionDataSource.removeListener("subscribed", handleSubscribed);
-  }, [sessionDataSource]);
+  }, [editSession, sessionDataSource]);
 
   useEffect(() => {
     const handleEditState = (nextEditState: EditState) => {
@@ -202,10 +230,23 @@ export const useEditableTable = ({
     sessionDataSource.status === "subscribed" &&
     sessionDataSource.tableSchema !== undefined;
 
+  const editSchema = subscribedSessionDataSource?.tableSchema;
+  const viewSchema = sourceDataSource.tableSchema;
+  // Consumers rendering a single Table must rebuild column descriptors when this is true.
+  const columnsDiverge =
+    editSchema !== undefined &&
+    viewSchema !== undefined &&
+    (editSchema.columns.length !== viewSchema.columns.length ||
+      editSchema.columns.some(
+        (column, index) => column.name !== viewSchema.columns[index]?.name,
+      ));
+
   return {
     canCancel,
     canSave,
+    columnsDiverge,
     dataSource,
+    editSchema,
     editSession,
     lifecycle,
     hasSelection: selectionCount > 0,

--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -32,14 +32,6 @@ export interface EditableTableHookProps {
   addRowsCount?: number;
   deleteMode?: DeleteRowMode;
   editSessionApi?: EditSessionApi;
-  /**
-   * Columns of the edit (session) table, where it differs from the view table.
-   * If omitted, the session datasource inherits the view datasource columns.
-   * Pass a stable reference - a new array triggers EditSession recreation.
-   */
-  editColumns?: string[];
-  /** Expected edit (session) table, used to validate the table returned by the server. */
-  editTable?: VuuTable;
   copyOption?: CopyOption;
   isEditMode: boolean;
   onCancel: () => void;
@@ -58,8 +50,6 @@ export const useEditableTable = ({
   dataSource: dataSourceProp,
   deleteMode = "soft",
   editSessionApi = "createSessionDataSource",
-  editColumns,
-  editTable,
   copyOption = "All",
   isEditMode,
   onCancel,
@@ -93,18 +83,9 @@ export const useEditableTable = ({
         dataSource: sourceDataSource as EditApi,
         deleteMode,
         editSessionApi,
-        editColumns,
-        editTable,
         rowDefaults,
       }),
-    [
-      deleteMode,
-      editColumns,
-      editSessionApi,
-      editTable,
-      rowDefaults,
-      sourceDataSource,
-    ],
+    [deleteMode, editSessionApi, rowDefaults, sourceDataSource],
   );
   const [lifecycle, setLifecycle] = useState<EditLifecycle>(
     editSession.lifecycle,

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -197,7 +197,7 @@ describe("EditSession lifecycle", () => {
 
   it("forwards copy options and defaults to All, defaults sessionType to edit", async () => {
     await editSession.begin();
-    expect(createSession).toHaveBeenCalledWith("All", "edit");
+    expect(createSession).toHaveBeenCalledWith("All", "edit", undefined);
 
     await editSession.end();
     createSession = vi.fn(
@@ -206,12 +206,12 @@ describe("EditSession lifecycle", () => {
     const selectedDataSource = new MockDataSource(endEdit, createSession);
     editSession = new EditSession({ dataSource: selectedDataSource });
     await editSession.begin("Selected");
-    expect(createSession).toHaveBeenCalledWith("Selected", "edit");
+    expect(createSession).toHaveBeenCalledWith("Selected", "edit", undefined);
   });
 
   it("forwards sessionType to createSessionDataSource", async () => {
     await editSession.begin("Empty", "import");
-    expect(createSession).toHaveBeenCalledWith("Empty", "import");
+    expect(createSession).toHaveBeenCalledWith("Empty", "import", undefined);
   });
 
   it("keeps a failed end session active and allows retry", async () => {

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -197,7 +197,7 @@ describe("EditSession lifecycle", () => {
 
   it("forwards copy options and defaults to All, defaults sessionType to edit", async () => {
     await editSession.begin();
-    expect(createSession).toHaveBeenCalledWith("All", "edit", undefined);
+    expect(createSession).toHaveBeenCalledWith("All", "edit");
 
     await editSession.end();
     createSession = vi.fn(
@@ -206,12 +206,12 @@ describe("EditSession lifecycle", () => {
     const selectedDataSource = new MockDataSource(endEdit, createSession);
     editSession = new EditSession({ dataSource: selectedDataSource });
     await editSession.begin("Selected");
-    expect(createSession).toHaveBeenCalledWith("Selected", "edit", undefined);
+    expect(createSession).toHaveBeenCalledWith("Selected", "edit");
   });
 
   it("forwards sessionType to createSessionDataSource", async () => {
     await editSession.begin("Empty", "import");
-    expect(createSession).toHaveBeenCalledWith("Empty", "import", undefined);
+    expect(createSession).toHaveBeenCalledWith("Empty", "import");
   });
 
   it("keeps a failed end session active and allows retry", async () => {

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
@@ -85,7 +85,7 @@ describe("EditSession", () => {
 
     await legacyEditSession.begin("Selected");
 
-    expect(beginEditSession).toHaveBeenCalledWith("selected-rows", undefined);
+    expect(beginEditSession).toHaveBeenCalledWith("selected-rows");
     expect(legacyEditSession.sessionDataSource).toBe(sessionDataSource);
   });
 

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
@@ -85,7 +85,7 @@ describe("EditSession", () => {
 
     await legacyEditSession.begin("Selected");
 
-    expect(beginEditSession).toHaveBeenCalledWith("selected-rows");
+    expect(beginEditSession).toHaveBeenCalledWith("selected-rows", undefined);
     expect(legacyEditSession.sessionDataSource).toBe(sessionDataSource);
   });
 

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -104,6 +104,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   #menu: VuuMenu | undefined;
   #optimize: OptimizeStrategy = "throttle";
   #selectedRowsCount = 0;
+  #session: SessionDataSourceOverrides | undefined;
   #sessionDataSource: DataSource | undefined = undefined;
   #sessionTableMessageColumn: string | undefined = undefined;
   #status: DataSourceStatus = "initialising";
@@ -112,6 +113,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   public table: VuuTable;
 
   constructor({
+    session,
     sessionTableMessageColumn,
     ...props
   }: DataSourceConstructorProps) {
@@ -126,6 +128,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     this.table = table;
 
     this.#pendingVisualLink = visualLink;
+    this.#session = session;
     this.#sessionTableMessageColumn = sessionTableMessageColumn;
     // this.rangeRequest = this.throttleRangeRequest;
     this.rangeRequest = this.rawRangeRequest;
@@ -700,9 +703,12 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
-      assertExpectedSessionTable(sessionTable, overrides?.table);
+      // A call-time override always wins; otherwise fall back to the session
+      // config this datasource was constructed with.
+      const effectiveOverrides = overrides ?? this.#session;
+      assertExpectedSessionTable(sessionTable, effectiveOverrides?.table);
       return new VuuDataSource({
-        ...sessionDataSourceConfig(this.config, overrides?.columns),
+        ...sessionDataSourceConfig(this.config, effectiveOverrides?.columns),
         table: sessionTable,
         viewport: sessionTable.table,
       });

--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -13,6 +13,7 @@ import type {
   EditSessionMode,
   OptimizeStrategy,
   ServerAPI,
+  SessionDataSourceOverrides,
   TableSchema,
   WithBaseFilter,
   WithFullConfig,
@@ -34,6 +35,7 @@ import type {
   VuuTable,
 } from "@vuu-ui/vuu-protocol-types";
 import {
+  assertExpectedSessionTable,
   BaseDataSource,
   combineFilters,
   constrainRange,
@@ -46,6 +48,7 @@ import {
   itemsOrOrderChanged,
   logger,
   Range,
+  sessionDataSourceConfig,
   StaleUpdateError,
   throttle,
   uuid,
@@ -688,6 +691,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   async createSessionDataSource(
     copyOption: CopyOption,
     sessionType: SessionType = "edit",
+    overrides?: SessionDataSourceOverrides,
   ): Promise<VuuDataSource | undefined> {
     const rpcResponse = await this?.rpcRequest?.({
       type: "RPC_REQUEST",
@@ -696,8 +700,9 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
+      assertExpectedSessionTable(sessionTable, overrides?.table);
       return new VuuDataSource({
-        ...this.config,
+        ...sessionDataSourceConfig(this.config, overrides?.columns),
         table: sessionTable,
         viewport: sessionTable.table,
       });

--- a/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
+++ b/vuu-ui/packages/vuu-data-remote/test/VuuDataSource.test.ts
@@ -23,6 +23,7 @@ vi.mock("../src/ConnectionManager", () => ({
     serverAPI: new Promise<ServerAPI>((resolve) => {
       // @ts-ignore
       resolve({
+        rpcCall: vi.fn(),
         send: vi.fn(),
         subscribe: vi.fn(),
       });
@@ -738,3 +739,76 @@ describe("VuuDataSource", () => {
     });
   });
 });
+
+describe("VuuDataSource createSessionDataSource session config", () => {
+  const table = { module: "SIMUL", table: "instruments" };
+  const sessionTableResponse = {
+    type: "SUCCESS_RESULT",
+    data: { table: { module: "SIMUL", table: "session-xyz" } },
+  };
+
+  const subscribedDataSource = async (
+    props: ConstructorParameters<typeof VuuDataSource>[0],
+  ) => {
+    const dataSource = new VuuDataSource(props);
+    await dataSource.subscribe({}, () => undefined);
+    return dataSource;
+  };
+
+  it("restricts session columns to session.columns when no call-time override is supplied", async () => {
+    const { rpcCall } = await ConnectionManager.serverAPI;
+    vi.mocked(rpcCall).mockResolvedValueOnce(sessionTableResponse as any);
+    const dataSource = await subscribedDataSource({
+      table,
+      columns: ["bbg", "currency", "description"],
+      session: { columns: ["ric", "isin"] },
+    });
+
+    const session = await dataSource.createSessionDataSource("All", "export");
+
+    expect(session?.columns).toEqual(["ric", "isin"]);
+  });
+
+  it("a call-time override takes precedence over the datasource's own session config", async () => {
+    const { rpcCall } = await ConnectionManager.serverAPI;
+    vi.mocked(rpcCall).mockResolvedValueOnce(sessionTableResponse as any);
+    const dataSource = await subscribedDataSource({
+      table,
+      columns: ["bbg", "currency", "description"],
+      session: { columns: ["ric", "isin"] },
+    });
+
+    const session = await dataSource.createSessionDataSource("All", "export", {
+      columns: ["lotSize"],
+    });
+
+    expect(session?.columns).toEqual(["lotSize"]);
+  });
+
+  it("without session.columns or a call-time override, the session inherits the source columns", async () => {
+    const { rpcCall } = await ConnectionManager.serverAPI;
+    vi.mocked(rpcCall).mockResolvedValueOnce(sessionTableResponse as any);
+    const dataSource = await subscribedDataSource({
+      table,
+      columns: ["bbg", "currency", "description"],
+    });
+
+    const session = await dataSource.createSessionDataSource("All", "export");
+
+    expect(session?.columns).toEqual(["bbg", "currency", "description"]);
+  });
+
+  it("rejects when the returned session table's module does not match session.table", async () => {
+    const { rpcCall } = await ConnectionManager.serverAPI;
+    vi.mocked(rpcCall).mockResolvedValueOnce(sessionTableResponse as any);
+    const dataSource = await subscribedDataSource({
+      table,
+      session: { table: { module: "WRONG_MODULE", table: "whatever" } },
+    });
+
+    await expect(
+      dataSource.createSessionDataSource("All", "export"),
+    ).rejects.toThrow(/does not match expected edit table module/);
+  });
+});
+

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -70,6 +70,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
   #pendingVisualLink?: LinkDescriptorWithLabel;
   #rpcMenuServices: RpcMenuService[] | undefined;
   #rpcServices: RpcService[] | undefined;
+  #session: SessionDataSourceOverrides | undefined;
   #sourceTableDataSource: TickingArrayDataSource | undefined;
   #table?: Table;
   #selectionLinkSubscribers: Map<string, LinkSubscription> | undefined;
@@ -84,6 +85,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
     getVisualLinks,
     rpcServices,
     rpcMenuServices,
+    session,
     table,
     menu,
     visualLink,
@@ -104,6 +106,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
     this.#rpcMenuServices = rpcMenuServices;
     this.#pendingVisualLink = visualLink;
     this.#rpcServices = rpcServices;
+    this.#session = session;
     this.#table = table;
     this.#visualLinkService = visualLinkService;
     this.#getVisualLinks = getVisualLinks;
@@ -183,10 +186,13 @@ export class TickingArrayDataSource extends ArrayDataSource {
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
-      assertExpectedSessionTable(sessionTable, overrides?.table);
+      // A call-time override always wins; otherwise fall back to the session
+      // config this datasource was constructed with.
+      const effectiveOverrides = overrides ?? this.#session;
+      assertExpectedSessionTable(sessionTable, effectiveOverrides?.table);
       const sessionConfig = sessionDataSourceConfig(
         this.config,
-        overrides?.columns,
+        effectiveOverrides?.columns,
       );
       const baseColumns = sessionConfig.columns.includes("vuuAction")
         ? sessionConfig.columns
@@ -222,11 +228,12 @@ export class TickingArrayDataSource extends ArrayDataSource {
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
-      assertExpectedSessionTable(sessionTable, overrides?.table);
+      const effectiveOverrides = overrides ?? this.#session;
+      assertExpectedSessionTable(sessionTable, effectiveOverrides?.table);
       const sessionDataSource = this.#vuuModule?.createDataSource(
         sessionTable.table,
         sessionTable.table,
-        { ...sessionDataSourceConfig(this.config, overrides?.columns) },
+        { ...sessionDataSourceConfig(this.config, effectiveOverrides?.columns) },
       );
       if (sessionDataSource instanceof TickingArrayDataSource) {
         sessionDataSource.#sourceTableDataSource = this;

--- a/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
+++ b/vuu-ui/packages/vuu-data-test/src/TickingArrayDataSource.ts
@@ -12,6 +12,7 @@ import type {
   DeleteRowMode,
   CopyOption,
   EditSessionMode,
+  SessionDataSourceOverrides,
   SessionType,
 } from "@vuu-ui/vuu-data-types";
 import type {
@@ -28,8 +29,10 @@ import type {
   VuuTable,
 } from "@vuu-ui/vuu-protocol-types";
 import {
+  assertExpectedSessionTable,
   isRpcSuccess,
   isTypeaheadRequest,
+  sessionDataSourceConfig,
   StaleUpdateError,
 } from "@vuu-ui/vuu-utils";
 import type {
@@ -171,6 +174,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
   async createSessionDataSource(
     copyOption: CopyOption,
     sessionType: SessionType = "edit",
+    overrides?: SessionDataSourceOverrides,
   ): Promise<DataSourceBase<DataSourceRowWithBigint> | undefined> {
     const rpcResponse = await this?.rpcRequest?.({
       type: "RPC_REQUEST",
@@ -179,9 +183,14 @@ export class TickingArrayDataSource extends ArrayDataSource {
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
-      const baseColumns = this.config.columns.includes("vuuAction")
-        ? this.config.columns
-        : this.config.columns.concat("vuuAction");
+      assertExpectedSessionTable(sessionTable, overrides?.table);
+      const sessionConfig = sessionDataSourceConfig(
+        this.config,
+        overrides?.columns,
+      );
+      const baseColumns = sessionConfig.columns.includes("vuuAction")
+        ? sessionConfig.columns
+        : sessionConfig.columns.concat("vuuAction");
       const columns =
         sessionType === "import" && !baseColumns.includes("vuuRowNum")
           ? baseColumns.concat("vuuRowNum")
@@ -189,7 +198,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
       const sessionDataSource = this.#vuuModule?.createDataSource(
         sessionTable.table,
         sessionTable.table,
-        { ...this.config, columns },
+        { ...sessionConfig, columns },
       );
       if (sessionDataSource instanceof TickingArrayDataSource) {
         sessionDataSource.#sourceTableDataSource = this;
@@ -204,6 +213,7 @@ export class TickingArrayDataSource extends ArrayDataSource {
 
   async beginEditSession(
     editSessionMode: EditSessionMode = "all-rows",
+    overrides?: SessionDataSourceOverrides,
   ): Promise<DataSourceBase<DataSourceRowWithBigint> | undefined> {
     const rpcResponse = await this?.rpcRequest?.({
       type: "RPC_REQUEST",
@@ -212,10 +222,11 @@ export class TickingArrayDataSource extends ArrayDataSource {
     });
     if (isRpcSuccess(rpcResponse)) {
       const { table: sessionTable } = rpcResponse.data as { table: VuuTable };
+      assertExpectedSessionTable(sessionTable, overrides?.table);
       const sessionDataSource = this.#vuuModule?.createDataSource(
         sessionTable.table,
         sessionTable.table,
-        { ...this.config },
+        { ...sessionDataSourceConfig(this.config, overrides?.columns) },
       );
       if (sessionDataSource instanceof TickingArrayDataSource) {
         sessionDataSource.#sourceTableDataSource = this;

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -7,6 +7,7 @@ import type {
   DeleteRowMode,
   EditSessionMode,
   CopyOption,
+  SessionDataSourceOverrides,
   SessionType,
   TableSchema,
 } from "@vuu-ui/vuu-data-types";
@@ -62,7 +63,7 @@ export interface IVuuModule<T extends string = string> {
   createDataSource: (
     tableName: T,
     viewport?: string,
-    config?: DataSourceConfig,
+    config?: DataSourceConfig & { session?: SessionDataSourceOverrides },
   ) => DataSourceBase<DataSourceRowWithBigint>;
 }
 
@@ -335,7 +336,7 @@ export abstract class VuuModule<T extends string = string>
   createDataSource = (
     tableName: T,
     viewport?: string,
-    config?: DataSourceConfig,
+    config?: DataSourceConfig & { session?: SessionDataSourceOverrides },
   ) => {
     const columnDescriptors = this.getColumnDescriptors(tableName);
     const table = this.tables[tableName];

--- a/vuu-ui/packages/vuu-data-test/src/local-datasource-provider/LocalDatasourceProvider.tsx
+++ b/vuu-ui/packages/vuu-data-test/src/local-datasource-provider/LocalDatasourceProvider.tsx
@@ -1,6 +1,7 @@
 import type {
   DataSourceConfig,
   DataSourceConstructorProps,
+  SessionDataSourceOverrides,
   ServerAPI,
 } from "@vuu-ui/vuu-data-types";
 import type { VuuTable } from "@vuu-ui/vuu-protocol-types";
@@ -45,16 +46,18 @@ class VuuDataSource {
     columns,
     filterSpec,
     groupBy,
+    session,
     sort,
     table,
     viewport,
     visualLink,
   }: DataSourceConstructorProps) {
-    const config: DataSourceConfig = {
+    const config: DataSourceConfig & { session?: SessionDataSourceOverrides } = {
       aggregations,
       columns,
       filterSpec,
       groupBy,
+      session,
       sort,
       visualLink,
     };

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.session-config.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.session-config.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { simulModule } from "../src/simul/SimulModule";
+
+// TickingArrayDataSource (the local/test datasource) ignores column
+// restriction at construction time - it only takes effect via subscribe().
+// Columns can't be asserted here, so these tests exercise the parts of the
+// merge logic that ARE visible on this datasource type: table validation and
+// discarding the inherited filterSpec. See VuuDataSource.test.ts for the
+// column-restriction behaviour, which the remote datasource honours directly.
+describe("TickingArrayDataSource session config (constructor-time)", () => {
+  it("a call-time override's table is validated against the server-assigned session table's module", async () => {
+    const ds = simulModule.createDataSource("instruments");
+    await expect(
+      ds.createSessionDataSource?.("All", "export", {
+        table: { module: "WRONG_MODULE", table: "whatever" },
+      }),
+    ).rejects.toThrow(/does not match expected edit table module/);
+  });
+
+  it("the datasource's own session config is validated the same way as a call-time override", async () => {
+    const ds = simulModule.createDataSource("instruments", undefined, {
+      session: { table: { module: "WRONG_MODULE", table: "whatever" } },
+    });
+    await expect(
+      ds.createSessionDataSource?.("All", "export"),
+    ).rejects.toThrow(/does not match expected edit table module/);
+  });
+
+  it("without session.columns, the session inherits the source datasource's filterSpec", async () => {
+    const ds = simulModule.createDataSource("instruments", undefined, {
+      filterSpec: { filter: 'currency = "USD"' },
+    });
+    const session = await ds.createSessionDataSource?.("All", "export");
+    expect(session?.config.filterSpec.filter).toBe('currency = "USD"');
+  });
+
+  it("with session.columns set, the session discards the source datasource's filterSpec", async () => {
+    const ds = simulModule.createDataSource("instruments", undefined, {
+      filterSpec: { filter: 'currency = "USD"' },
+      session: { columns: ["ric", "currency"] },
+    });
+    const session = await ds.createSessionDataSource?.("All", "export");
+    expect(session?.config.filterSpec).toEqual({ filter: "" });
+  });
+
+  it("with a call-time columns override, the session discards the source datasource's filterSpec", async () => {
+    const ds = simulModule.createDataSource("instruments", undefined, {
+      filterSpec: { filter: 'currency = "USD"' },
+    });
+    const session = await ds.createSessionDataSource?.("All", "export", {
+      columns: ["ric", "currency"],
+    });
+    expect(session?.config.filterSpec).toEqual({ filter: "" });
+  });
+
+  it("a call-time override takes precedence over the datasource's own session config", async () => {
+    const ds = simulModule.createDataSource("instruments", undefined, {
+      session: { table: { module: "WRONG_MODULE", table: "whatever" } },
+    });
+    // The call-time override has no `table`, so it should win outright and
+    // skip validation against the (invalid) session config's table.
+    const session = await ds.createSessionDataSource?.("All", "export", {
+      columns: ["ric"],
+    });
+    expect(session).toBeDefined();
+  });
+});
+

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -598,6 +598,18 @@ export declare type EditSessionMode =
   | "all-rows"
   | "empty-session-table";
 
+/**
+ * Describes an edit (session) table whose schema differs from the source (view) table.
+ * When supplied, the session datasource is built from these values instead of inheriting
+ * the source datasource config, which would otherwise reference view-only columns.
+ */
+export declare type SessionDataSourceOverrides = {
+  /** Columns to subscribe to on the session table. */
+  columns?: VuuColumns;
+  /** Expected session table. Used to validate the table returned by the server. */
+  table?: VuuTable;
+};
+
 export interface EditApi<
   T extends DataSourceRow | DataSourceRowWithBigint = DataSourceRow,
 > {
@@ -622,12 +634,14 @@ export interface EditApi<
   createSessionDataSource?: (
     copyOption: CopyOption,
     sessionType?: SessionType,
+    overrides?: SessionDataSourceOverrides,
   ) => Promise<DataSource<T> | undefined>;
   /**
    * Legacy session creation API. Prefer createSessionDataSource for new servers.
    */
   beginEditSession?: (
     editSessionMode?: EditSessionMode,
+    overrides?: SessionDataSourceOverrides,
   ) => Promise<DataSource<T> | undefined>;
   endEditSession?: (
     saveChanges?: boolean,

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -454,6 +454,12 @@ export interface DataSourceConstructorProps extends WithBaseFilter<DataSourceCon
    * after an edit session is saved. Default is no additional column.
    */
   sessionTableMessageColumn?: string;
+  /**
+   * Describes the session (edit/import/export) table when it differs from `table`.
+   * Applied internally by `createSessionDataSource` / `beginEditSession` whenever
+   * a call does not supply its own `SessionDataSourceOverrides`.
+   */
+  session?: SessionDataSourceOverrides;
   suspenseProps?: DataSourceSuspenseProps;
   table: VuuTable;
   title?: string;

--- a/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-export/CsvExport.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-export/CsvExport.playwright.test.tsx
@@ -1,0 +1,197 @@
+import { test, expect } from "../../../../../../playwright/fixtures";
+import * as fs from "fs";
+
+test.describe("exportCsvTemplate", () => {
+  test("WHEN triggered THEN a header-only CSV file is downloaded with the correct filename", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportTemplate");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page
+        .locator("button", { hasText: "Download template (all columns)" })
+        .click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("instruments-template.csv");
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("ric");
+    expect(lines[0]).toContain("currency");
+  });
+
+  test("WHEN a column subset is specified THEN the file contains exactly those columns in order", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportTemplate");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download template (ric" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const [header] = content.split("\r\n");
+
+    expect(header).toBe("ric,currency,description,exchange,isin");
+  });
+});
+
+test.describe("exportToCsv", () => {
+  test("WHEN triggered THEN a CSV file is downloaded with the correct filename", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportSimple");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments.csv" }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("instruments.csv");
+  });
+
+  test("WHEN triggered THEN the downloaded file contains a header row and data rows", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportSimple");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments.csv" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+    const [header, ...dataRows] = lines;
+
+    expect(header).toContain("ric");
+    expect(header).toContain("currency");
+    expect(header).toContain("description");
+    expect(dataRows.length).toBeGreaterThan(0);
+  });
+
+  test("WHEN triggered THEN internal session columns are excluded from the output", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportSimple");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments.csv" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const [header] = content.split("\r\n");
+
+    expect(header).not.toContain("vuuMsg");
+    expect(header).not.toContain("vuuAction");
+  });
+
+  test("WHEN row count exceeds maxRows THEN an error message is displayed and no download occurs", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithRowLimit");
+
+    // ensure no spurious download event fires
+    let downloadFired = false;
+    page.on("download", () => { downloadFired = true; });
+
+    await page.locator("button", { hasText: "Export (max 50 rows)" }).click();
+
+    await expect(
+      page.locator("span", { hasText: /Export failed/ }),
+    ).toBeVisible({ timeout: 5000 });
+    expect(downloadFired).toBe(false);
+  });
+
+  test("WHEN copyOption is Selected THEN only selected rows appear in the download", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportAllRows");
+
+    // select the first row via the row checkbox then export selected
+    await page
+      .getByRole("checkbox", { name: "Press space to select row" })
+      .first()
+      .click();
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Export Selected to CSV" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+
+    // header + exactly one data row
+    expect(lines).toHaveLength(2);
+  });
+});
+
+test.describe("ExportColumnDescriptor — exportFormatter and label", () => {
+  test("WHEN columnDescriptors with labels are provided THEN the CSV header uses label overrides", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithFormatters");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments-formatted.csv" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const [header] = content.split("\r\n");
+
+    expect(header).toContain("RIC Code");
+    expect(header).toContain("Bloomberg");
+    expect(header).toContain("Lot Size");
+    expect(header).not.toContain("ric,");
+    expect(header).not.toContain("lotSize");
+  });
+
+  test("WHEN an exportFormatter is provided THEN formatted values appear in the data rows", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithFormatters");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download instruments-formatted.csv" }).click(),
+    ]);
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+    const dataRows = lines.slice(1);
+
+    expect(dataRows.length).toBeGreaterThan(0);
+    // every data row's lotSize column should end with " units"
+    expect(dataRows.every((row) => row.split(",").some((cell) => cell.endsWith(" units")))).toBe(true);
+  });
+});

--- a/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-export/CsvExport.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-export/CsvExport.playwright.test.tsx
@@ -195,3 +195,50 @@ test.describe("ExportColumnDescriptor — exportFormatter and label", () => {
     expect(dataRows.every((row) => row.split(",").some((cell) => cell.endsWith(" units")))).toBe(true);
   });
 });
+
+test.describe("exportCsvTemplate and exportToCsv with overrides", () => {
+  test("WHEN overrides with columns are passed to exportCsvTemplate THEN the template header matches overrides", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithOverrides");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page
+        .locator("button", { hasText: "Template with column overrides" })
+        .click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("template-overrides.csv");
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const [header] = content.split("\r\n");
+
+    expect(header).toBe("ric,isin");
+  });
+
+  test("WHEN overrides with columns are passed to exportToCsv THEN exported CSV columns match overrides", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithOverrides");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page
+        .locator("button", { hasText: "Export with column overrides" })
+        .click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("instruments-overrides.csv");
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const [header] = content.split("\r\n");
+
+    expect(header).toBe("ric,currency,lotSize");
+  });
+});
+

--- a/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-upload/CsvUpload.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-upload/CsvUpload.playwright.test.tsx
@@ -254,3 +254,74 @@ test.describe("Given a CsvUpload with a missing key column", () => {
     );
   });
 });
+
+test.describe("Given a CsvUpload with an import table", () => {
+  test("WHEN importSchema is provided THEN the CSV is validated against it and its columns drive the session", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvUpload/CsvUploadWithImportSchema");
+
+    // 'quantity' is absent from the target table schema, present in the import schema
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "import-cols.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from("id,quantity\nrow-001,10\n"),
+    });
+
+    await expect(page.locator("button", { hasText: "Import" })).toBeEnabled({
+      timeout: 5000,
+    });
+    await expect(page.locator(".vuuCsvUpload-dropZone")).not.toContainText(
+      "Your file contains errors",
+    );
+
+    await page.locator("button", { hasText: "Import" }).click();
+
+    await expect(
+      page.locator('[data-testid="session-columns"]'),
+    ).toHaveAttribute("data-columns", "id,quantity", { timeout: 5000 });
+  });
+
+  test("WHEN a CSV matching the target table but not the import table is selected THEN it is rejected", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvUpload/CsvUploadWithImportSchema");
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "target-cols.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from("id,name\nrow-001,Widget\n"),
+    });
+
+    await expect(page.locator(".saltFileDropZone")).toHaveClass(
+      /saltFileDropZone-error/,
+      { timeout: 5000 },
+    );
+    await expect(page.locator(".vuuCsvUpload-errorItem")).toContainText(
+      "Column name is not present in table schema.",
+    );
+  });
+
+  test("WHEN only importTable is provided THEN the schema is fetched and used for validation", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvUpload/CsvUploadWithImportTableOnly");
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "instruments.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(
+        "bbg,currency,description,exchange,isin,lotSize,ric\nAAPL US,USD,Apple Inc,NASDAQ,US0378331005,120,AAPL.O\n",
+      ),
+    });
+
+    await expect(page.locator(".vuuCsvUpload-dropZone")).not.toContainText(
+      "Your file contains errors",
+      { timeout: 5000 },
+    );
+    await expect(page.locator("button", { hasText: "Import" })).toBeEnabled();
+  });
+});

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/CsvUpload.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/CsvUpload.tsx
@@ -14,7 +14,7 @@ import { type ReactNode, useCallback, useState } from "react";
 import type { RowDefaultDataItemValues, EditSession } from "@vuu-ui/vuu-data-editing";
 import type { CsvParseError, CsvParseOptions } from "./parse/csv-parse";
 import type { CsvValidationStructuredError } from "./parse/csv-schema-validation";
-import type { DataSource } from "@vuu-ui/vuu-data-types";
+import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
 import type { VuuTable } from "@vuu-ui/vuu-protocol-types";
 import type { CsvUploadTableData } from "./parse/csv-upload-utils";
 import { useCsvUpload } from "./useCsvUpload";
@@ -68,6 +68,14 @@ export interface CsvUploadProps {
   children?: ReactNode;
   dataSource: DataSource;
   embedded?: boolean;
+  /**
+   * Schema of the import table, where it differs from the target table. Used to validate
+   * the CSV and to determine the session datasource columns. If omitted and importTable is
+   * provided, the schema is fetched via getTableSchema. Pass a stable reference.
+   */
+  importSchema?: TableSchema;
+  /** Expected import table, used to validate the session table returned by the server. */
+  importTable?: VuuTable;
   onImportSessionStarted?: (dataSource: DataSource) => void;
   onImportSessionEnded?: (result: CsvUploadSessionEndResult) => void;
   onError?: (result: CsvUploadErrorResult | undefined) => void;

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
@@ -2,6 +2,8 @@
 
 The `CsvUpload` component provides a dialog-based workflow for uploading, validating, and importing a CSV file into a Vuu table via RPC. It manages a server-side edit session throughout the process and exposes a lifecycle callback API so consumers can track and react to each phase.
 
+See [CSV Export](../../../vuu-utils/docs/csv-export.md) for the counterpart utilities that export a table to CSV.
+
 ---
 
 ## Usage

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
@@ -30,6 +30,8 @@ import { CsvUpload } from "@vuu-ui/vuu-table-extras";
 | Prop | Type | Description |
 |---|---|---|
 | `dataSource` | `DataSource` | **Required.** The Vuu data source for the target table. Must support `createSessionDataSource` (used internally with `sessionType: "import"`), `addRow`, and `endEditSession`. |
+| `importSchema` | `TableSchema` | Schema of the import table, where it differs from the target table. Used to validate the CSV and to determine the session datasource columns. If omitted and `importTable` is provided, the schema is fetched via `getTableSchema`. Pass a stable reference. See [Importing into a separate table](#importing-into-a-separate-table). |
+| `importTable` | `VuuTable` | The import table, where it differs from the target table. Used to resolve `importSchema` when that is not supplied, and to validate the module of the session table returned by the server. |
 | `embedded` | `boolean` | Renders the upload content and actions without its own `Dialog`, for use inside an existing modal. Defaults to `false`. |
 | `importMode` | `"direct" \| "preview"` | Both modes create and populate an `EditSession`. `"direct"` commits it when Import is pressed; `"preview"` returns the live session through `onPreview` so the caller can edit or delete rows before ending it. Defaults to `"direct"`. |
 | `maxRows` | `number` | Maximum number of data rows permitted in the CSV. Defaults to `25000`. |
@@ -191,6 +193,34 @@ Row payloads sent to `addRow` differ by validity:
 - **Error rows** — only `{ vuuRowNum, vuuMsg }` (no column data); the session table key is set to the string value of `vuuRowNum`.
 
 On `endEditSession(save: true)` the server skips any row where `vuuMsg` is non-empty, so error rows are never committed to the source table.
+
+---
+
+## Importing into a separate table
+
+By default the CSV is validated against `dataSource.tableSchema` and the session inherits the target table's columns. When uploads land in a dedicated import/export table with its own schema, declare it:
+
+```tsx
+<CsvUpload
+  dataSource={targetDataSource}   // subscribed; carries the createSessionTable RPC
+  importTable={IMPORT_TABLE}
+  importSchema={IMPORT_SCHEMA}    // optional - fetched from importTable if omitted
+/>
+```
+
+`importSchema` does double duty: its column names become the session datasource columns, and it replaces `dataSource.tableSchema` as the schema the CSV is validated against. That second role is not optional — `processFile` validates the CSV *before* the session begins, and the session datasource is never subscribed (rows are added via `addRow` RPC), so its schema is never populated. The import schema has to be known up front.
+
+| Props | Behaviour |
+|---|---|
+| neither | Validates against `dataSource.tableSchema`; session inherits target columns. |
+| `importTable` only | Schema fetched once via `getTableSchema`; drives validation and session columns. |
+| both | `importSchema` wins; no fetch. |
+
+Notes:
+
+- Once `importTable` is set, the schema never falls back to `dataSource.tableSchema`. Until the fetch resolves `schema` is `undefined`, which disables the drop zone — validating against the target table's columns would be silently wrong.
+- `importSchema` must be a stable reference; it feeds the `EditSession` memo, so a value constructed inline each render recreates the session.
+- The import table's session table must still accept `vuuRowNum` and `vuuMsg`, which are sent on every row.
 
 ---
 

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
@@ -1,4 +1,9 @@
-import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
+import type {
+  DataSource,
+  EditApi,
+  SessionDataSourceOverrides,
+  TableSchema,
+} from "@vuu-ui/vuu-data-types";
 import { EditSession, type RowDefaultDataItemValues } from "@vuu-ui/vuu-data-editing";
 import type { VuuRowDataItemType, VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { isRpcError, isSessionTable, useData } from "@vuu-ui/vuu-utils";
@@ -119,20 +124,41 @@ export const useCsvUpload = ({
   }, [getServerAPI, importSchema, importTable]);
 
   const resolvedImportSchema = importSchema ?? fetchedImportSchema;
-  const editColumns = useMemo(
-    () => resolvedImportSchema?.columns.map(({ name }) => name),
-    [resolvedImportSchema],
-  );
+  const sessionOverrides = useMemo<SessionDataSourceOverrides | undefined>(() => {
+    const columns = resolvedImportSchema?.columns.map(({ name }) => name);
+    return columns || importTable ? { columns, table: importTable } : undefined;
+  }, [resolvedImportSchema, importTable]);
+  // EditSession's constructor takes no session/schema config - the override is applied
+  // here, at the createSessionDataSource call site, since `dataSource` is supplied by the
+  // caller and may be shared with a view that has no knowledge of the import table.
+  const importDataSource = useMemo<EditApi & { tableSchema?: TableSchema }>(() => {
+    if (!sessionOverrides) {
+      return dataSource;
+    }
+    return {
+      tableSchema: dataSource.tableSchema,
+      createSessionDataSource: async (copyOption, sessionType) => {
+        if (!dataSource.createSessionDataSource) {
+          throw Error(
+            "[useCsvUpload] dataSource does not support createSessionDataSource",
+          );
+        }
+        return dataSource.createSessionDataSource(
+          copyOption,
+          sessionType,
+          sessionOverrides,
+        );
+      },
+    };
+  }, [dataSource, sessionOverrides]);
   const editSession = useMemo(
     () =>
       new EditSession({
-        dataSource,
+        dataSource: importDataSource,
         editSessionApi: "createSessionDataSource",
-        editColumns,
-        editTable: importTable,
         rowDefaults,
       }),
-    [dataSource, editColumns, importTable, rowDefaults],
+    [importDataSource, rowDefaults],
   );
   const ownsEditSessionRef = useRef(true);
   const operationIdRef = useRef(0);

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
@@ -1,7 +1,7 @@
 import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
 import { EditSession, type RowDefaultDataItemValues } from "@vuu-ui/vuu-data-editing";
-import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
-import { isRpcError, isSessionTable } from "@vuu-ui/vuu-utils";
+import type { VuuRowDataItemType, VuuTable } from "@vuu-ui/vuu-protocol-types";
+import { isRpcError, isSessionTable, useData } from "@vuu-ui/vuu-utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { parseCsv, type CsvParseOptions } from "./parse/csv-parse";
 import {
@@ -29,6 +29,14 @@ import type {
 export interface CsvUploadHookProps {
   dataSource: DataSource;
   importMode?: "direct" | "preview";
+  /**
+   * Schema of the import table, where it differs from the target table. Used to validate
+   * the CSV and to determine the session datasource columns. If omitted and importTable is
+   * provided, the schema is fetched via getTableSchema. Pass a stable reference.
+   */
+  importSchema?: TableSchema;
+  /** Expected import table, used to validate the session table returned by the server. */
+  importTable?: VuuTable;
   maxRows?: number;
   onImportSessionEnded?: (result: CsvUploadSessionEndResult) => void;
   onImportSessionStarted?: (dataSource: DataSource) => void;
@@ -60,6 +68,8 @@ export type UseCsvUploadReturn = {
 export const useCsvUpload = ({
   dataSource,
   importMode = "direct",
+  importSchema,
+  importTable,
   onImportSessionEnded,
   onImportSessionStarted,
   onError,
@@ -70,6 +80,7 @@ export const useCsvUpload = ({
   parseOptions,
   rowDefaults,
 }: CsvUploadHookProps): UseCsvUploadReturn => {
+  const { getServerAPI } = useData();
   const [validation, setValidation] = useState<
     CsvValidationResult | undefined
   >();
@@ -78,9 +89,50 @@ export const useCsvUpload = ({
   >();
   const [isProcessingFile, setIsProcessingFile] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
+  const [fetchedImportSchema, setFetchedImportSchema] = useState<
+    TableSchema | undefined
+  >();
+
+  useEffect(() => {
+    if (importSchema || importTable === undefined) {
+      setFetchedImportSchema(undefined);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const server = await getServerAPI();
+        const tableSchema = await server.getTableSchema(importTable);
+        if (!cancelled) {
+          setFetchedImportSchema(tableSchema);
+        }
+      } catch (error) {
+        console.error(
+          "[useCsvUpload] failed to fetch import table schema",
+          error,
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getServerAPI, importSchema, importTable]);
+
+  const resolvedImportSchema = importSchema ?? fetchedImportSchema;
+  const editColumns = useMemo(
+    () => resolvedImportSchema?.columns.map(({ name }) => name),
+    [resolvedImportSchema],
+  );
   const editSession = useMemo(
-    () => new EditSession({ dataSource, editSessionApi: "createSessionDataSource", rowDefaults }),
-    [dataSource, rowDefaults],
+    () =>
+      new EditSession({
+        dataSource,
+        editSessionApi: "createSessionDataSource",
+        editColumns,
+        editTable: importTable,
+        rowDefaults,
+      }),
+    [dataSource, editColumns, importTable, rowDefaults],
   );
   const ownsEditSessionRef = useRef(true);
   const operationIdRef = useRef(0);
@@ -152,7 +204,12 @@ export const useCsvUpload = ({
   );
 
   const table = dataSource.table;
-  const schema = dataSource.tableSchema;
+  // CSV is validated before the session table exists, so the import schema cannot
+  // come from the session datasource. Never fall back to the target schema once an
+  // import table is declared - that would validate against the wrong columns.
+  const schema = importTable
+    ? resolvedImportSchema
+    : (resolvedImportSchema ?? dataSource.tableSchema);
 
   const addAllRows = useCallback(
     async (mergedValidation: CsvValidationResult, operationId: number) => {

--- a/vuu-ui/packages/vuu-table-types/index.d.ts
+++ b/vuu-ui/packages/vuu-table-types/index.d.ts
@@ -299,6 +299,8 @@ export interface ColumnDescriptor extends DataValueDescriptor {
    */
   colHeaderContentRenderer?: string;
   colHeaderLabelRenderer?: string;
+  /** Formats a raw value for CSV export; return value is still CSV-escaped. */
+  exportFormatter?: (value: unknown) => string;
   flex?: number;
   /**
    * Only used when the column is included in a grouby clause.

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -38,7 +38,7 @@ test.describe("useEditableTable session readiness", () => {
 });
 
 test.describe("useEditableTable with a divergent edit table", () => {
-  test("forwards editColumns to createSessionDataSource and reports divergence", async ({
+  test("applies the datasource's session config and reports divergence", async ({
     mount,
     page,
   }) => {
@@ -48,10 +48,6 @@ test.describe("useEditableTable with a divergent edit table", () => {
     await page.getByRole("button", { name: "Start edit session" }).click();
 
     await expect(output).toHaveAttribute("data-session", "true");
-    await expect(output).toHaveAttribute(
-      "data-override-columns",
-      "id,quantity",
-    );
     await expect(output).toHaveAttribute("data-edit-schema", "id,quantity");
     await expect(output).toHaveAttribute("data-diverge", "true");
   });

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-editing.playwright.test.tsx
@@ -37,6 +37,26 @@ test.describe("useEditableTable session readiness", () => {
   });
 });
 
+test.describe("useEditableTable with a divergent edit table", () => {
+  test("forwards editColumns to createSessionDataSource and reports divergence", async ({
+    mount,
+    page,
+  }) => {
+    await mount("Table/Editing/UseEditableTableWithEditColumns");
+
+    const output = page.locator("output");
+    await page.getByRole("button", { name: "Start edit session" }).click();
+
+    await expect(output).toHaveAttribute("data-session", "true");
+    await expect(output).toHaveAttribute(
+      "data-override-columns",
+      "id,quantity",
+    );
+    await expect(output).toHaveAttribute("data-edit-schema", "id,quantity");
+    await expect(output).toHaveAttribute("data-diverge", "true");
+  });
+});
+
 test.describe("Inline add row", () => {
   test("renders insert-editable cells and blanks update-only columns", async ({
     mount,

--- a/vuu-ui/packages/vuu-utils/docs/csv-export.md
+++ b/vuu-ui/packages/vuu-utils/docs/csv-export.md
@@ -1,0 +1,168 @@
+# CSV Export
+
+CSV export is a set of standalone utility functions — `exportToCsv`, `exportCsvTemplate`, and `exportSessionTableToCsv` — implemented in [export-utils.ts](../src/export-utils.ts) and exported from `@vuu-ui/vuu-utils`. There is no React component: call them directly from a button handler or menu action.
+
+See [CsvUpload](../../vuu-table-extras/src/csv-upload/README.md) for the counterpart component that imports a CSV into a Vuu table.
+
+---
+
+## Usage
+
+```tsx
+import { exportToCsv } from "@vuu-ui/vuu-utils";
+
+const handleExport = useCallback(async () => {
+  await exportToCsv(
+    dataSource,
+    "All",
+    "instruments.csv",
+    [],
+    (err) => setStatus(`Export failed: ${err.message}`),
+    () => setStatus("Download started"),
+  );
+}, [dataSource]);
+```
+
+`exportCsvTemplate` downloads a header-only CSV, useful for giving users a starting point for a [CsvUpload](../../vuu-table-extras/src/csv-upload/README.md) import:
+
+```tsx
+import { exportCsvTemplate } from "@vuu-ui/vuu-utils";
+
+exportCsvTemplate(dataSource, "instruments-template.csv");
+```
+
+---
+
+## `exportToCsv`
+
+```ts
+exportToCsv<TName extends string = string>(
+  dataSource: DataSource,
+  copyOption?: CopyOption,             // default "All"
+  filename?: string,                   // default "export.csv"
+  excludeColumns?: string[],
+  onError?: (error: Error) => void,
+  onSuccess?: () => void,
+  maxRows?: number,                    // default 10_000
+  columnDescriptors?: ExportColumnDescriptor<TName>[],
+  overrides?: SessionDataSourceOverrides,
+): Promise<void>
+```
+
+Creates a session table via `dataSource.createSessionDataSource(copyOption, "export", overrides)`, subscribes to it, drains every row, then triggers a browser download. The session data source is unsubscribed automatically once the download completes or the export fails.
+
+| Param | Description |
+|---|---|
+| `dataSource` | The target `DataSource`. Must support `createSessionDataSource`, unless it is already a session table (see [Exporting an existing session table](#exporting-an-existing-session-table)). |
+| `copyOption` | `"All"` exports every row, `"Selected"` only the currently selected rows. |
+| `excludeColumns` | Additional columns to omit, on top of the always-excluded `vuuMsg`, `vuuAction`, `vuuRowNum`. |
+| `onError` | Called once with the failure reason. Never called and rejected simultaneously — the returned promise always resolves. |
+| `onSuccess` | Called once the download has been triggered (or once, with no download, if the table has zero rows). |
+| `maxRows` | Row limit for the whole table. If the server reports more rows than this, the export fails via `onError` before any data is requested. |
+| `columnDescriptors` | See [Column labels and formatters](#column-labels-and-formatters). Every `name` not present in the session table's columns (excluding the always-excluded set) fails the export via `onError`. |
+| `overrides` | See [Exporting a divergent export table](#exporting-a-divergent-export-table). |
+
+Rows are requested from the session data source in chunks of 1,000 rather than one bulk range request, so this behaves predictably across both local and remote data sources.
+
+---
+
+## `exportCsvTemplate`
+
+```ts
+exportCsvTemplate(
+  dataSource: DataSource,
+  filename?: string,                   // default "template.csv"
+  excludeColumns?: string[],
+  columns?: string[],
+  overrides?: SessionDataSourceOverrides,
+): Promise<void>
+```
+
+Downloads a single-row CSV containing only the column headers — no data rows, no server round trip for rows (it creates an `"Empty"` session table purely to discover columns). Pass `columns` to restrict the header to a specific subset and order; omit it to include every schema column except the always-excluded set.
+
+If `dataSource.createSessionDataSource` fails or is unavailable, this falls back to `dataSource.tableSchema` to build the header. In that fallback path, `columns` (or `overrides.columns`) not present in the schema produce a console warning rather than a thrown error.
+
+---
+
+## `exportSessionTableToCsv`
+
+```ts
+exportSessionTableToCsv<TName extends string = string>(
+  dataSource: DataSource,
+  filename?: string,
+  excludeColumns?: string[],
+  onError?: (error: Error) => void,
+  onSuccess?: () => void,
+  maxRows?: number,
+  columnDescriptors?: ExportColumnDescriptor<TName>[],
+  copyOption?: CopyOption,
+  overrides?: SessionDataSourceOverrides,
+): Promise<void>
+```
+
+The lower-level function `exportToCsv` delegates to. Accepts either a view `DataSource` (in which case it creates the session table itself, exactly like `exportToCsv`) or an already-created session `DataSource` — see below.
+
+### Exporting an existing session table
+
+If `dataSource.table` is already a session table (`isSessionTable(dataSource.table)`), `exportSessionTableToCsv` subscribes to it directly instead of calling `createSessionDataSource` again. This lets a caller build and populate a session table itself (e.g. an in-progress `EditSession`) and export it without a redundant server round trip.
+
+---
+
+## Column labels and formatters
+
+```ts
+type ExportColumnDescriptor<TName extends string = string> = {
+  name: TName;
+  /** Override the column name used as the CSV header label. */
+  label?: string;
+  exportFormatter?: (value: unknown) => string;
+};
+```
+
+```tsx
+const descriptors: ExportColumnDescriptor[] = [
+  { name: "ric", label: "RIC Code" },
+  { name: "lotSize", label: "Lot Size", exportFormatter: (v) => `${v} units` },
+];
+
+await exportToCsv(dataSource, "All", "instruments.csv", [], onError, onSuccess, 10_000, descriptors);
+```
+
+`exportFormatter` is applied per-cell before CSV escaping. `label` overrides only the header row — the underlying column selection and order are unaffected. Omitting `columnDescriptors` exports every subscribed column (excluding the always-excluded set) using its raw column name as both header and value.
+
+---
+
+## Exporting a divergent export table
+
+By default the session table is built from the target data source's config, so it carries the target table's columns. When exports should target a separate table with its own schema, pass `overrides`:
+
+```ts
+await exportToCsv(
+  dataSource,
+  "All",
+  "instruments-overrides.csv",
+  [],
+  onError,
+  onSuccess,
+  10_000,
+  undefined,
+  { columns: ["ric", "currency", "lotSize"], table: EXPORT_TABLE },
+);
+```
+
+```ts
+type SessionDataSourceOverrides = {
+  /** Columns to subscribe to on the session table. */
+  columns?: string[];
+  /** Expected session table. Used to validate the table returned by the server. */
+  table?: VuuTable;
+};
+```
+
+`overrides.columns` is forwarded to both `createSessionDataSource` and the subsequent `subscribe()` call, so the exported header and rows reflect exactly those columns — not the target table's full column set. `overrides.table` is checked against the module of the server-assigned session table; the session table name itself is always server-generated, so only the module is compared.
+
+---
+
+## Row limits
+
+`maxRows` (default `10_000`) caps the whole export, not the local buffer size. If the session table reports more rows than `maxRows`, the export fails via `onError` before any row data is requested — no partial file is downloaded.

--- a/vuu-ui/packages/vuu-utils/src/datasource/datasource-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/datasource/datasource-utils.ts
@@ -18,11 +18,13 @@ import type {
 } from "@vuu-ui/vuu-data-types";
 import type {
   LinkDescriptorWithLabel,
+  VuuColumns,
   VuuCreateVisualLink,
   VuuFilter,
   VuuRemoveVisualLink,
   VuuRowDataItemType,
   VuuSort,
+  VuuTable,
 } from "@vuu-ui/vuu-protocol-types";
 import type { ColumnMap } from "../column-utils";
 import type { ConfigWithVisualLink } from "./BaseDataSource";
@@ -36,6 +38,38 @@ export const vanillaConfig: WithFullConfig = {
   filterSpec: NoFilter,
   groupBy: [],
   sort: NoSort,
+};
+
+/**
+ * Derive the config for a session (edit) datasource from the source (view) datasource config.
+ * When the edit table declares its own columns, the view config's filter, groupBy, sort and
+ * aggregations are discarded rather than inherited - they may reference view-only columns.
+ */
+export const sessionDataSourceConfig = (
+  sourceConfig: WithFullConfig,
+  overrideColumns?: VuuColumns,
+): WithFullConfig => {
+  if (overrideColumns === undefined) {
+    return sourceConfig;
+  }
+  return {
+    ...vanillaConfig,
+    columns: overrideColumns,
+  };
+};
+
+/**
+ * The session table name is server generated, so only the module is compared.
+ */
+export const assertExpectedSessionTable = (
+  sessionTable: VuuTable,
+  expectedTable?: VuuTable,
+) => {
+  if (expectedTable && expectedTable.module !== sessionTable.module) {
+    throw Error(
+      `[datasource-utils] session table ${sessionTable.module}/${sessionTable.table} does not match expected edit table module ${expectedTable.module}`,
+    );
+  }
 };
 
 export const stripVisualLink = (

--- a/vuu-ui/packages/vuu-utils/src/export-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/export-utils.ts
@@ -4,8 +4,10 @@ import type {
   DataSourceCallbackMessage,
   DataSourceRow,
   DataSourceSubscribedMessage,
+  SessionDataSourceOverrides,
 } from "@vuu-ui/vuu-data-types";
 import { metadataKeys } from "./column-utils";
+import { isSessionTable } from "./protocol-message-utils";
 import { Range } from "./range-utils";
 
 export type ExportColumnDescriptor<TName extends string = string> = {
@@ -41,46 +43,127 @@ const triggerCsvDownload = (csv: string, filename: string): void => {
 };
 
 /** Downloads a single-row CSV containing only the column headers, for use as an import template. */
-export const exportCsvTemplate = (
+export const exportCsvTemplate = async (
   dataSource: DataSource,
   filename = "template.csv",
   excludeColumns: string[] = [],
   columns?: string[],
-): void => {
-  const schema = dataSource.tableSchema;
-  if (!schema) {
-    throw Error("exportCsvTemplate: tableSchema not available on dataSource");
-  }
-  const schemaColumnNames = new Set(schema.columns.map((col) => col.name));
-  if (columns !== undefined) {
-    const unknown = columns.filter((name) => !schemaColumnNames.has(name));
-    if (unknown.length > 0) {
-      throw Error(`exportCsvTemplate: unknown column(s): ${unknown.join(", ")}`);
+  overrides?: SessionDataSourceOverrides,
+): Promise<void> => {
+  const sessionOverrides: SessionDataSourceOverrides | undefined =
+    overrides ?? (columns ? { columns } : undefined);
+
+  if (!isSessionTable(dataSource.table) && dataSource.createSessionDataSource) {
+    try {
+      const sessionDataSource = await dataSource.createSessionDataSource(
+        "Empty",
+        "export",
+        sessionOverrides,
+      );
+      if (sessionDataSource) {
+        return new Promise<void>((resolve) => {
+          const excluded = new Set([
+            ...EXPORT_EXCLUDED_COLUMNS,
+            ...excludeColumns,
+          ]);
+          sessionDataSource.subscribe(
+            { range: Range(0, 0), columns: sessionOverrides?.columns },
+            (message: DataSourceCallbackMessage) => {
+              if (message.type === "subscribed") {
+                const { columns: subColumns } =
+                  message as DataSourceSubscribedMessage;
+                const exportCols = subColumns.filter(
+                  (name) => !excluded.has(name),
+                );
+                const header = exportCols.map(csvCell).join(",");
+                triggerCsvDownload(`${header}\r\n`, filename);
+                sessionDataSource.unsubscribe();
+                resolve();
+              }
+            },
+          );
+        });
+      }
+    } catch (error) {
+      console.warn(
+        "[exportCsvTemplate] createSessionDataSource failed, falling back to tableSchema",
+        error,
+      );
     }
   }
+
+  const schema = dataSource.tableSchema;
+  const targetColumns = columns ?? overrides?.columns;
+  if (targetColumns !== undefined) {
+    if (schema) {
+      const schemaColumnNames = new Set(schema.columns.map((col) => col.name));
+      const unknown = targetColumns.filter((name) => !schemaColumnNames.has(name));
+      if (unknown.length > 0) {
+        console.warn(
+          `[exportCsvTemplate] unknown column(s) in view tableSchema: ${unknown.join(", ")}`,
+        );
+      }
+    }
+  } else if (!schema) {
+    throw Error("exportCsvTemplate: tableSchema not available on dataSource");
+  }
+
   const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
-  const exportCols = columns
-    ? columns.filter((name) => !excluded.has(name))
-    : schema.columns.filter((col) => !excluded.has(col.name)).map((col) => col.name);
+  const exportCols = targetColumns
+    ? targetColumns.filter((name) => !excluded.has(name))
+    : schema?.columns
+        .filter((col) => !excluded.has(col.name))
+        .map((col) => col.name) ?? [];
+
+  if (exportCols.length === 0) {
+    throw Error("exportCsvTemplate: no columns available for export");
+  }
+
   const header = exportCols.map(csvCell).join(",");
   triggerCsvDownload(`${header}\r\n`, filename);
 };
 
 /**
- * Subscribes to `sessionDataSource` with a full-range request to drain all rows,
- * serialises them to CSV (excluding internal session columns), then triggers a
- * browser download. The dataSource is unsubscribed automatically once the download
+ * Subscribes to `dataSource` (creating an export session data source if a view data source is passed)
+ * with a full-range request to drain all rows, serialises them to CSV (excluding internal session columns),
+ * then triggers a browser download. The session data source is unsubscribed automatically once the download
  * is initiated.
  */
-export const exportSessionTableToCsv = <TName extends string = string>(
-  sessionDataSource: DataSource,
+export const exportSessionTableToCsv = async <TName extends string = string>(
+  dataSource: DataSource,
   filename = "export.csv",
   excludeColumns: string[] = [],
   onError?: (error: Error) => void,
   onSuccess?: () => void,
   maxRows = MAX_EXPORT_ROWS,
   columnDescriptors?: ExportColumnDescriptor<TName>[],
-): void => {
+  copyOption: CopyOption = "All",
+  overrides?: SessionDataSourceOverrides,
+): Promise<void> => {
+  let sessionDataSource: DataSource | undefined;
+  if (!isSessionTable(dataSource.table) && dataSource.createSessionDataSource) {
+    try {
+      sessionDataSource = await dataSource.createSessionDataSource(
+        copyOption,
+        "export",
+        overrides,
+      );
+    } catch (err) {
+      onError?.(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+  } else {
+    sessionDataSource = dataSource;
+  }
+
+  if (!sessionDataSource) {
+    onError?.(
+      new Error("exportSessionTableToCsv: unable to obtain sessionDataSource"),
+    );
+    return;
+  }
+
+  const activeSessionDataSource = sessionDataSource;
   const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
   let exportCols: string[] = [];
   let colNameToRowIdx: Record<string, number> = {};
@@ -88,72 +171,102 @@ export const exportSessionTableToCsv = <TName extends string = string>(
   let totalSize = 0;
   const collectedRows: DataSourceRow[] = [];
 
-  const handleMessage = (message: DataSourceCallbackMessage): void => {
-    if (message.type === "subscribed") {
-      const { columns } = message as DataSourceSubscribedMessage;
-      if (columnDescriptors) {
-        const subscribedSet = new Set(columns);
-        const unknown = columnDescriptors
-          .filter((d) => !excluded.has(d.name) && !subscribedSet.has(d.name))
-          .map((d) => d.name);
-        if (unknown.length > 0) {
-          sessionDataSource.unsubscribe();
-          onError?.(new Error(`exportToCsv: unknown column(s) in columnDescriptors: ${unknown.join(", ")}`));
-          return;
+  return new Promise<void>((resolve) => {
+    const handleMessage = (message: DataSourceCallbackMessage): void => {
+      if (message.type === "subscribed") {
+        const { columns } = message as DataSourceSubscribedMessage;
+        if (columnDescriptors) {
+          const subscribedSet = new Set(columns);
+          const unknown = columnDescriptors
+            .filter((d) => !excluded.has(d.name) && !subscribedSet.has(d.name))
+            .map((d) => d.name);
+          if (unknown.length > 0) {
+            activeSessionDataSource.unsubscribe();
+            onError?.(
+              new Error(
+                `exportToCsv: unknown column(s) in columnDescriptors: ${unknown.join(", ")}`,
+              ),
+            );
+            resolve();
+            return;
+          }
+          descriptorMap = Object.fromEntries(
+            columnDescriptors.map((d) => [d.name, d]),
+          );
         }
-        descriptorMap = Object.fromEntries(columnDescriptors.map((d) => [d.name, d]));
-      }
-      exportCols = columns.filter((name) => !excluded.has(name));
-      // column values start after the fixed metadata block
-      colNameToRowIdx = Object.fromEntries(
-        columns.map((name, i) => [name, metadataKeys.count + i]),
-      );
-    } else if (message.type === "viewport-update") {
-      if (message.mode === "size-only") {
-        totalSize = message.size ?? 0;
-        if (totalSize === 0) {
-          sessionDataSource.unsubscribe();
-          return;
-        }
-        if (totalSize > maxRows) {
-          sessionDataSource.unsubscribe();
-          onError?.(new Error(`exportToCsv: row count ${totalSize} exceeds the ${maxRows} row limit`));
-          return;
-        }
-        // request rows in chunks for predictable behaviour across local and remote DataSources
-        sessionDataSource.range = Range(0, Math.min(CHUNK_SIZE, totalSize));
-      } else if (message.mode === "batch" && message.rows) {
-        collectedRows.push(...message.rows);
-        // update totalSize in case it changed between size-only and batch
-        if (message.size !== undefined) {
-          totalSize = message.size;
-        }
-        if (collectedRows.length >= totalSize) {
-          sessionDataSource.unsubscribe();
-          const lines: string[] = [
-            exportCols.map((name) => csvCell(descriptorMap[name]?.label ?? name)).join(","),
-          ];
-          for (const row of collectedRows) {
-            lines.push(
-              exportCols.map((c) => {
-                const raw = row[colNameToRowIdx[c]];
-                const formatter = descriptorMap[c]?.exportFormatter;
-                return csvCell(formatter ? formatter(raw) : raw);
-              }).join(","),
+        exportCols = columns.filter((name) => !excluded.has(name));
+        // column values start after the fixed metadata block
+        colNameToRowIdx = Object.fromEntries(
+          columns.map((name, i) => [name, metadataKeys.count + i]),
+        );
+      } else if (message.type === "viewport-update") {
+        if (message.mode === "size-only") {
+          totalSize = message.size ?? 0;
+          if (totalSize === 0) {
+            activeSessionDataSource.unsubscribe();
+            onSuccess?.();
+            resolve();
+            return;
+          }
+          if (totalSize > maxRows) {
+            activeSessionDataSource.unsubscribe();
+            onError?.(
+              new Error(
+                `exportToCsv: row count ${totalSize} exceeds the ${maxRows} row limit`,
+              ),
+            );
+            resolve();
+            return;
+          }
+          // request rows in chunks for predictable behaviour across local and remote DataSources
+          activeSessionDataSource.range = Range(
+            0,
+            Math.min(CHUNK_SIZE, totalSize),
+          );
+        } else if (message.mode === "batch" && message.rows) {
+          collectedRows.push(...message.rows);
+          // update totalSize in case it changed between size-only and batch
+          if (message.size !== undefined) {
+            totalSize = message.size;
+          }
+          if (collectedRows.length >= totalSize) {
+            activeSessionDataSource.unsubscribe();
+            const lines: string[] = [
+              exportCols
+                .map((name) => csvCell(descriptorMap[name]?.label ?? name))
+                .join(","),
+            ];
+            for (const row of collectedRows) {
+              lines.push(
+                exportCols
+                  .map((c) => {
+                    const raw = row[colNameToRowIdx[c]];
+                    const formatter = descriptorMap[c]?.exportFormatter;
+                    return csvCell(formatter ? formatter(raw) : raw);
+                  })
+                  .join(","),
+              );
+            }
+            triggerCsvDownload(lines.join("\r\n"), filename);
+            onSuccess?.();
+            resolve();
+          } else {
+            const nextFrom = collectedRows.length;
+            activeSessionDataSource.range = Range(
+              nextFrom,
+              Math.min(nextFrom + CHUNK_SIZE, totalSize),
             );
           }
-          triggerCsvDownload(lines.join("\r\n"), filename);
-          onSuccess?.();
-        } else {
-          const nextFrom = collectedRows.length;
-          sessionDataSource.range = Range(nextFrom, Math.min(nextFrom + CHUNK_SIZE, totalSize));
         }
       }
-    }
-  };
+    };
 
-  sessionDataSource.subscribe({ range: Range(0, 0) }, handleMessage);
-}
+    activeSessionDataSource.subscribe(
+      { range: Range(0, 0), columns: overrides?.columns },
+      handleMessage,
+    );
+  });
+};
 
 /**
  * Creates an export session table from `dataSource` then streams all rows to a CSV download.
@@ -167,11 +280,17 @@ export const exportToCsv = async <TName extends string = string>(
   onSuccess?: () => void,
   maxRows = MAX_EXPORT_ROWS,
   columnDescriptors?: ExportColumnDescriptor<TName>[],
+  overrides?: SessionDataSourceOverrides,
 ): Promise<void> => {
-  const sessionDataSource =
-    await dataSource.createSessionDataSource?.(copyOption, "export");
-  if (!sessionDataSource) {
-    throw Error("exportToCsv: dataSource does not support createSessionDataSource");
-  }
-  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess, maxRows, columnDescriptors);
-}
+  return exportSessionTableToCsv(
+    dataSource,
+    filename,
+    excludeColumns,
+    onError,
+    onSuccess,
+    maxRows,
+    columnDescriptors,
+    copyOption,
+    overrides,
+  );
+};

--- a/vuu-ui/packages/vuu-utils/src/export-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/export-utils.ts
@@ -1,0 +1,143 @@
+import type {
+  CopyOption,
+  DataSource,
+  DataSourceCallbackMessage,
+  DataSourceRow,
+  DataSourceSubscribedMessage,
+} from "@vuu-ui/vuu-data-types";
+import { metadataKeys } from "./column-utils";
+import { Range } from "./range-utils";
+
+const EXPORT_EXCLUDED_COLUMNS = new Set(["vuuMsg", "vuuAction", "vuuRowNum"]);
+const MAX_EXPORT_ROWS = 10_000;
+
+const csvCell = (value: unknown): string => {
+  const s = value == null ? "" : String(value);
+  return s.includes(",") || s.includes('"') || s.includes("\n")
+    ? `"${s.replace(/"/g, '""')}`
+    : s;
+};
+
+const triggerCsvDownload = (csv: string, filename: string): void => {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // delay revoke to give the browser time to start the download
+  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+};
+
+/** Downloads a single-row CSV containing only the column headers, for use as an import template. */
+export const exportCsvTemplate = (
+  dataSource: DataSource,
+  filename = "template.csv",
+  excludeColumns: string[] = [],
+  columns?: string[],
+): void => {
+  const schema = dataSource.tableSchema;
+  if (!schema) {
+    throw Error("exportCsvTemplate: tableSchema not available on dataSource");
+  }
+  const schemaColumnNames = new Set(schema.columns.map((col) => col.name));
+  if (columns !== undefined) {
+    const unknown = columns.filter((name) => !schemaColumnNames.has(name));
+    if (unknown.length > 0) {
+      throw Error(`exportCsvTemplate: unknown column(s): ${unknown.join(", ")}`);
+    }
+  }
+  const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
+  const exportCols = columns
+    ? columns.filter((name) => !excluded.has(name))
+    : schema.columns.filter((col) => !excluded.has(col.name)).map((col) => col.name);
+  const header = exportCols.map(csvCell).join(",");
+  triggerCsvDownload(header + "\r\n", filename);
+};
+
+/**
+ * Subscribes to `sessionDataSource` with a full-range request to drain all rows,
+ * serialises them to CSV (excluding internal session columns), then triggers a
+ * browser download. The dataSource is unsubscribed automatically once the download
+ * is initiated.
+ */
+export const exportSessionTableToCsv = (
+  sessionDataSource: DataSource,
+  filename = "export.csv",
+  excludeColumns: string[] = [],
+  onError?: (error: Error) => void,
+  onSuccess?: () => void,
+): void => {
+  const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
+  let exportCols: string[] = [];
+  let colNameToRowIdx: Record<string, number> = {};
+  let totalSize = 0;
+  const collectedRows: DataSourceRow[] = [];
+
+  const handleMessage = (message: DataSourceCallbackMessage): void => {
+    if (message.type === "subscribed") {
+      const { columns } = message as DataSourceSubscribedMessage;
+      exportCols = columns.filter((name) => !excluded.has(name));
+      // column values start after the fixed metadata block
+      colNameToRowIdx = Object.fromEntries(
+        columns.map((name, i) => [name, metadataKeys.count + i]),
+      );
+    } else if (message.type === "viewport-update") {
+      if (message.mode === "size-only") {
+        totalSize = message.size ?? 0;
+        if (totalSize === 0) {
+          sessionDataSource.unsubscribe();
+          return;
+        }
+        if (totalSize > MAX_EXPORT_ROWS) {
+          sessionDataSource.unsubscribe();
+          onError?.(new Error(`exportToCsv: row count ${totalSize} exceeds the ${MAX_EXPORT_ROWS} row limit`));
+          return;
+        }
+        // request all rows in one shot
+        sessionDataSource.range = Range(0, totalSize);
+      } else if (message.mode === "batch" && message.rows) {
+        collectedRows.push(...message.rows);
+        // update totalSize in case it changed between size-only and batch
+        if (message.size !== undefined) {
+          totalSize = message.size;
+        }
+        if (collectedRows.length >= totalSize) {
+          sessionDataSource.unsubscribe();
+          const lines: string[] = [exportCols.map(csvCell).join(",")];
+          for (const row of collectedRows) {
+            lines.push(
+              exportCols.map((c) => csvCell(row[colNameToRowIdx[c]])).join(","),
+            );
+          }
+          triggerCsvDownload(lines.join("\r\n"), filename);
+          onSuccess?.();
+        }
+      }
+    }
+  };
+
+  sessionDataSource.subscribe({ range: Range(0, 0) }, handleMessage);
+}
+
+/**
+ * Creates an export session table from `dataSource` then streams all rows to a CSV download.
+ */
+export const exportToCsv = async (
+  dataSource: DataSource,
+  copyOption: CopyOption = "All",
+  filename = "export.csv",
+  excludeColumns: string[] = [],
+  onError?: (error: Error) => void,
+  onSuccess?: () => void,
+): Promise<void> => {
+  const sessionDataSource =
+    await dataSource.createSessionDataSource?.(copyOption, "export");
+  if (!sessionDataSource) {
+    throw Error("exportToCsv: dataSource does not support createSessionDataSource");
+  }
+  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess);
+}

--- a/vuu-ui/packages/vuu-utils/src/export-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/export-utils.ts
@@ -8,6 +8,13 @@ import type {
 import { metadataKeys } from "./column-utils";
 import { Range } from "./range-utils";
 
+export type ExportColumnDescriptor<TName extends string = string> = {
+  name: TName;
+  /** Override the column name used as the CSV header label. */
+  label?: string;
+  exportFormatter?: (value: unknown) => string;
+};
+
 const EXPORT_EXCLUDED_COLUMNS = new Set(["vuuMsg", "vuuAction", "vuuRowNum"]);
 const MAX_EXPORT_ROWS = 10_000;
 const CHUNK_SIZE = 1_000;
@@ -56,7 +63,7 @@ export const exportCsvTemplate = (
     ? columns.filter((name) => !excluded.has(name))
     : schema.columns.filter((col) => !excluded.has(col.name)).map((col) => col.name);
   const header = exportCols.map(csvCell).join(",");
-  triggerCsvDownload(header + "\r\n", filename);
+  triggerCsvDownload(`${header}\r\n`, filename);
 };
 
 /**
@@ -65,23 +72,37 @@ export const exportCsvTemplate = (
  * browser download. The dataSource is unsubscribed automatically once the download
  * is initiated.
  */
-export const exportSessionTableToCsv = (
+export const exportSessionTableToCsv = <TName extends string = string>(
   sessionDataSource: DataSource,
   filename = "export.csv",
   excludeColumns: string[] = [],
   onError?: (error: Error) => void,
   onSuccess?: () => void,
   maxRows = MAX_EXPORT_ROWS,
+  columnDescriptors?: ExportColumnDescriptor<TName>[],
 ): void => {
   const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
   let exportCols: string[] = [];
   let colNameToRowIdx: Record<string, number> = {};
+  let descriptorMap: Record<string, ExportColumnDescriptor> = {};
   let totalSize = 0;
   const collectedRows: DataSourceRow[] = [];
 
   const handleMessage = (message: DataSourceCallbackMessage): void => {
     if (message.type === "subscribed") {
       const { columns } = message as DataSourceSubscribedMessage;
+      if (columnDescriptors) {
+        const subscribedSet = new Set(columns);
+        const unknown = columnDescriptors
+          .filter((d) => !excluded.has(d.name) && !subscribedSet.has(d.name))
+          .map((d) => d.name);
+        if (unknown.length > 0) {
+          sessionDataSource.unsubscribe();
+          onError?.(new Error(`exportToCsv: unknown column(s) in columnDescriptors: ${unknown.join(", ")}`));
+          return;
+        }
+        descriptorMap = Object.fromEntries(columnDescriptors.map((d) => [d.name, d]));
+      }
       exportCols = columns.filter((name) => !excluded.has(name));
       // column values start after the fixed metadata block
       colNameToRowIdx = Object.fromEntries(
@@ -109,10 +130,16 @@ export const exportSessionTableToCsv = (
         }
         if (collectedRows.length >= totalSize) {
           sessionDataSource.unsubscribe();
-          const lines: string[] = [exportCols.map(csvCell).join(",")];
+          const lines: string[] = [
+            exportCols.map((name) => csvCell(descriptorMap[name]?.label ?? name)).join(","),
+          ];
           for (const row of collectedRows) {
             lines.push(
-              exportCols.map((c) => csvCell(row[colNameToRowIdx[c]])).join(","),
+              exportCols.map((c) => {
+                const raw = row[colNameToRowIdx[c]];
+                const formatter = descriptorMap[c]?.exportFormatter;
+                return csvCell(formatter ? formatter(raw) : raw);
+              }).join(","),
             );
           }
           triggerCsvDownload(lines.join("\r\n"), filename);
@@ -131,7 +158,7 @@ export const exportSessionTableToCsv = (
 /**
  * Creates an export session table from `dataSource` then streams all rows to a CSV download.
  */
-export const exportToCsv = async (
+export const exportToCsv = async <TName extends string = string>(
   dataSource: DataSource,
   copyOption: CopyOption = "All",
   filename = "export.csv",
@@ -139,11 +166,12 @@ export const exportToCsv = async (
   onError?: (error: Error) => void,
   onSuccess?: () => void,
   maxRows = MAX_EXPORT_ROWS,
+  columnDescriptors?: ExportColumnDescriptor<TName>[],
 ): Promise<void> => {
   const sessionDataSource =
     await dataSource.createSessionDataSource?.(copyOption, "export");
   if (!sessionDataSource) {
     throw Error("exportToCsv: dataSource does not support createSessionDataSource");
   }
-  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess, maxRows);
+  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess, maxRows, columnDescriptors);
 }

--- a/vuu-ui/packages/vuu-utils/src/export-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/export-utils.ts
@@ -10,6 +10,7 @@ import { Range } from "./range-utils";
 
 const EXPORT_EXCLUDED_COLUMNS = new Set(["vuuMsg", "vuuAction", "vuuRowNum"]);
 const MAX_EXPORT_ROWS = 10_000;
+const CHUNK_SIZE = 1_000;
 
 const csvCell = (value: unknown): string => {
   const s = value == null ? "" : String(value);
@@ -70,6 +71,7 @@ export const exportSessionTableToCsv = (
   excludeColumns: string[] = [],
   onError?: (error: Error) => void,
   onSuccess?: () => void,
+  maxRows = MAX_EXPORT_ROWS,
 ): void => {
   const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
   let exportCols: string[] = [];
@@ -92,13 +94,13 @@ export const exportSessionTableToCsv = (
           sessionDataSource.unsubscribe();
           return;
         }
-        if (totalSize > MAX_EXPORT_ROWS) {
+        if (totalSize > maxRows) {
           sessionDataSource.unsubscribe();
-          onError?.(new Error(`exportToCsv: row count ${totalSize} exceeds the ${MAX_EXPORT_ROWS} row limit`));
+          onError?.(new Error(`exportToCsv: row count ${totalSize} exceeds the ${maxRows} row limit`));
           return;
         }
-        // request all rows in one shot
-        sessionDataSource.range = Range(0, totalSize);
+        // request rows in chunks for predictable behaviour across local and remote DataSources
+        sessionDataSource.range = Range(0, Math.min(CHUNK_SIZE, totalSize));
       } else if (message.mode === "batch" && message.rows) {
         collectedRows.push(...message.rows);
         // update totalSize in case it changed between size-only and batch
@@ -115,6 +117,9 @@ export const exportSessionTableToCsv = (
           }
           triggerCsvDownload(lines.join("\r\n"), filename);
           onSuccess?.();
+        } else {
+          const nextFrom = collectedRows.length;
+          sessionDataSource.range = Range(nextFrom, Math.min(nextFrom + CHUNK_SIZE, totalSize));
         }
       }
     }
@@ -133,11 +138,12 @@ export const exportToCsv = async (
   excludeColumns: string[] = [],
   onError?: (error: Error) => void,
   onSuccess?: () => void,
+  maxRows = MAX_EXPORT_ROWS,
 ): Promise<void> => {
   const sessionDataSource =
     await dataSource.createSessionDataSource?.(copyOption, "export");
   if (!sessionDataSource) {
     throw Error("exportToCsv: dataSource does not support createSessionDataSource");
   }
-  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess);
+  exportSessionTableToCsv(sessionDataSource, filename, excludeColumns, onError, onSuccess, maxRows);
 }

--- a/vuu-ui/packages/vuu-utils/src/index.ts
+++ b/vuu-ui/packages/vuu-utils/src/index.ts
@@ -13,6 +13,7 @@ export * from "./component-registry";
 export * from "./cookie-utils";
 export * from "./css-utils";
 export * from "./data-utils";
+export * from "./export-utils";
 export * from "./datasource/BaseDataSource";
 export * from "./datasource/datasource-action-utils";
 export * from "./datasource/datasource-filter-utils";

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -47,6 +47,7 @@ import {
 } from "@vuu-ui/vuu-ui-controls";
 import {
   DataSourceProvider,
+  EventEmitter,
   registerComponent,
   toColumnName,
   useData,
@@ -63,7 +64,7 @@ import {
   useState,
 } from "react";
 import { SimulTable } from "./SimulTableTemplate";
-import type { CopyOption, DataSource } from "@vuu-ui/vuu-data-types";
+import type { CopyOption, DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
 import { LayoutProvider, Stack, View } from "@vuu-ui/vuu-layout";
 import { ColumnFilter } from "@vuu-ui/vuu-filters";
 import { Toolbar } from "./Toolbar";
@@ -594,6 +595,78 @@ export const UseEditableTableSessionReadiness = ({
     />
   </LocalDataSourceProvider>
 );
+
+const DIVERGENT_VIEW_SCHEMA: TableSchema = {
+  columns: [
+    { name: "id", serverDataType: "string" },
+    { name: "name", serverDataType: "string" },
+  ],
+  key: "id",
+  table: { module: "TEST", table: "items" },
+};
+
+const DIVERGENT_EDIT_TABLE: VuuTable = { module: "TEST", table: "itemsEdit" };
+
+const DIVERGENT_EDIT_SCHEMA: TableSchema = {
+  columns: [
+    { name: "id", serverDataType: "string" },
+    { name: "quantity", serverDataType: "int" },
+  ],
+  key: "id",
+  table: DIVERGENT_EDIT_TABLE,
+};
+
+const DIVERGENT_EDIT_COLUMNS = DIVERGENT_EDIT_SCHEMA.columns.map(toColumnName);
+
+export const UseEditableTableWithEditColumns = () => {
+  const [editMode, setEditMode] = useState<EditMode>("view");
+  const [overrideColumns, setOverrideColumns] = useState<string[]>();
+
+  const sourceDataSource = useMemo(() => {
+    const sessionDataSource = Object.assign(new EventEmitter(), {
+      columns: DIVERGENT_EDIT_COLUMNS,
+      status: "subscribed",
+      table: { module: "TEST", table: "session-itemsEdit" },
+      tableSchema: DIVERGENT_EDIT_SCHEMA,
+      endEditSession: async () => undefined,
+    });
+    return Object.assign(new EventEmitter(), {
+      columns: DIVERGENT_VIEW_SCHEMA.columns.map(toColumnName),
+      status: "subscribed",
+      table: DIVERGENT_VIEW_SCHEMA.table,
+      tableSchema: DIVERGENT_VIEW_SCHEMA,
+      createSessionDataSource: async (
+        _copyOption: CopyOption,
+        _sessionType?: string,
+        overrides?: { columns?: string[] },
+      ) => {
+        setOverrideColumns(overrides?.columns);
+        return sessionDataSource as unknown as DataSource;
+      },
+    }) as unknown as DataSource;
+  }, []);
+
+  const { columnsDiverge, editSchema, sessionDataSource } = useEditableTable({
+    dataSource: sourceDataSource,
+    editColumns: DIVERGENT_EDIT_COLUMNS,
+    editTable: DIVERGENT_EDIT_TABLE,
+    isEditMode: editMode === "edit",
+    onCancel: () => setEditMode("view"),
+    onSave: () => setEditMode("view"),
+  });
+
+  return (
+    <div>
+      <button onClick={() => setEditMode("edit")}>Start edit session</button>
+      <output
+        data-diverge={columnsDiverge}
+        data-edit-schema={editSchema?.columns.map(toColumnName).join(",") ?? ""}
+        data-override-columns={overrideColumns?.join(",") ?? ""}
+        data-session={Boolean(sessionDataSource)}
+      />
+    </div>
+  );
+};
 
 /** tags=data-consumer */
 export const CreateSessionTableInstruments = () => (

--- a/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/Editing.examples.tsx
@@ -620,7 +620,6 @@ const DIVERGENT_EDIT_COLUMNS = DIVERGENT_EDIT_SCHEMA.columns.map(toColumnName);
 
 export const UseEditableTableWithEditColumns = () => {
   const [editMode, setEditMode] = useState<EditMode>("view");
-  const [overrideColumns, setOverrideColumns] = useState<string[]>();
 
   const sourceDataSource = useMemo(() => {
     const sessionDataSource = Object.assign(new EventEmitter(), {
@@ -630,26 +629,21 @@ export const UseEditableTableWithEditColumns = () => {
       tableSchema: DIVERGENT_EDIT_SCHEMA,
       endEditSession: async () => undefined,
     });
+    // Simulates a datasource constructed with a session config (e.g.
+    // `new VuuDataSource({ ..., session: { columns: DIVERGENT_EDIT_COLUMNS, table: DIVERGENT_EDIT_TABLE } })`) -
+    // the override is applied internally, not passed in by the caller.
     return Object.assign(new EventEmitter(), {
       columns: DIVERGENT_VIEW_SCHEMA.columns.map(toColumnName),
       status: "subscribed",
       table: DIVERGENT_VIEW_SCHEMA.table,
       tableSchema: DIVERGENT_VIEW_SCHEMA,
-      createSessionDataSource: async (
-        _copyOption: CopyOption,
-        _sessionType?: string,
-        overrides?: { columns?: string[] },
-      ) => {
-        setOverrideColumns(overrides?.columns);
-        return sessionDataSource as unknown as DataSource;
-      },
+      createSessionDataSource: async () =>
+        sessionDataSource as unknown as DataSource,
     }) as unknown as DataSource;
   }, []);
 
   const { columnsDiverge, editSchema, sessionDataSource } = useEditableTable({
     dataSource: sourceDataSource,
-    editColumns: DIVERGENT_EDIT_COLUMNS,
-    editTable: DIVERGENT_EDIT_TABLE,
     isEditMode: editMode === "edit",
     onCancel: () => setEditMode("view"),
     onSave: () => setEditMode("view"),
@@ -661,7 +655,6 @@ export const UseEditableTableWithEditColumns = () => {
       <output
         data-diverge={columnsDiverge}
         data-edit-schema={editSchema?.columns.map(toColumnName).join(",") ?? ""}
-        data-override-columns={overrideColumns?.join(",") ?? ""}
         data-session={Boolean(sessionDataSource)}
       />
     </div>

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -216,10 +216,10 @@ export const CsvExportTemplate = () => (
 );
 
 const INSTRUMENTS_EXPORT_DESCRIPTORS: ExportColumnDescriptor[] = [
-  { name: "ric",      label: "RIC Code" },
-  { name: "bbg",      label: "Bloomberg" },
+  { name: "ric", label: "RIC Code" },
+  { name: "bbg", label: "Bloomberg" },
   { name: "currency" },
-  { name: "lotSize",  label: "Lot Size", exportFormatter: (v) => `${v} units` },
+  { name: "lotSize", label: "Lot Size", exportFormatter: (v) => `${v} units` },
   { name: "isin" },
 ];
 

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -1,6 +1,6 @@
 import { getSchema, LocalDataSourceProvider, simulModule } from "@vuu-ui/vuu-data-test";
 import type { DataSource } from "@vuu-ui/vuu-data-types";
-import { exportCsvTemplate, exportToCsv } from "@vuu-ui/vuu-utils";
+import { exportCsvTemplate, exportToCsv, type ExportColumnDescriptor } from "@vuu-ui/vuu-utils";
 import { Button } from "@salt-ds/core";
 import { Table } from "@vuu-ui/vuu-table";
 import type { TableConfig } from "@vuu-ui/vuu-table-types";
@@ -212,5 +212,58 @@ const CsvExportTemplateContent = () => {
 export const CsvExportTemplate = () => (
   <LocalDataSourceProvider>
     <CsvExportTemplateContent />
+  </LocalDataSourceProvider>
+);
+
+const INSTRUMENTS_EXPORT_DESCRIPTORS: ExportColumnDescriptor[] = [
+  { name: "ric",      label: "RIC Code" },
+  { name: "bbg",      label: "Bloomberg" },
+  { name: "currency" },
+  { name: "lotSize",  label: "Lot Size", exportFormatter: (v) => `${v} units` },
+  { name: "isin" },
+];
+
+const CsvExportWithFormattersContent = () => {
+  const [status, setStatus] = useState<string | undefined>();
+
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const handleExport = useCallback(async () => {
+    setStatus(undefined);
+    try {
+      await exportToCsv(
+        dataSource as DataSource,
+        "All",
+        "instruments-formatted.csv",
+        [],
+        (err) => setStatus(`Export failed: ${err.message}`),
+        () => setStatus("Download started"),
+        10_000,
+        INSTRUMENTS_EXPORT_DESCRIPTORS,
+      );
+    } catch (e) {
+      setStatus(`Export failed: ${(e as Error).message}`);
+    }
+  }, [dataSource]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, padding: 12 }}>
+      <Button onClick={handleExport}>Download instruments-formatted.csv</Button>
+      <p style={{ fontSize: 12, margin: 0, color: "#555" }}>
+        lotSize formatted as "X units"; ric/bbg/lotSize/isin use label overrides in header
+      </p>
+      {status ? (
+        <span style={{ fontSize: 12, fontWeight: 600 }}>{status}</span>
+      ) : null}
+    </div>
+  );
+};
+
+export const CsvExportWithFormatters = () => (
+  <LocalDataSourceProvider>
+    <CsvExportWithFormattersContent />
   </LocalDataSourceProvider>
 );

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -117,6 +117,65 @@ export const CsvExportSimple = () => (
   </LocalDataSourceProvider>
 );
 
+const CsvExportWithRowLimitContent = () => {
+  const [status, setStatus] = useState<string | undefined>();
+
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const config = useMemo<TableConfig>(
+    () => ({ columns: getSchema(TABLE_NAME).columns }),
+    [],
+  );
+
+  const handleExport = useCallback(async () => {
+    setStatus(undefined);
+    try {
+      await exportToCsv(
+        dataSource as DataSource,
+        "All",
+        "instruments-limited.csv",
+        [],
+        (err) => setStatus(`Export failed: ${err.message}`),
+        () => setStatus("Download started"),
+        50,
+      );
+    } catch (e) {
+      setStatus(`Export failed: ${(e as Error).message}`);
+    }
+  }, [dataSource]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        height: "100%",
+        padding: 12,
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Button onClick={handleExport}>Export (max 50 rows)</Button>
+        {status ? (
+          <span style={{ fontSize: 12, fontWeight: 600 }}>{status}</span>
+        ) : null}
+      </div>
+      <div style={{ flex: "1 1 0", border: "solid 1px lightgray" }}>
+        <Table config={config} dataSource={dataSource} />
+      </div>
+    </div>
+  );
+};
+
+export const CsvExportWithRowLimit = () => (
+  <LocalDataSourceProvider>
+    <CsvExportWithRowLimitContent />
+  </LocalDataSourceProvider>
+);
+
 const INSTRUMENTS_TEMPLATE_COLUMNS = ["ric", "currency", "description", "exchange", "isin"];
 
 const CsvExportTemplateContent = () => {

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -267,3 +267,61 @@ export const CsvExportWithFormatters = () => (
     <CsvExportWithFormattersContent />
   </LocalDataSourceProvider>
 );
+
+const CsvExportWithOverridesContent = () => {
+  const [status, setStatus] = useState<string | undefined>();
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const handleExportOverrides = useCallback(async () => {
+    setStatus(undefined);
+    try {
+      await exportToCsv(
+        dataSource as DataSource,
+        "All",
+        "instruments-overrides.csv",
+        [],
+        (err) => setStatus(`Export failed: ${err.message}`),
+        () => setStatus("Download started"),
+        10_000,
+        undefined,
+        { columns: ["ric", "currency", "lotSize"] },
+      );
+    } catch (e) {
+      setStatus(`Export failed: ${(e as Error).message}`);
+    }
+  }, [dataSource]);
+
+  const handleTemplateOverrides = useCallback(async () => {
+    await exportCsvTemplate(
+      dataSource as DataSource,
+      "template-overrides.csv",
+      [],
+      undefined,
+      { columns: ["ric", "isin"] },
+    );
+  }, [dataSource]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, padding: 12 }}>
+      <Button onClick={handleExportOverrides}>
+        Export with column overrides
+      </Button>
+      <Button onClick={handleTemplateOverrides}>
+        Template with column overrides
+      </Button>
+      {status ? (
+        <span style={{ fontSize: 12, fontWeight: 600 }}>{status}</span>
+      ) : null}
+    </div>
+  );
+};
+
+export const CsvExportWithOverrides = () => (
+  <LocalDataSourceProvider>
+    <CsvExportWithOverridesContent />
+  </LocalDataSourceProvider>
+);
+

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -1,0 +1,157 @@
+import { getSchema, LocalDataSourceProvider, simulModule } from "@vuu-ui/vuu-data-test";
+import type { DataSource } from "@vuu-ui/vuu-data-types";
+import { exportCsvTemplate, exportToCsv } from "@vuu-ui/vuu-utils";
+import { Button } from "@salt-ds/core";
+import { Table } from "@vuu-ui/vuu-table";
+import type { TableConfig } from "@vuu-ui/vuu-table-types";
+import { useCallback, useMemo, useState } from "react";
+
+const TABLE_NAME = "instruments";
+
+const CsvExportContent = () => {
+  const [isExporting, setIsExporting] = useState(false);
+  const [status, setStatus] = useState<string | undefined>();
+
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const config = useMemo<TableConfig>(
+    () => ({ columns: getSchema(TABLE_NAME).columns }),
+    [],
+  );
+
+  const handleExportAll = useCallback(async () => {
+    setIsExporting(true);
+    setStatus(undefined);
+    try {
+      await exportToCsv(
+        dataSource as DataSource,
+        "All",
+        "instruments-export.csv",
+        [],
+        (err) => { setStatus(`Export failed: ${err.message}`); setIsExporting(false); },
+        () => { setStatus("Download started"); setIsExporting(false); },
+      );
+    } catch (e) {
+      setStatus(`Export failed: ${(e as Error).message}`);
+      setIsExporting(false);
+    }
+  }, [dataSource]);
+
+  const handleExportSelected = useCallback(async () => {
+    setIsExporting(true);
+    setStatus(undefined);
+    try {
+      await exportToCsv(
+        dataSource as DataSource,
+        "Selected",
+        "instruments-selected-export.csv",
+        [],
+        (err) => { setStatus(`Export failed: ${err.message}`); setIsExporting(false); },
+        () => { setStatus("Download started"); setIsExporting(false); },
+      );
+    } catch (e) {
+      setStatus(`Export failed: ${(e as Error).message}`);
+      setIsExporting(false);
+    }
+  }, [dataSource]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        height: "100%",
+        padding: 12,
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Button disabled={isExporting} onClick={handleExportAll}>
+          Export All to CSV
+        </Button>
+        <Button disabled={isExporting} onClick={handleExportSelected}>
+          Export Selected to CSV
+        </Button>
+        {status ? (
+          <span style={{ fontSize: 12, color: "#027a48", fontWeight: 600 }}>
+            {status}
+          </span>
+        ) : null}
+      </div>
+      <div style={{ flex: "1 1 0", border: "solid 1px lightgray" }}>
+        <Table config={config} dataSource={dataSource} selectionModel="checkbox" />
+      </div>
+    </div>
+  );
+};
+
+export const CsvExportAllRows = () => (
+  <LocalDataSourceProvider>
+    <CsvExportContent />
+  </LocalDataSourceProvider>
+);
+
+const CsvExportSimpleContent = () => {
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const handleExport = useCallback(async () => {
+    await exportToCsv(dataSource as DataSource, "All", "instruments.csv");
+  }, [dataSource]);
+
+  return (
+    <div style={{ padding: 12 }}>
+      <Button onClick={handleExport}>Download instruments.csv</Button>
+    </div>
+  );
+};
+
+export const CsvExportSimple = () => (
+  <LocalDataSourceProvider>
+    <CsvExportSimpleContent />
+  </LocalDataSourceProvider>
+);
+
+const INSTRUMENTS_TEMPLATE_COLUMNS = ["ric", "currency", "description", "exchange", "isin"];
+
+const CsvExportTemplateContent = () => {
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME),
+    [],
+  );
+
+  const handleDownloadAllColumns = useCallback(() => {
+    exportCsvTemplate(dataSource as DataSource, "instruments-template.csv");
+  }, [dataSource]);
+
+  const handleDownloadSubset = useCallback(() => {
+    exportCsvTemplate(
+      dataSource as DataSource,
+      "instruments-template-subset.csv",
+      [],
+      INSTRUMENTS_TEMPLATE_COLUMNS,
+    );
+  }, [dataSource]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8, padding: 12 }}>
+      <Button onClick={handleDownloadAllColumns}>
+        Download template (all columns)
+      </Button>
+      <Button onClick={handleDownloadSubset}>
+        Download template ({INSTRUMENTS_TEMPLATE_COLUMNS.join(", ")})
+      </Button>
+    </div>
+  );
+};
+
+export const CsvExportTemplate = () => (
+  <LocalDataSourceProvider>
+    <CsvExportTemplateContent />
+  </LocalDataSourceProvider>
+);

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvUpload.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvUpload.examples.tsx
@@ -2,7 +2,7 @@ import {
   CsvUpload,
 } from "@vuu-ui/vuu-table-extras";
 import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
-import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
+import type { VuuRowDataItemType, VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { useCallback, useMemo, useState } from "react";
 import { Button } from "@salt-ds/core";
 import { LocalDataSourceProvider, simulModule } from "@vuu-ui/vuu-data-test";
@@ -149,3 +149,95 @@ export const CsvUploadWithRowDefaults = () => {
     </div>
   );
 };
+
+const IMPORT_TABLE: VuuTable = { module: "TEST", table: "items-import" };
+
+const importOnlySchema: TableSchema = {
+  columns: [
+    { name: "id", serverDataType: "string" },
+    { name: "quantity", serverDataType: "int" },
+  ],
+  key: "id",
+  table: IMPORT_TABLE,
+};
+
+/**
+ * Target table schema is `id`/`name`, import table schema is `id`/`quantity`, so a CSV
+ * containing `quantity` only validates if the import schema is used.
+ */
+export const CsvUploadWithImportSchema = () => {
+  const [sessionColumns, setSessionColumns] = useState<string[]>();
+
+  const dataSource = useMemo(() => {
+    const sessionDs = {
+      table: { module: "TEST", table: "session-items-import" },
+      tableSchema: importOnlySchema,
+      columns: ["id"],
+      addRow: async () => ({
+        data: undefined,
+        type: "SUCCESS_RESULT" as const,
+      }),
+      endEditSession: async () => void 0,
+    };
+    return {
+      table: { module: "TEST", table: "items" },
+      tableSchema: rowDefaultsSchema,
+      createSessionDataSource: async (
+        _copyOption: unknown,
+        _sessionType: unknown,
+        overrides?: { columns?: string[] },
+      ) => {
+        setSessionColumns(overrides?.columns);
+        return sessionDs as unknown as DataSource;
+      },
+      subscribe: async () => void 0,
+      unsubscribe: () => void 0,
+    } as unknown as DataSource;
+  }, []);
+
+  return (
+    <div>
+      <CsvUpload
+        dataSource={dataSource}
+        importSchema={importOnlySchema}
+        importTable={IMPORT_TABLE}
+      />
+      <output
+        data-testid="session-columns"
+        data-columns={sessionColumns?.join(",") ?? ""}
+      />
+    </div>
+  );
+};
+
+/** importTable only - the schema is fetched via getTableSchema. */
+export const CsvUploadWithImportTableOnly = () => {
+  const dataSource = useMemo(() => {
+    const sessionDs = {
+      table: { module: "TEST", table: "session-instruments" },
+      columns: ["ric"],
+      addRow: async () => ({
+        data: undefined,
+        type: "SUCCESS_RESULT" as const,
+      }),
+      endEditSession: async () => void 0,
+    };
+    return {
+      table: { module: "TEST", table: "items" },
+      tableSchema: rowDefaultsSchema,
+      createSessionDataSource: async () => sessionDs as unknown as DataSource,
+      subscribe: async () => void 0,
+      unsubscribe: () => void 0,
+    } as unknown as DataSource;
+  }, []);
+
+  return (
+    <LocalDataSourceProvider>
+      <CsvUpload
+        dataSource={dataSource}
+        importTable={{ module: "SIMUL", table: "instruments" }}
+      />
+    </LocalDataSourceProvider>
+  );
+};
+


### PR DESCRIPTION
## Summary

Editing, CSV import, and CSV export all create a server-side session table via
`createSessionDataSource`/`beginEditSession`. Until now the session datasource
was always built by inheriting the source (view) datasource's config — columns,
filter, groupBy, sort, aggregations — which breaks whenever the session table's
schema differs from the view table's (a dedicated edit table, a separate
import/export table, etc.): the session subscribes with columns it doesn't
have, and view-only filter/sort/groupBy get carried over incorrectly.

This PR adds an explicit `SessionDataSourceOverrides` mechanism so callers can
declare the session table's columns and expected `VuuTable` up front, and fixes
a related bug in the CSV export path where column overrides were silently
ignored for local (`ArrayDataSource`-backed) session tables.

## Changes

- **`SessionDataSourceOverrides`** (`vuu-data-types`): new `{ columns?, table? }`
  argument added to `EditApi.createSessionDataSource` / `beginEditSession`.
- **`sessionDataSourceConfig` / `assertExpectedSessionTable`** (`vuu-utils`):
  shared helpers — discard the view config's filter/groupBy/sort/aggregations
  when session columns are overridden; validate the server-assigned session
  table's module against the expected table.
- **`VuuDataSource` / `TickingArrayDataSource`**: `createSessionDataSource`
  (and `TickingArrayDataSource.beginEditSession`) now honour `overrides`.
  `VuuDataSource.beginEditSession` (legacy path) intentionally left unchanged —
  it's a dead/broken API independent of this change.
- **`EditSession` / `useEditableTable`**: new `editColumns`/`editTable` props.
  `rowDefaults` pruning moved out of `begin()` into `reconcileWithSessionSchema`,
  which now also warns on missing `editColumns` and discards pending edits on a
  key-column mismatch. Hook returns `editSchema`/`columnsDiverge` for consumers
  rendering a single `Table` across view/edit modes.
- **`CsvUpload`**: new `importSchema`/`importTable` props for uploading into a
  table whose schema differs from the target table. Schema is fetched via
  `getTableSchema` when only `importTable` is given.
- **CSV export (`export-utils.ts`)**: `exportToCsv`/`exportCsvTemplate`/
  `exportSessionTableToCsv` accept `overrides`. Fixed a bug where overrides were
  passed to `createSessionDataSource` but never to the subsequent `subscribe()`
  call, so local session tables ignored the column restriction entirely.
- **Docs**: `vuu-data-editing/DESIGN.md` (RPC routing, divergent edit tables),
  `vuu-table-extras/csv-upload/README.md`, new `vuu-utils/docs/csv-export.md`.
