### PR TITLE
fix(grid-layout): refresh splitters for stack lifecycle

### DIFF
--- a/vuu-ui/packages/grid-layout/src/GridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayout.tsx
@@ -161,6 +161,12 @@ export const GridLayout = ({
               // {...splitterProps}
               aria-controls={splitter.controls}
               ariaOrientation={splitter.ariaOrientation}
+              data-resized-child-items-after={splitter.resizedChildItems.after.join(
+                " ",
+              )}
+              data-resized-child-items-before={splitter.resizedChildItems.before.join(
+                " ",
+              )}
               id={splitter.id}
               key={splitter.id}
               offsetStart={startsAtHorizontalSplitter(splitter, splitters)}

--- a/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayout.playwright.test.tsx
+++ b/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayout.playwright.test.tsx
@@ -741,9 +741,24 @@ test.describe("GridLayout browser interactions", () => {
       .locator(
         "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' vuuGridLayoutItem ')][1]",
       );
+    const stackId = await stack.getAttribute("id");
+    if (!stackId) {
+      throw Error("Palette-created stack has no id");
+    }
+    const separator = grid.separator("horizontal");
+    await expect(separator).toHaveAttribute(
+      "data-resized-child-items-before",
+      "palette-target",
+    );
+    await expect(separator).toHaveAttribute(
+      "data-resized-child-items-after",
+      stackId,
+    );
+    await expect(separator).toHaveAttribute("aria-controls", stackId);
+    await expect(component.locator(`[id="${stackId}"]`)).toHaveCount(1);
     const targetBefore = await grid.item("palette-target").boundingBox();
     const stackBefore = await stack.boundingBox();
-    await grid.resize(grid.separator("horizontal"), 0, 40);
+    await grid.resize(separator, 0, 40);
     const targetAfter = await grid.item("palette-target").boundingBox();
     const stackAfter = await stack.boundingBox();
 

--- a/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
@@ -668,22 +668,33 @@ export const useGridLayout = ({
   );
 
   const handleTabsChange = useCallback<TabsChangeHandler>(() => {
-    forceRender({});
-  }, []);
+    const splitters = gridLayoutModel.createSplitters();
+    setNonContentGridItems((items) => ({ ...items, splitters }));
+  }, [gridLayoutModel]);
 
-  const handleTabsCreated = useCallback((stackItem: GridModelChildItem) => {
-    setNonContentGridItems(({ stackedItems, ...rest }) => ({
-      ...rest,
-      stackedItems: stackedItems.concat(stackItem),
-    }));
-  }, []);
+  const handleTabsCreated = useCallback(
+    (stackItem: GridModelChildItem) => {
+      const splitters = gridLayoutModel.createSplitters();
+      setNonContentGridItems(({ stackedItems, ...rest }) => ({
+        ...rest,
+        splitters,
+        stackedItems: stackedItems.concat(stackItem),
+      }));
+    },
+    [gridLayoutModel],
+  );
 
-  const handleTabsRemoved = useCallback((stackId: string) => {
-    setNonContentGridItems(({ stackedItems, ...rest }) => ({
-      ...rest,
-      stackedItems: stackedItems.filter(({ id }) => id !== stackId),
-    }));
-  }, []);
+  const handleTabsRemoved = useCallback(
+    (stackId: string) => {
+      const splitters = gridLayoutModel.createSplitters();
+      setNonContentGridItems(({ stackedItems, ...rest }) => ({
+        ...rest,
+        splitters,
+        stackedItems: stackedItems.filter(({ id }) => id !== stackId),
+      }));
+    },
+    [gridLayoutModel],
+  );
 
   const handleTabSelectionChange =
     useCallback<TabSelectionChangeHandler>(() => {

--- a/vuu-ui/packages/grid-layout/test/GridLayout.stack-splitter.react.test.tsx
+++ b/vuu-ui/packages/grid-layout/test/GridLayout.stack-splitter.react.test.tsx
@@ -1,0 +1,256 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GridLayout,
+  GridLayoutItem,
+  GridLayoutProvider,
+  type GridLayoutSplitDirection,
+  type TemplateSource,
+  useGridLayoutDispatch,
+  useGridModel,
+} from "../src";
+import { useGridLayoutDropHandler } from "../src/GridLayoutContext";
+
+const rect = {
+  bottom: 100,
+  height: 100,
+  left: 0,
+  right: 100,
+  toJSON: () => ({}),
+  top: 0,
+  width: 100,
+  x: 0,
+  y: 0,
+};
+
+const templateSource = (label: string): TemplateSource => ({
+  componentJson: JSON.stringify({
+    label,
+    props: { children: label },
+    type: "div",
+  }),
+  element: document.createElement("button"),
+  label,
+  layoutId: "stack-splitter-test",
+  type: "template",
+});
+
+const PaletteTransitionControls = ({
+  splitDirection,
+}: {
+  splitDirection: GridLayoutSplitDirection;
+}) => {
+  const drop = useGridLayoutDropHandler();
+  const dispatch = useGridLayoutDispatch();
+  const gridModel = useGridModel();
+
+  return (
+    <>
+      <button
+        data-testid="split-template"
+        onClick={() => drop("target", templateSource("Teal"), splitDirection)}
+        type="button"
+      >
+        Split
+      </button>
+      <button
+        data-testid="stack-template"
+        onClick={() => {
+          const teal = gridModel.childItems.find(
+            ({ title }) => title === "Teal",
+          );
+          if (!teal) {
+            throw Error("Teal palette item not found");
+          }
+          drop(teal.id, templateSource("Coral"), "header");
+        }}
+        type="button"
+      >
+        Stack
+      </button>
+      <button
+        data-testid="dissolve-stack"
+        onClick={() => {
+          const coral = gridModel.childItems.find(
+            ({ title }) => title === "Coral",
+          );
+          if (!coral) {
+            throw Error("Coral palette item not found");
+          }
+          dispatch({ id: coral.id, type: "close" });
+        }}
+        type="button"
+      >
+        Dissolve
+      </button>
+    </>
+  );
+};
+
+const StackSplitterFixture = ({
+  splitDirection,
+}: {
+  splitDirection: GridLayoutSplitDirection;
+}) => (
+  <GridLayoutProvider options={{ newChildItem: { header: true } }}>
+    <GridLayout
+      colsAndRows={{ cols: ["140px", "200px"], rows: ["200px"] }}
+      id="stack-splitter-test"
+      style={{ height: 320, width: 640 }}
+    >
+      <GridLayoutItem id="palette" style={{ gridArea: "1/1/2/2" }}>
+        <PaletteTransitionControls splitDirection={splitDirection} />
+      </GridLayoutItem>
+      <GridLayoutItem
+        data-drop-target
+        header
+        id="target"
+        resizeable="hv"
+        style={{ gridArea: "1/2/2/3" }}
+        title="Drop target"
+      >
+        <div>Drop target</div>
+      </GridLayoutItem>
+    </GridLayout>
+  </GridLayoutProvider>
+);
+
+const click = async (container: HTMLElement, testId: string) => {
+  const button = container.querySelector(`[data-testid="${testId}"]`);
+  if (!button) {
+    throw Error(`Button ${testId} not found`);
+  }
+  await act(async () =>
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true })),
+  );
+};
+
+const participants = (separator: HTMLElement) => ({
+  after: separator.dataset.resizedChildItemsAfter?.split(" ") ?? [],
+  before: separator.dataset.resizedChildItemsBefore?.split(" ") ?? [],
+});
+
+describe("GridLayout stack splitter lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let uuidSeed: number;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    uuidSeed = 10;
+    vi.spyOn(globalThis.crypto, "getRandomValues").mockImplementation(((
+      array: Uint8Array,
+    ) => {
+      array.fill(uuidSeed++);
+      return array;
+    }) as typeof globalThis.crypto.getRandomValues);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(
+      rect,
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it.each([
+    ["south", "horizontal"],
+    ["east", "vertical"],
+  ] as const)("projects the live stack into the %s palette splitter before resizing", async (splitDirection, ariaOrientation) => {
+    await act(async () => {
+      root.render(<StackSplitterFixture splitDirection={splitDirection} />);
+    });
+    await click(container, "split-template");
+
+    const teal = [
+      ...container.querySelectorAll<HTMLElement>(".vuuGridLayoutItem"),
+    ].find((item) => item.textContent?.includes("Teal"));
+    if (!teal) {
+      throw Error("Rendered Teal palette item not found");
+    }
+    const tealId = teal.id;
+    await click(container, "stack-template");
+
+    const stack = container.querySelector<HTMLElement>(
+      ".vuuGridLayoutStackedItem",
+    );
+    const separator = [
+      ...container.querySelectorAll<HTMLElement>(
+        `[role="separator"][aria-orientation="${ariaOrientation}"]`,
+      ),
+    ].find(
+      (candidate) => candidate.dataset.resizedChildItemsBefore === "target",
+    );
+    if (!stack || !separator) {
+      throw Error("Stacked splitter DOM was not rendered");
+    }
+
+    expect(participants(separator)).toEqual({
+      after: [stack.id],
+      before: ["target"],
+    });
+    expect(separator.getAttribute("aria-controls")).toBe(stack.id);
+    expect(participants(separator).after).not.toContain(tealId);
+    expect(container.querySelector(`[id="${stack.id}"]`)).toBe(stack);
+
+    const grid = container.querySelector<HTMLElement>("#stack-splitter-test");
+    const trackTemplateBefore =
+      ariaOrientation === "horizontal"
+        ? grid?.style.gridTemplateRows
+        : grid?.style.gridTemplateColumns;
+    await act(async () => {
+      separator.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          clientX: 50,
+          clientY: 50,
+        }),
+      );
+      document.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: ariaOrientation === "vertical" ? 40 : 50,
+          clientY: ariaOrientation === "horizontal" ? 40 : 50,
+        }),
+      );
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    });
+
+    const trackTemplateAfter =
+      ariaOrientation === "horizontal"
+        ? grid?.style.gridTemplateRows
+        : grid?.style.gridTemplateColumns;
+    expect(trackTemplateAfter).not.toBe(trackTemplateBefore);
+
+    await click(container, "dissolve-stack");
+    const dissolvedSeparator = [
+      ...container.querySelectorAll<HTMLElement>(
+        `[role="separator"][aria-orientation="${ariaOrientation}"]`,
+      ),
+    ].find(
+      (candidate) => candidate.dataset.resizedChildItemsBefore === "target",
+    );
+    expect(container.querySelector(".vuuGridLayoutStackedItem")).toBeNull();
+    expect(dissolvedSeparator).not.toBeNull();
+    expect(participants(dissolvedSeparator as HTMLElement).after).toEqual([
+      tealId,
+    ]);
+    expect(dissolvedSeparator?.getAttribute("aria-controls")).toBe(tealId);
+  });
+});


### PR DESCRIPTION
## Summary
- recompute both rendered splitter state and the imperative `GridLayoutModel` splitter cache when stack membership is created, changed, or dissolved
- expose splitter participant IDs on separator data attributes so mounted identity can be checked against rendered grid items
- add focused React DOM coverage for the real palette split-then-header-drop path in row and column orientations, including resize and stack dissolution

## Why #2379 was insufficient
#2379 correctly filtered `computeSplitters` to live placements, so a fresh computation uses the canonical stack container rather than its members. The palette header-drop runtime path did not request that fresh computation: `tabs-created` only mounted the stack component and `tabs-change` only forced a render. The existing separator React state and `GridLayoutModel.splitters` cache therefore survived with the pre-stack palette member ID.

On pointer down, `useGridSplitterResizing` read that stale cached splitter and attempted to resolve the old member in the mounted grid. The rendered live placement was the canonical stack container, producing the reported `GridItem not found` exception. This was stale projection/cache timing, not a stack-ID, placeholder, or selector mismatch.

## Regression distinction
The new DOM-level React test drives the actual template `onDrop` path: palette split, palette header drop, and splitter pointer events. On the merged #2379 code it fails because `resizedChildItems.after` and `aria-controls` retain the generated Teal member ID while the rendered placement has the generated stack ID. With this fix, participant IDs exactly match the rendered stack container, row/column geometry changes, and dissolving the stack recomputes the separator back to the surviving Teal ID. The existing Playwright scenario now asserts the same identity contract; its repository-wide gallery remains blocked by unrelated Showcase imports.

## Validation
- 191 targeted GridLayout Vitest tests passed; 2 existing todos
- focused React DOM regression passed in both south/horizontal and east/vertical cases
- Biome check passed for all changed files
- `@heswell/grid-layout` package build passed
- repository Playwright gallery remains blocked before mount by unrelated missing `UserSettingsPanel` and `feature-filter-table` Showcase imports