### PR TITLE
feat(grid-layout): add per-grid controller transactions

### DIFF
--- a/vuu-ui/packages/grid-layout/src/GridCommand.ts
+++ b/vuu-ui/packages/grid-layout/src/GridCommand.ts
@@ -123,6 +123,8 @@ export type GridCommandErrorCode =
   | "STACK_NOT_FOUND"
   | "TAB_NOT_FOUND"
   | "TRACK_NOT_FOUND"
+  | "TRANSACTION_ACTIVE"
+  | "TRANSACTION_CLOSED"
   | "UNSUPPORTED_ACTION";
 
 export interface GridCommandError {

--- a/vuu-ui/packages/grid-layout/src/GridController.ts
+++ b/vuu-ui/packages/grid-layout/src/GridController.ts
@@ -1,0 +1,361 @@
+import {
+  LegacyGridCommandExecutor,
+  type GridCommand,
+  type GridCommandResult,
+} from "./GridCommand";
+import {
+  gridLayoutDescriptorToSnapshot,
+  normalizeGridSnapshot,
+} from "./grid-snapshot-adapters";
+import type { GridModel, GridModelCheckpoint } from "./GridModel";
+import type { GridSnapshot } from "./GridSnapshot";
+
+export type GridTransactionKind = "drag" | "resize";
+export type GridControllerListener = () => void;
+
+export type GridControllerErrorCode =
+  | "TRANSACTION_ACTIVE"
+  | "TRANSACTION_CLOSED";
+
+export interface GridControllerError {
+  readonly code: GridControllerErrorCode;
+  readonly message: string;
+}
+
+export type GridTransactionStartResult =
+  | { readonly ok: true; readonly transaction: GridTransaction }
+  | { readonly error: GridControllerError; readonly ok: false };
+
+export type GridTransactionCloseResult =
+  | { readonly ok: true; readonly snapshot: GridSnapshot }
+  | { readonly error: GridControllerError; readonly ok: false };
+
+export interface GridTransaction {
+  readonly kind: GridTransactionKind;
+  commit(): GridTransactionCloseResult;
+  dispatch(command: GridCommand): GridCommandResult;
+  rollback(): GridTransactionCloseResult;
+}
+
+export interface GridCommittedTransition {
+  readonly commands: readonly GridCommand[];
+  readonly kind: "dispatch" | GridTransactionKind;
+  readonly previous: GridSnapshot;
+  readonly snapshot: GridSnapshot;
+}
+
+export type GridCommittedTransitionListener = (
+  transition: GridCommittedTransition,
+) => void;
+
+const semanticSnapshot = ({ revision: _revision, ...snapshot }: GridSnapshot) =>
+  JSON.stringify(snapshot);
+
+const transactionError = (
+  code: GridControllerErrorCode,
+  message: string,
+): GridControllerError => ({ code, message });
+
+export class GridController {
+  readonly #executor: LegacyGridCommandExecutor;
+  readonly #listeners = new Set<GridControllerListener>();
+  readonly #commitListeners = new Set<GridCommittedTransitionListener>();
+  #activeTransaction: LegacyGridTransaction | undefined;
+  #snapshot: GridSnapshot;
+
+  constructor(
+    private readonly gridModel: GridModel,
+    revision = 0,
+    executor = new LegacyGridCommandExecutor(gridModel),
+  ) {
+    this.#executor = executor;
+    this.#snapshot = this.#readSnapshot(revision);
+  }
+
+  getSnapshot = (): GridSnapshot => this.#snapshot;
+
+  subscribe = (listener: GridControllerListener): (() => void) => {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  };
+
+  subscribeCommitted = (
+    listener: GridCommittedTransitionListener,
+  ): (() => void) => {
+    this.#commitListeners.add(listener);
+    return () => {
+      this.#commitListeners.delete(listener);
+    };
+  };
+
+  dispatch(command: GridCommand): GridCommandResult {
+    if (this.#activeTransaction) {
+      return {
+        command: command.type,
+        error: transactionError(
+          "TRANSACTION_ACTIVE",
+          `Cannot dispatch ${command.type} while a grid transaction is active`,
+        ),
+        ok: false,
+      };
+    }
+
+    const checkpoint = this.gridModel.createCheckpoint();
+    const previous = this.#snapshot;
+    const result = this.#executeAtomically(command, checkpoint);
+    if (!result.ok) {
+      return result;
+    }
+    const candidate = this.#readSnapshot(previous.revision);
+    if (semanticSnapshot(candidate) === semanticSnapshot(previous)) {
+      return result;
+    }
+    this.#snapshot = this.#readSnapshot(previous.revision + 1);
+    this.#notifyState();
+    this.#notifyCommitted({
+      commands: [command],
+      kind: "dispatch",
+      previous,
+      snapshot: this.#snapshot,
+    });
+    return result;
+  }
+
+  beginTransaction(kind: GridTransactionKind): GridTransactionStartResult {
+    if (this.#activeTransaction) {
+      return {
+        error: transactionError(
+          "TRANSACTION_ACTIVE",
+          `Cannot begin ${kind}; a grid transaction is already active`,
+        ),
+        ok: false,
+      };
+    }
+    let transaction: LegacyGridTransaction;
+    transaction = new LegacyGridTransaction(
+      kind,
+      this.gridModel.createCheckpoint(),
+      this.#snapshot,
+      (command) => this.#executePreview(transaction, command),
+      (commands) =>
+        this.#commitTransaction(
+          transaction,
+          kind,
+          transaction.baseline,
+          commands,
+        ),
+      () =>
+        this.#rollbackTransaction(
+          transaction,
+          transaction.checkpoint,
+          transaction.baseline,
+        ),
+    );
+    this.#activeTransaction = transaction;
+    return { ok: true, transaction };
+  }
+
+  #executePreview(
+    transaction: LegacyGridTransaction,
+    command: GridCommand,
+  ): GridCommandResult {
+    if (this.#activeTransaction !== transaction) {
+      return {
+        command: command.type,
+        error: transactionError(
+          "TRANSACTION_CLOSED",
+          `Cannot dispatch ${command.type}; the grid transaction is closed`,
+        ),
+        ok: false,
+      };
+    }
+    const checkpoint = this.gridModel.createCheckpoint();
+    const result = this.#executeAtomically(command, checkpoint);
+    if (!result.ok) {
+      return result;
+    }
+    const candidate = this.#readSnapshot(this.#snapshot.revision);
+    if (semanticSnapshot(candidate) !== semanticSnapshot(this.#snapshot)) {
+      this.#snapshot =
+        semanticSnapshot(candidate) === semanticSnapshot(transaction.baseline)
+          ? transaction.baseline
+          : candidate;
+      this.#notifyState();
+    }
+    return result;
+  }
+
+  #commitTransaction(
+    transaction: LegacyGridTransaction,
+    kind: GridTransactionKind,
+    baseline: GridSnapshot,
+    commands: readonly GridCommand[],
+  ): GridTransactionCloseResult {
+    if (this.#activeTransaction !== transaction) {
+      return this.#closedResult("commit");
+    }
+    const changed =
+      semanticSnapshot(this.#snapshot) !== semanticSnapshot(baseline);
+    this.#activeTransaction = undefined;
+    if (!changed) {
+      this.#snapshot = baseline;
+      return { ok: true, snapshot: this.#snapshot };
+    }
+    this.#snapshot = this.#readSnapshot(baseline.revision + 1);
+    this.#notifyState();
+    this.#notifyCommitted({
+      commands: [...commands],
+      kind,
+      previous: baseline,
+      snapshot: this.#snapshot,
+    });
+    return { ok: true, snapshot: this.#snapshot };
+  }
+
+  #rollbackTransaction(
+    transaction: LegacyGridTransaction,
+    checkpoint: GridModelCheckpoint,
+    baseline: GridSnapshot,
+  ): GridTransactionCloseResult {
+    if (this.#activeTransaction !== transaction) {
+      return this.#closedResult("rollback");
+    }
+    const changed =
+      semanticSnapshot(this.#snapshot) !== semanticSnapshot(baseline);
+    this.gridModel.restoreCheckpoint(checkpoint);
+    this.#snapshot = baseline;
+    this.#activeTransaction = undefined;
+    if (changed) {
+      this.#notifyState();
+    }
+    return { ok: true, snapshot: this.#snapshot };
+  }
+
+  #closedResult(action: "commit" | "rollback"): GridTransactionCloseResult {
+    return {
+      error: transactionError(
+        "TRANSACTION_CLOSED",
+        `Cannot ${action}; the grid transaction is closed`,
+      ),
+      ok: false,
+    };
+  }
+
+  #executeAtomically(
+    command: GridCommand,
+    checkpoint: GridModelCheckpoint,
+  ): GridCommandResult {
+    try {
+      return this.#executor.execute(command);
+    } catch (error) {
+      this.gridModel.restoreCheckpoint(checkpoint);
+      throw error;
+    }
+  }
+
+  #readSnapshot(revision: number): GridSnapshot {
+    const snapshot = gridLayoutDescriptorToSnapshot(
+      this.gridModel.toGridLayoutDescriptor(),
+      { gridId: this.gridModel.id, revision },
+    );
+    return normalizeGridSnapshot({
+      ...snapshot,
+      stacks: snapshot.stacks.map(({ id }) => {
+        const tabState = this.gridModel.getTabState(id);
+        return {
+          id,
+          itemIds: tabState.tabs.map(({ id: itemId }) => itemId),
+          selectedItemId: tabState.activeTab.id,
+        };
+      }),
+    });
+  }
+
+  #notifyState() {
+    for (const listener of [...this.#listeners]) {
+      if (this.#listeners.has(listener)) {
+        listener();
+      }
+    }
+  }
+
+  #notifyCommitted(transition: GridCommittedTransition) {
+    for (const listener of [...this.#commitListeners]) {
+      if (this.#commitListeners.has(listener)) {
+        listener(transition);
+      }
+    }
+  }
+}
+
+class LegacyGridTransaction implements GridTransaction {
+  readonly #commands: GridCommand[] = [];
+  #closed = false;
+
+  constructor(
+    readonly kind: GridTransactionKind,
+    readonly checkpoint: GridModelCheckpoint,
+    readonly baseline: GridSnapshot,
+    private readonly executePreview: (
+      command: GridCommand,
+    ) => GridCommandResult,
+    private readonly commitTransaction: (
+      commands: readonly GridCommand[],
+    ) => GridTransactionCloseResult,
+    private readonly rollbackTransaction: () => GridTransactionCloseResult,
+  ) {}
+
+  dispatch(command: GridCommand): GridCommandResult {
+    if (this.#closed) {
+      return {
+        command: command.type,
+        error: transactionError(
+          "TRANSACTION_CLOSED",
+          `Cannot dispatch ${command.type}; the grid transaction is closed`,
+        ),
+        ok: false,
+      };
+    }
+    const result = this.executePreview(command);
+    if (result.ok) {
+      this.#commands.push(command);
+    }
+    return result;
+  }
+
+  commit(): GridTransactionCloseResult {
+    if (this.#closed) {
+      return {
+        error: transactionError(
+          "TRANSACTION_CLOSED",
+          "Cannot commit; the grid transaction is closed",
+        ),
+        ok: false,
+      };
+    }
+    const result = this.commitTransaction(this.#commands);
+    if (result.ok) {
+      this.#closed = true;
+    }
+    return result;
+  }
+
+  rollback(): GridTransactionCloseResult {
+    if (this.#closed) {
+      return {
+        error: transactionError(
+          "TRANSACTION_CLOSED",
+          "Cannot rollback; the grid transaction is closed",
+        ),
+        ok: false,
+      };
+    }
+    const result = this.rollbackTransaction();
+    if (result.ok) {
+      this.#closed = true;
+    }
+    return result;
+  }
+}

--- a/vuu-ui/packages/grid-layout/src/GridModel.ts
+++ b/vuu-ui/packages/grid-layout/src/GridModel.ts
@@ -668,6 +668,17 @@ export class GridTrack {
   toString = () => this.trackSize;
 }
 
+type GridTrackCheckpoint = {
+  readonly track: GridTrack;
+  readonly measuredValue: number;
+  readonly size: TrackSize;
+};
+
+type GridTracksCheckpoint = {
+  readonly columns: readonly GridTrackCheckpoint[];
+  readonly rows: readonly GridTrackCheckpoint[];
+};
+
 export class GridTracks extends EventEmitter<GridTrackEvents> {
   #columns: GridTrack[];
   #rows: GridTrack[];
@@ -711,6 +722,36 @@ export class GridTracks extends EventEmitter<GridTrackEvents> {
 
   getTracks(trackType: TrackType) {
     return trackType === "column" ? this.#columns : this.#rows;
+  }
+
+  createCheckpoint(): GridTracksCheckpoint {
+    const checkpointTrack = (track: GridTrack): GridTrackCheckpoint => ({
+      measuredValue: track.measuredValue,
+      size: track.trackSize,
+      track,
+    });
+    return {
+      columns: this.#columns.map(checkpointTrack),
+      rows: this.#rows.map(checkpointTrack),
+    };
+  }
+
+  restoreCheckpoint({ columns, rows }: GridTracksCheckpoint) {
+    const restoreTrack = ({
+      measuredValue,
+      size,
+      track,
+    }: GridTrackCheckpoint) => {
+      track.trackSize = size;
+      if (measuredValue !== -1) {
+        track.measuredValue = measuredValue;
+      }
+      return track;
+    };
+    this.#columns = columns.map(restoreTrack);
+    this.#rows = rows.map(restoreTrack);
+    this.emit("grid-track-resize", "column", this.#columns);
+    this.emit("grid-track-resize", "row", this.#rows);
   }
 
   /**
@@ -1280,12 +1321,163 @@ export class GridTracks extends EventEmitter<GridTrackEvents> {
     `;
   }
 }
+
+type GridModelChildItemCheckpoint = {
+  readonly item: GridModelChildItem;
+  readonly state: {
+    readonly column: GridModelPosition;
+    readonly contentDetached: boolean | undefined;
+    readonly contentVisible: boolean | undefined;
+    readonly dragging: boolean;
+    readonly dropTarget: boolean | string | undefined;
+    readonly header: boolean | undefined;
+    readonly height: number | undefined;
+    readonly horizontalSplitter: boolean;
+    readonly minHeight: number | undefined;
+    readonly minWidth: number | undefined;
+    readonly resizeable: GridModelItemResizeable;
+    readonly row: GridModelPosition;
+    readonly stackId: string | undefined;
+    readonly title: string | undefined;
+    readonly type: GridModelItemType;
+    readonly verticalSplitter: boolean;
+    readonly width: number | undefined;
+  };
+};
+
+type TabStateCheckpoint = {
+  readonly active: number;
+  readonly detachedTab: TabStateTab | undefined;
+  readonly tabs: readonly TabStateTab[];
+  readonly tabState: TabState;
+};
+
+export type GridModelCheckpoint = {
+  readonly childItems: readonly GridModelChildItemCheckpoint[];
+  readonly tabStates: readonly TabStateCheckpoint[];
+  readonly tracks: GridTracksCheckpoint;
+};
+
 export class GridModel extends EventEmitter<GridModelEvents> {
   tracks: GridTracks;
 
   #childItems: GridModelChildItem[] = [];
   #index = new Map<string, IGridModelChildItem>();
   #tabState = new Map<string, TabState>();
+
+  createCheckpoint(): GridModelCheckpoint {
+    return {
+      childItems: this.#childItems.map((item) => ({
+        item,
+        state: {
+          column: { end: item.column.end, start: item.column.start },
+          contentDetached: item.contentDetached,
+          contentVisible: item.contentVisible,
+          dragging: item.dragging,
+          dropTarget: item.dropTarget,
+          header: item.header,
+          height: item.height,
+          horizontalSplitter: item.horizontalSplitter,
+          minHeight: item.minHeight,
+          minWidth: item.minWidth,
+          resizeable: item.resizeable,
+          row: { end: item.row.end, start: item.row.start },
+          stackId: item.stackId,
+          title: item.title,
+          type: item.type,
+          verticalSplitter: item.verticalSplitter,
+          width: item.width,
+        },
+      })),
+      tabStates: [...this.#tabState.values()].map((tabState) => ({
+        active: tabState.active,
+        detachedTab: tabState.detachedTab
+          ? { ...tabState.detachedTab }
+          : undefined,
+        tabState,
+        tabs: tabState.tabs.map((tab) => ({ ...tab })),
+      })),
+      tracks: this.tracks.createCheckpoint(),
+    };
+  }
+
+  restoreCheckpoint({ childItems, tabStates, tracks }: GridModelCheckpoint) {
+    const currentStacks = new Map(
+      this.#childItems
+        .filter(({ type }) => type === "stacked-content")
+        .map((item) => [item.id, item]),
+    );
+    const currentTabStates = new Map(
+      [...this.#tabState].map(([id, { active, tabs }]) => [
+        id,
+        { active, tabs: tabs.map((tab) => ({ ...tab })) },
+      ]),
+    );
+    this.tracks.restoreCheckpoint(tracks);
+    this.#childItems = childItems.map(({ item, state }) => {
+      item.column.start = state.column.start;
+      item.column.end = state.column.end;
+      item.contentDetached = state.contentDetached;
+      item.contentVisible = state.contentVisible;
+      item.dragging = state.dragging;
+      item.dropTarget = state.dropTarget;
+      item.header = state.header;
+      item.height = state.height;
+      item.horizontalSplitter = state.horizontalSplitter;
+      item.minHeight = state.minHeight;
+      item.minWidth = state.minWidth;
+      item.resizeable = state.resizeable;
+      item.row.start = state.row.start;
+      item.row.end = state.row.end;
+      item.stackId = state.stackId;
+      item.title = state.title;
+      item.type = state.type;
+      item.verticalSplitter = state.verticalSplitter;
+      item.width = state.width;
+      return item;
+    });
+    this.#index = new Map(this.#childItems.map((item) => [item.id, item]));
+    this.#tabState = new Map(
+      tabStates.map(({ active, detachedTab, tabs, tabState }) => {
+        tabState.active = active;
+        tabState.detachedTab = detachedTab ? { ...detachedTab } : undefined;
+        tabState.tabs = tabs.map((tab) => ({ ...tab }));
+        return [tabState.id, tabState];
+      }),
+    );
+    const restoredStacks = new Map(
+      this.#childItems
+        .filter(({ type }) => type === "stacked-content")
+        .map((item) => [item.id, item]),
+    );
+    for (const stackId of currentStacks.keys()) {
+      if (!restoredStacks.has(stackId)) {
+        this.emit("tabs-removed", stackId);
+      }
+    }
+    for (const [stackId, stackItem] of restoredStacks) {
+      if (!currentStacks.has(stackId)) {
+        this.emit("tabs-created", stackItem);
+      } else {
+        const restored = this.#tabState.get(stackId);
+        const current = currentTabStates.get(stackId);
+        if (
+          restored &&
+          current &&
+          (restored.active !== current.active ||
+            JSON.stringify(restored.tabs) !== JSON.stringify(current.tabs))
+        ) {
+          this.emit(
+            "tabs-change",
+            stackId,
+            restored.active,
+            restored.tabs.map((tab) => ({ ...tab })),
+          );
+          this.emit("tab-selection-change", stackId, restored.active);
+        }
+      }
+    }
+  }
 
   constructor(
     public id: string,

--- a/vuu-ui/packages/grid-layout/src/index.ts
+++ b/vuu-ui/packages/grid-layout/src/index.ts
@@ -5,6 +5,18 @@ export type {
 export { DragDropProviderNext } from "./drag-drop-next/DragDropProviderNext";
 export { GridLayout, type GridResizeDistribution } from "./GridLayout";
 export {
+  GridController,
+  type GridCommittedTransition,
+  type GridCommittedTransitionListener,
+  type GridControllerError,
+  type GridControllerErrorCode,
+  type GridControllerListener,
+  type GridTransactionCloseResult,
+  type GridTransactionKind,
+  type GridTransactionStartResult,
+  type GridTransaction,
+} from "./GridController";
+export {
   GridCommandExecutionError,
   LegacyGridCommandExecutor,
   throwForGridCommandFailure,

--- a/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
@@ -74,6 +74,7 @@ import {
   LegacyGridCommandExecutor,
   throwForGridCommandFailure,
 } from "./GridCommand";
+import { GridController } from "./GridController";
 
 export type GridLayoutHookProps = {
   children: ReactNode;
@@ -201,8 +202,13 @@ export const useGridLayout = ({
   const dragStartLayoutRef = useRef<GridLayoutDescriptor | undefined>(
     undefined,
   );
-  const commandExecutor = useMemo(
-    () => new LegacyGridCommandExecutor(gridModel, gridLayoutModel),
+  const gridController = useMemo(
+    () =>
+      new GridController(
+        gridModel,
+        0,
+        new LegacyGridCommandExecutor(gridModel, gridLayoutModel),
+      ),
     [gridLayoutModel, gridModel],
   );
 
@@ -686,7 +692,7 @@ export const useGridLayout = ({
       switch (action.type) {
         case "close": {
           throwForGridCommandFailure(
-            commandExecutor.execute({
+            gridController.dispatch({
               itemId: action.id,
               reason: "close",
               type: "remove-item",
@@ -699,7 +705,7 @@ export const useGridLayout = ({
         }
         case "rename-tab":
           throwForGridCommandFailure(
-            commandExecutor.execute({
+            gridController.dispatch({
               itemId: action.id,
               title: action.title,
               type: "rename-item",
@@ -715,7 +721,7 @@ export const useGridLayout = ({
 
             const newChildId = uuid();
             throwForGridCommandFailure(
-              commandExecutor.execute({
+              gridController.dispatch({
                 item: {
                   id: newChildId,
                   column: {
@@ -741,7 +747,7 @@ export const useGridLayout = ({
             addChildComponent(component, gridModelChildItem);
 
             throwForGridCommandFailure(
-              commandExecutor.execute({
+              gridController.dispatch({
                 itemId: newChildId,
                 stackId,
                 type: "select-stack-item",
@@ -752,7 +758,7 @@ export const useGridLayout = ({
           break;
         case "resize-grid-column":
           throwForGridCommandFailure(
-            commandExecutor.execute({
+            gridController.dispatch({
               index: action.trackIndex,
               size: action.value,
               track: "column",
@@ -762,7 +768,7 @@ export const useGridLayout = ({
           break;
         case "resize-grid-row":
           throwForGridCommandFailure(
-            commandExecutor.execute({
+            gridController.dispatch({
               index: action.trackIndex,
               size: action.value,
               track: "row",
@@ -772,7 +778,7 @@ export const useGridLayout = ({
           break;
         case "select-tab":
           throwForGridCommandFailure(
-            commandExecutor.execute({
+            gridController.dispatch({
               itemId: action.itemId,
               stackId: action.stackId,
               type: "select-stack-item",
@@ -791,7 +797,7 @@ export const useGridLayout = ({
     },
     [
       addChildComponent,
-      commandExecutor,
+      gridController,
       gridModel,
       layoutOptions?.newChildItem.header,
       setChildren,

--- a/vuu-ui/packages/grid-layout/test/GridController.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridController.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  GridController,
+  type GridCommittedTransition,
+} from "../src/GridController";
+import type { GridCommand } from "../src/GridCommand";
+import { GridModel } from "../src/GridModel";
+import { descriptor, item, normalizeModel } from "./model-scenario-harness";
+
+const resizeColumn = (index: number, size: `${number}px`): GridCommand => ({
+  index,
+  size,
+  track: "column",
+  type: "resize-track",
+});
+
+const modelWithTwoItems = (id = "grid") =>
+  new GridModel(
+    id,
+    descriptor(["100px", "100px"], ["1fr"], {
+      left: item("1/1/2/2", { title: "Left" }),
+      right: item("1/2/2/3", { title: "Right" }),
+    }),
+  );
+
+describe("GridController external store", () => {
+  it("keeps snapshot identity stable until semantic state changes", () => {
+    const controller = new GridController(modelWithTwoItems());
+    const initial = controller.getSnapshot();
+
+    expect(controller.getSnapshot()).toBe(initial);
+    expect(
+      controller.dispatch({
+        itemId: "left",
+        title: "Left",
+        type: "rename-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(controller.getSnapshot()).toBe(initial);
+
+    expect(
+      controller.dispatch({
+        itemId: "left",
+        title: "Renamed",
+        type: "rename-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(controller.getSnapshot()).not.toBe(initial);
+  });
+
+  it("notifies once per visible transition and never for rejects or no-ops", () => {
+    const controller = new GridController(modelWithTwoItems());
+    const listener = vi.fn();
+    const commitListener = vi.fn();
+    controller.subscribe(listener);
+    controller.subscribeCommitted(commitListener);
+
+    controller.dispatch({
+      itemId: "missing",
+      title: "Missing",
+      type: "rename-item",
+    });
+    controller.dispatch({
+      itemId: "left",
+      title: "Left",
+      type: "rename-item",
+    });
+    expect(listener).not.toHaveBeenCalled();
+    expect(commitListener).not.toHaveBeenCalled();
+
+    controller.dispatch({
+      itemId: "left",
+      title: "Renamed",
+      type: "rename-item",
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports idempotent unsubscribe and reentrant listener changes", () => {
+    const controller = new GridController(modelWithTwoItems());
+    const late = vi.fn();
+    const removed = vi.fn();
+    let unsubscribeRemoved = () => {};
+    const first = vi.fn(() => {
+      unsubscribeRemoved();
+      controller.subscribe(late);
+    });
+    const unsubscribeFirst = controller.subscribe(first);
+    unsubscribeRemoved = controller.subscribe(removed);
+
+    controller.dispatch(resizeColumn(0, "120px"));
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(removed).not.toHaveBeenCalled();
+    expect(late).not.toHaveBeenCalled();
+
+    unsubscribeFirst();
+    unsubscribeFirst();
+    controller.dispatch(resizeColumn(0, "130px"));
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(late).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps published snapshots detached from later legacy mutations", () => {
+    const model = modelWithTwoItems();
+    const controller = new GridController(model);
+    const initial = controller.getSnapshot();
+
+    model.tracks.resizeTo("column", 0, "175px");
+    model.updateChildTitle("left", "Mutated directly");
+
+    expect(initial.columns[0].size).toBe("100px");
+    expect(initial.items.find(({ id }) => id === "left")?.title).toBe("Left");
+    expect(controller.getSnapshot()).toBe(initial);
+  });
+
+  it("commits ordinary dispatches with one revision and commit event", () => {
+    const controller = new GridController(modelWithTwoItems(), 7);
+    const stateListener = vi.fn();
+    const transitions: GridCommittedTransition[] = [];
+    controller.subscribe(stateListener);
+    controller.subscribeCommitted((transition) => transitions.push(transition));
+
+    controller.dispatch(resizeColumn(0, "125px"));
+
+    expect(controller.getSnapshot().revision).toBe(8);
+    expect(stateListener).toHaveBeenCalledTimes(1);
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0]).toMatchObject({
+      commands: [{ type: "resize-track" }],
+      kind: "dispatch",
+      previous: { revision: 7 },
+      snapshot: { revision: 8 },
+    });
+  });
+
+  it("isolates subscriptions between controller instances", () => {
+    const outer = new GridController(modelWithTwoItems("outer"));
+    const inner = new GridController(modelWithTwoItems("inner"));
+    const outerListener = vi.fn();
+    const innerListener = vi.fn();
+    outer.subscribe(outerListener);
+    inner.subscribe(innerListener);
+
+    inner.dispatch(resizeColumn(1, "140px"));
+
+    expect(innerListener).toHaveBeenCalledTimes(1);
+    expect(outerListener).not.toHaveBeenCalled();
+    expect(outer.getSnapshot().revision).toBe(0);
+  });
+});
+
+describe("GridController transactions", () => {
+  it("publishes previews at the committed revision and commits once", () => {
+    const controller = new GridController(modelWithTwoItems(), 4);
+    const stateListener = vi.fn();
+    const commitListener = vi.fn();
+    controller.subscribe(stateListener);
+    controller.subscribeCommitted(commitListener);
+    const start = controller.beginTransaction("resize");
+    expect(start.ok).toBe(true);
+    if (!start.ok) {
+      return;
+    }
+
+    start.transaction.dispatch(resizeColumn(0, "125px"));
+    expect(controller.getSnapshot()).toMatchObject({ revision: 4 });
+    start.transaction.dispatch(resizeColumn(1, "75px"));
+    expect(controller.getSnapshot()).toMatchObject({ revision: 4 });
+    expect(stateListener).toHaveBeenCalledTimes(2);
+    expect(commitListener).not.toHaveBeenCalled();
+
+    expect(start.transaction.commit()).toMatchObject({
+      ok: true,
+      snapshot: { revision: 5 },
+    });
+    expect(stateListener).toHaveBeenCalledTimes(3);
+    expect(commitListener).toHaveBeenCalledTimes(1);
+    expect(commitListener.mock.calls[0][0]).toMatchObject({
+      commands: [{ type: "resize-track" }, { type: "resize-track" }],
+      kind: "resize",
+      previous: { revision: 4 },
+      snapshot: { revision: 5 },
+    });
+  });
+
+  it("closes a net-unchanged transaction without a revision or commit event", () => {
+    const controller = new GridController(modelWithTwoItems(), 4);
+    const baseline = controller.getSnapshot();
+    const stateListener = vi.fn();
+    const commitListener = vi.fn();
+    controller.subscribe(stateListener);
+    controller.subscribeCommitted(commitListener);
+    const start = controller.beginTransaction("resize");
+    expect(start.ok).toBe(true);
+    if (!start.ok) {
+      return;
+    }
+
+    start.transaction.dispatch(resizeColumn(0, "125px"));
+    start.transaction.dispatch(resizeColumn(0, "100px"));
+    expect(controller.getSnapshot()).toBe(baseline);
+    expect(start.transaction.commit()).toEqual({
+      ok: true,
+      snapshot: baseline,
+    });
+    expect(controller.getSnapshot()).toBe(baseline);
+    expect(controller.getSnapshot().revision).toBe(4);
+    expect(stateListener).toHaveBeenCalledTimes(2);
+    expect(commitListener).not.toHaveBeenCalled();
+  });
+
+  it("publishes and commits runtime tab order", () => {
+    const model = modelWithTwoItems();
+    model.stackChildItems("left", "right");
+    const stackId = model.childItems.find(
+      ({ type }) => type === "stacked-content",
+    )?.id;
+    expect(stackId).toBeDefined();
+    if (!stackId) {
+      return;
+    }
+    const controller = new GridController(model);
+    const start = controller.beginTransaction("drag");
+    expect(start.ok).toBe(true);
+    if (!start.ok) {
+      return;
+    }
+
+    start.transaction.dispatch({
+      itemId: "right",
+      position: "before",
+      stackId,
+      targetItemId: "left",
+      type: "reorder-stack-item",
+    });
+
+    expect(controller.getSnapshot().stacks[0].itemIds).toEqual([
+      "right",
+      "left",
+    ]);
+    expect(start.transaction.commit()).toMatchObject({
+      ok: true,
+      snapshot: {
+        revision: 1,
+        stacks: [{ itemIds: ["right", "left"] }],
+      },
+    });
+  });
+
+  it("reconciles legacy stack observers when structural previews roll back", () => {
+    const model = modelWithTwoItems();
+    const removed = vi.fn();
+    model.on("tabs-removed", removed);
+    const controller = new GridController(model);
+    const start = controller.beginTransaction("drag");
+    expect(start.ok).toBe(true);
+    if (!start.ok) {
+      return;
+    }
+
+    start.transaction.dispatch({
+      itemId: "right",
+      targetId: "left",
+      type: "create-stack",
+    });
+    const stackId = model.childItems.find(
+      ({ type }) => type === "stacked-content",
+    )?.id;
+    expect(stackId).toBeDefined();
+    start.transaction.rollback();
+
+    expect(removed).toHaveBeenCalledExactlyOnceWith(stackId);
+  });
+
+  it("rejects nested transactions and command failure leaves the transaction active", () => {
+    const controller = new GridController(modelWithTwoItems());
+    const start = controller.beginTransaction("drag");
+    expect(start.ok).toBe(true);
+    if (!start.ok) {
+      return;
+    }
+
+    expect(controller.beginTransaction("resize")).toEqual({
+      error: {
+        code: "TRANSACTION_ACTIVE",
+        message: "Cannot begin resize; a grid transaction is already active",
+      },
+      ok: false,
+    });
+    expect(
+      start.transaction.dispatch({
+        itemId: "missing",
+        title: "No item",
+        type: "rename-item",
+      }),
+    ).toMatchObject({ error: { code: "ITEM_NOT_FOUND" }, ok: false });
+    expect(start.transaction.dispatch(resizeColumn(0, "115px"))).toMatchObject({
+      ok: true,
+    });
+    expect(start.transaction.commit()).toMatchObject({ ok: true });
+  });
+
+  it("restores stacks, tabs, placeholders, fractional tracks and runtime metadata exactly", () => {
+    const model = new GridModel(
+      "rollback",
+      descriptor(["1fr", "2fr"], ["1fr"], {
+        alpha: item("1/1/2/2", { title: "Alpha" }),
+        beta: item("1/1/2/2", { title: "Beta" }),
+      }),
+    );
+    model.stackChildItems("alpha", "beta");
+    const stackId = model.childItems.find(
+      ({ type }) => type === "stacked-content",
+    )?.id;
+    expect(stackId).toBeDefined();
+    if (!stackId) {
+      return;
+    }
+    model.createPlaceholders();
+    const alpha = model.getChildItem("alpha", true);
+    const stack = model.getChildItem(stackId, true);
+    alpha.dragging = true;
+    stack.horizontalSplitter = true;
+    model.tracks.getTracks("column")[0].measuredValue = 100;
+    model.tracks.getTracks("column")[1].measuredValue = 200;
+    const before = normalizeModel(model);
+    const beforePlaceholders = model.getPlaceholders();
+    const beforeTracks = model.tracks.getTracks("column");
+    const controller = new GridController(model, 9);
+    const baseline = controller.getSnapshot();
+    const stateListener = vi.fn();
+    const commitListener = vi.fn();
+    controller.subscribe(stateListener);
+    controller.subscribeCommitted(commitListener);
+    const start = controller.beginTransaction("drag");
+    expect(start.ok).toBe(true);
+    if (!start.ok) {
+      return;
+    }
+
+    start.transaction.dispatch({
+      itemId: "beta",
+      stackId,
+      type: "select-stack-item",
+    });
+    start.transaction.dispatch({
+      activate: true,
+      itemId: "beta",
+      position: "before",
+      stackId,
+      targetItemId: "alpha",
+      type: "reorder-stack-item",
+    });
+    start.transaction.dispatch({
+      contraTrackIndex: 1,
+      delta: 25,
+      distribution: "adjacent",
+      measuredSizes: [100, 200],
+      resizedTrackIndex: 0,
+      track: "column",
+      type: "resize-tracks",
+    });
+    start.transaction.dispatch({ type: "regenerate-placeholders" });
+    const previewNotificationCount = stateListener.mock.calls.length;
+
+    expect(start.transaction.rollback()).toEqual({
+      ok: true,
+      snapshot: baseline,
+    });
+    expect(controller.getSnapshot()).toBe(baseline);
+    expect(normalizeModel(model)).toEqual(before);
+    expect(model.getPlaceholders()).toEqual(beforePlaceholders);
+    expect(model.getChildItem("alpha", true)).toBe(alpha);
+    expect(model.getChildItem(stackId, true)).toBe(stack);
+    expect(alpha.dragging).toBe(true);
+    expect(stack.horizontalSplitter).toBe(true);
+    expect(model.tracks.columns).toEqual(["1fr", "2fr"]);
+    expect(
+      model.tracks
+        .getTracks("column")
+        .map(({ measuredValue }) => measuredValue),
+    ).toEqual([100, 200]);
+    expect(model.tracks.getTracks("column")).toEqual(beforeTracks);
+    expect(controller.getSnapshot().revision).toBe(9);
+    expect(stateListener).toHaveBeenCalledTimes(previewNotificationCount + 1);
+    expect(commitListener).not.toHaveBeenCalled();
+  });
+
+  it("returns typed errors for dispatch and repeated close after closure", () => {
+    const controller = new GridController(modelWithTwoItems());
+    const start = controller.beginTransaction("resize");
+    expect(start.ok).toBe(true);
+    if (!start.ok) {
+      return;
+    }
+
+    expect(controller.dispatch(resizeColumn(0, "150px"))).toMatchObject({
+      error: { code: "TRANSACTION_ACTIVE" },
+      ok: false,
+    });
+    expect(start.transaction.rollback()).toMatchObject({ ok: true });
+    expect(start.transaction.dispatch(resizeColumn(0, "160px"))).toMatchObject({
+      error: { code: "TRANSACTION_CLOSED" },
+      ok: false,
+    });
+    expect(start.transaction.commit()).toMatchObject({
+      error: { code: "TRANSACTION_CLOSED" },
+      ok: false,
+    });
+    expect(start.transaction.rollback()).toMatchObject({
+      error: { code: "TRANSACTION_CLOSED" },
+      ok: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 6 increment 3 in the #2341 stack, following merged #2369 (canonical immutable snapshots) and #2371 (typed legacy commands).

- add a per-`GridLayout` `GridController` external store over the existing `GridModel` / `GridLayoutModel` mutation engine
- preserve stable snapshot identity across rejects and semantic no-ops, publish detached canonical snapshots for visible changes, and support reentrant/idempotent subscriptions
- separate render/state subscribers from typed committed-transition subscribers
- add explicit drag/resize transactions with one-active-transaction enforcement, atomic preview commands, committed-revision retention during previews, one durable revision/event on commit, typed closed/active errors, and exact rollback
- add a narrow internal legacy checkpoint for tracks and measurement state, child/runtime metadata, placeholders, stack containers, tab order/selection/detachment, and observer reconciliation
- derive canonical stack ordering from runtime tab state so reorder commands are represented correctly
- create one controller per `useGridLayout` instance and route only the already-typed compatibility actions through it without duplicate mutation

## Compatibility boundary

The legacy `GridModel` / `GridLayoutModel` remains the sole writer. Existing React rendering, `childrenRef`, force-render behavior, context model exports, direct track style updates, and drag/drop paths remain authoritative. Transactions are characterized but are not wired into complex production drag/drop in this increment. No `useSyncExternalStore` hook is added yet because production rendering has not cut over to controller snapshots.

## Validation

- Vitest: 66 passed, 2 existing model todos preserved (68 total)
- targeted Biome error check: 6 changed files clean
- `@heswell/grid-layout` build: 49 files generated successfully
- targeted GridLayout Playwright: blocked before fixture mount by unrelated showcase baseline build failures (`UserSettingsPanel` export and missing `feature-filter-table`); 3 existing skips preserved
- root UI typecheck: 43 existing errors across `vuu-data-react`, `vuu-utils`, portal examples, sample app, and showcase; none originate in `packages/grid-layout` or changed files

## Deferred

Pure geometry extraction, React rendering source-of-truth cutover, controller-backed drag coordination, persistence schema/settings codecs, and complex drag/drop transaction migration remain deferred to later increments.