### PR TITLE
fix(grid-layout): resolve stacked splitter items

### DIFF
--- a/vuu-ui/packages/grid-layout/src/GridGeometry.ts
+++ b/vuu-ui/packages/grid-layout/src/GridGeometry.ts
@@ -2233,20 +2233,18 @@ export const computeSplitters = (
   geometry: GridGeometry,
 ): GridSplitterGeometry => {
   const { items } = geometry;
+  const layoutItems = items.filter(({ stackId }) => stackId === undefined);
   const splitters: GridGeometrySplitter[] = [];
   const horizontalSplitterItemIds: GridItemId[] = [];
   const verticalSplitterItemIds: GridItemId[] = [];
 
-  for (const childItem of items) {
-    if (childItem.stackId) {
-      continue;
-    }
+  for (const childItem of layoutItems) {
     const { column, id, row } = childItem;
 
     // 1) Horizontal (column) resizing - the vertically aligned splitters
     if (!isFixedWidthItem(childItem)) {
       const columnContrasAndSiblings = findColumnContrasAndSiblings(
-        items,
+        layoutItems,
         childItem,
       );
       if (columnContrasAndSiblings) {
@@ -2274,7 +2272,10 @@ export const computeSplitters = (
 
     // 2) Vertical (row) resizing - the horizontally aligned splitters
     if (!isFixedHeightItem(childItem)) {
-      const rowContrasAndSiblings = findRowContrasAndSiblings(items, childItem);
+      const rowContrasAndSiblings = findRowContrasAndSiblings(
+        layoutItems,
+        childItem,
+      );
       if (rowContrasAndSiblings) {
         const contraTrackIndex = row.start - 2;
         let resizeTrackIndex = row.start - 1;

--- a/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayout.playwright.test.tsx
+++ b/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayout.playwright.test.tsx
@@ -711,6 +711,52 @@ test.describe("GridLayout browser interactions", () => {
     ).toBeVisible();
   });
 
+  test("resizes a south split after a palette header drop creates a stack", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(fixture, { variant: "palette-target" });
+    const grid = new GridLayoutDriver(component, page);
+
+    await grid.dragTemplate(
+      component.getByTestId("palette-item-1"),
+      grid.content("palette-target"),
+      "south",
+    );
+    const templateHeader = component.locator(".vuuGridLayoutItemHeader-title", {
+      hasText: /^Template A$/,
+    });
+    const templateItem = templateHeader.locator(
+      "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' vuuGridLayoutItem ')][1]",
+    );
+
+    await grid.dragTemplate(
+      component.getByTestId("palette-item-2"),
+      templateItem.locator(".vuuGridLayoutItemHeader"),
+      "header",
+    );
+
+    const stack = component
+      .getByRole("tablist")
+      .locator(
+        "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' vuuGridLayoutItem ')][1]",
+      );
+    const targetBefore = await grid.item("palette-target").boundingBox();
+    const stackBefore = await stack.boundingBox();
+    await grid.resize(grid.separator("horizontal"), 0, 40);
+    const targetAfter = await grid.item("palette-target").boundingBox();
+    const stackAfter = await stack.boundingBox();
+
+    expect(targetAfter?.height).not.toBeCloseTo(targetBefore?.height ?? 0, 0);
+    expect(stackAfter?.height).not.toBeCloseTo(stackBefore?.height ?? 0, 0);
+    await expect(
+      component.getByRole("tab", { name: "Template A" }),
+    ).toBeVisible();
+    await expect(
+      component.getByRole("tab", { name: "Template B" }),
+    ).toBeVisible();
+  });
+
   test.fixme("palette template drop onto an empty placeholder", async () => {
     // Native template drag currently depends on unstable placeholder drag-enter
     // sequencing in Playwright CT.

--- a/vuu-ui/packages/grid-layout/test/GridGeometry.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridGeometry.test.ts
@@ -809,6 +809,46 @@ describe("GridGeometry item transitions", () => {
     expect(splitters.map(({ id }) => id)).toEqual(["lower-splitter-v"]);
   });
 
+  it("references stack containers rather than their compatibility members", () => {
+    const horizontal = computeSplitters(
+      geometry(
+        ["1fr"],
+        ["1fr", "1fr"],
+        [
+          item("upper", "1/1/2/2"),
+          item("stack", "2/1/3/2", { type: "stacked-content" }),
+          item("teal", "2/1/3/2", { stackId: "stack" }),
+          item("coral", "2/1/3/2", { stackId: "stack" }),
+        ],
+      ),
+    ).splitters;
+    const vertical = computeSplitters(
+      geometry(
+        ["1fr", "1fr"],
+        ["1fr"],
+        [
+          item("left", "1/1/2/2"),
+          item("stack", "1/2/2/3", { type: "stacked-content" }),
+          item("teal", "1/2/2/3", { stackId: "stack" }),
+          item("coral", "1/2/2/3", { stackId: "stack" }),
+        ],
+      ),
+    ).splitters;
+
+    expect(horizontal).toMatchObject([
+      {
+        orientation: "vertical",
+        resizedChildItems: { after: ["stack"], before: ["upper"] },
+      },
+    ]);
+    expect(vertical).toMatchObject([
+      {
+        orientation: "horizontal",
+        resizedChildItems: { after: ["stack"], before: ["left"] },
+      },
+    ]);
+  });
+
   it("propagates stacked-content updates to stack members", () => {
     const next = applyGeometryUpdates(
       geometry(

--- a/vuu-ui/packages/grid-layout/test/GridModel.scenarios.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridModel.scenarios.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { LegacyGridCommandExecutor } from "../src/GridCommand";
 import { GridLayoutModel } from "../src/GridLayoutModel";
 import { GridModel } from "../src/GridModel";
 import {
@@ -616,6 +617,93 @@ describe("GridModel declarative layout scenarios", () => {
     expect(
       new GridLayoutModel(model).canSplitGridItem(stack?.id ?? "", "east"),
     ).toBe(false);
+  });
+
+  it("resizes a south split after its lower item becomes a palette stack", () => {
+    const model = new GridModel(
+      "palette-replace",
+      descriptor(["600px"], ["400px"], {
+        target: item("1/1/2/2", { resizeable: "hv", title: "Drop target" }),
+      }),
+    );
+    const executor = new LegacyGridCommandExecutor(model);
+
+    expect(
+      executor.execute({
+        item: {
+          column: { span: 1, start: 1 },
+          id: "teal",
+          resizeable: "hv",
+          row: { span: 1, start: 1 },
+          title: "Teal",
+        },
+        type: "add-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      executor.execute({
+        itemId: "teal",
+        position: "south",
+        targetId: "target",
+        type: "move-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      executor.execute({
+        item: {
+          column: { span: 1, start: 1 },
+          id: "coral",
+          resizeable: "hv",
+          row: { span: 1, start: 1 },
+          title: "Coral",
+        },
+        type: "add-item",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      executor.execute({
+        itemId: "coral",
+        targetId: "teal",
+        type: "create-stack",
+      }),
+    ).toMatchObject({ ok: true });
+
+    const stack = model.childItems.find(
+      ({ type }) => type === "stacked-content",
+    );
+    expect(stack).toBeDefined();
+    const stackId = stack?.id ?? "";
+    expect(model.getStackState(stackId)).toMatchObject({
+      members: [{ id: "teal" }, { id: "coral" }],
+      selectedItemId: "teal",
+    });
+    expect(model.getTabState(stackId).tabs.map(({ id }) => id)).toEqual([
+      "teal",
+      "coral",
+    ]);
+
+    const [splitter] = model.getSplitters();
+    expect(splitter).toMatchObject({
+      ariaOrientation: "horizontal",
+      resizedChildItems: {
+        after: [stackId],
+        before: ["target"],
+      },
+      resizedGridTracks: [0, 1],
+    });
+    expect(
+      executor.execute({
+        contraTrackIndex: splitter.resizedGridTracks[0],
+        delta: 40,
+        distribution: "adjacent",
+        resizedTrackIndex: splitter.resizedGridTracks[1],
+        track: "row",
+        type: "resize-tracks",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(model.tracks.rows).toEqual(["160px", "240px"]);
+    expect(model.getChildItem("teal", true).stackId).toBe(stackId);
+    expect(model.getChildItem("coral", true).stackId).toBe(stackId);
   });
 
   it("creates one shared splitter when only one track item opts into resizing", () => {


### PR DESCRIPTION
## Reproduction

In the Showcase `PaletteSplitAndReplace` scenario:

1. Drop Teal south of DropTarget.
2. Drop Coral on the Teal header to create a Teal/Coral stack.
3. Drag the horizontal splitter between DropTarget and the stack.

Previously this threw `[useGridSplitterResizing] GridItem #<member-id> not found`.

## Root cause

Canonical stack creation correctly keeps member items in `GridModel` for legacy `TabState`/descriptor compatibility and adds a rendered `stacked-content` container. `computeSplitters()` excluded stack members as splitter owners, but still passed the full geometry projection into contra/sibling discovery. The resulting splitter could therefore reference an unrendered member ID instead of the live stack-container ID, breaking DOM lookup and minimum-size calculation. The same topology error applied to row and column splitters.

## Fix

Compute splitter topology exclusively from live layout placements: unstacked items plus stack containers. Canonical stack membership and legacy member projections remain unchanged, while splitter references now identify the rendered stack container so its minimum constraints participate normally in resizing.

## Regression tests

- Geometry characterization for both horizontal and vertical splitters verifies stack-container IDs replace member IDs.
- Model scenario performs the exact south split -> palette stack -> horizontal resize transition and verifies canonical stack state, legacy `TabState`, member compatibility projections, splitter identity, and applied track sizes.
- Playwright component regression performs the palette split/header-stack/resize interaction.
- Existing targeted stack suites cover existing-item stacking, duplicate-title identity, selection, tab removal, and stack dissolution.

## Validation

- Vitest: 5 targeted files passed; 150 tests passed, 2 existing todos.
- Biome: changed files pass check/format.
- GridLayout package build: passed (50 files generated).
- Playwright component test attempted, but the existing Showcase harness cannot mount because its bundle currently fails on unrelated baseline issues: missing `UserSettingsPanel` export from `@vuu-ui/vuu-shell` and unresolved `feature-filter-table` imports. The regression remains enabled for execution once those blockers are resolved.