### PR TITLE
Move CSV export utilities from vuu-utils to vuu-table-extras

### DIFF
--- a/vuu-ui/packages/vuu-table-extras/src/csv-export/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-export/README.md
@@ -1,15 +1,15 @@
 # CSV Export
 
-CSV export is a set of standalone utility functions — `exportToCsv`, `exportCsvTemplate`, and `exportSessionTableToCsv` — implemented in [export-utils.ts](../src/export-utils.ts) and exported from `@vuu-ui/vuu-utils`. There is no React component: call them directly from a button handler or menu action.
+CSV export is a set of standalone utility functions — `exportToCsv`, `exportCsvTemplate`, and `exportSessionTableToCsv` — implemented in [export-utils.ts](./export-utils.ts) and exported from `@vuu-ui/vuu-table-extras`. There is no React component: call them directly from a button handler or menu action.
 
-See [CsvUpload](../../vuu-table-extras/src/csv-upload/README.md) for the counterpart component that imports a CSV into a Vuu table.
+See [CsvUpload](../csv-upload/README.md) for the counterpart component that imports a CSV into a Vuu table.
 
 ---
 
 ## Usage
 
 ```tsx
-import { exportToCsv } from "@vuu-ui/vuu-utils";
+import { exportToCsv } from "@vuu-ui/vuu-table-extras";
 
 const handleExport = useCallback(async () => {
   await exportToCsv(
@@ -23,10 +23,10 @@ const handleExport = useCallback(async () => {
 }, [dataSource]);
 ```
 
-`exportCsvTemplate` downloads a header-only CSV, useful for giving users a starting point for a [CsvUpload](../../vuu-table-extras/src/csv-upload/README.md) import:
+`exportCsvTemplate` downloads a header-only CSV, useful for giving users a starting point for a [CsvUpload](../csv-upload/README.md) import:
 
 ```tsx
-import { exportCsvTemplate } from "@vuu-ui/vuu-utils";
+import { exportCsvTemplate } from "@vuu-ui/vuu-table-extras";
 
 exportCsvTemplate(dataSource, "instruments-template.csv");
 ```

--- a/vuu-ui/packages/vuu-table-extras/src/csv-export/export-utils.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-export/export-utils.ts
@@ -6,9 +6,7 @@ import type {
   DataSourceSubscribedMessage,
   SessionDataSourceOverrides,
 } from "@vuu-ui/vuu-data-types";
-import { metadataKeys } from "./column-utils";
-import { isSessionTable } from "./protocol-message-utils";
-import { Range } from "./range-utils";
+import { isSessionTable, metadataKeys, Range } from "@vuu-ui/vuu-utils";
 
 export type ExportColumnDescriptor<TName extends string = string> = {
   name: TName;

--- a/vuu-ui/packages/vuu-table-extras/src/csv-export/index.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-export/index.ts
@@ -1,0 +1,6 @@
+export {
+  exportCsvTemplate,
+  exportSessionTableToCsv,
+  exportToCsv,
+  type ExportColumnDescriptor,
+} from "./export-utils";

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
@@ -2,7 +2,7 @@
 
 The `CsvUpload` component provides a dialog-based workflow for uploading, validating, and importing a CSV file into a Vuu table via RPC. It manages a server-side edit session throughout the process and exposes a lifecycle callback API so consumers can track and react to each phase.
 
-See [CSV Export](../../../vuu-utils/docs/csv-export.md) for the counterpart utilities that export a table to CSV.
+See [CSV Export](../csv-export/README.md) for the counterpart utilities that export a table to CSV.
 
 ---
 

--- a/vuu-ui/packages/vuu-table-extras/src/index.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/index.ts
@@ -1,4 +1,5 @@
 export { CalculatedColumnPanel } from "./calculated-column/CalculatedColumnPanel";
+export * from "./csv-export";
 export * from "./csv-upload";
 export * from "./cell-edit-validators";
 export * from "./cell-renderers";
@@ -25,7 +26,7 @@ export {
   type ColumnPickerProps,
 } from "./column-picker/ColumnPicker";
 export { ColumnPickerAction } from "./column-picker/ColumnPickerAction";
-export { type SelectedColumnsChangeHandler } from "./column-picker/useColumnPicker";
+export type { SelectedColumnsChangeHandler } from "./column-picker/useColumnPicker";
 export { useTableColumnPicker } from "./column-picker/useTableColumnPicker";
 export { ColumnSettingsPanel } from "./column-settings-panel/ColumnSettingsPanel";
 export { useColumnSettings } from "./column-settings-panel/useColumnSettings";

--- a/vuu-ui/packages/vuu-utils/src/index.ts
+++ b/vuu-ui/packages/vuu-utils/src/index.ts
@@ -13,7 +13,6 @@ export * from "./component-registry";
 export * from "./cookie-utils";
 export * from "./css-utils";
 export * from "./data-utils";
-export * from "./export-utils";
 export * from "./datasource/BaseDataSource";
 export * from "./datasource/datasource-action-utils";
 export * from "./datasource/datasource-filter-utils";

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -1,6 +1,6 @@
 import { getSchema, LocalDataSourceProvider, simulModule } from "@vuu-ui/vuu-data-test";
 import type { DataSource } from "@vuu-ui/vuu-data-types";
-import { exportCsvTemplate, exportToCsv, type ExportColumnDescriptor } from "@vuu-ui/vuu-utils";
+import { exportCsvTemplate, exportToCsv, type ExportColumnDescriptor } from "@vuu-ui/vuu-table-extras";
 import { Button } from "@salt-ds/core";
 import { Table } from "@vuu-ui/vuu-table";
 import type { TableConfig } from "@vuu-ui/vuu-table-types";


### PR DESCRIPTION
Moves the CSV export utilities (`exportToCsv`, `exportCsvTemplate`, `exportSessionTableToCsv`, `ExportColumnDescriptor`) from `@vuu-ui/vuu-utils` to `@vuu-ui/vuu-table-extras`, mirroring the existing `csv-upload` component's location. There is no behavioral change — this is a pure code-location refactor.