### PR TITLE
feat(grid-layout): render from controller snapshots

### DIFF
--- a/vuu-ui/packages/grid-layout/GridLayout.mdx
+++ b/vuu-ui/packages/grid-layout/GridLayout.mdx
@@ -1,3 +1,9 @@
 ### GridLayout
 
 `GridLayout` is a container component that manages the layout of nested child components. The `GridLayout` component used CSS Grid to manage the positioning of child components.
+
+### Controller snapshots
+
+`GridLayout` renders durable tracks, item placement, placeholders, and stack state from its `GridController` snapshot. React component content is retained separately and resolved by stable item ID.
+
+`useGridControllerSnapshot(controller)` is available for React integrations that need the controller's visible immutable snapshot. It uses React's external-store contract, suppresses revision-only transaction commit renders, and supports server rendering.

--- a/vuu-ui/packages/grid-layout/src/GridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayout.tsx
@@ -3,7 +3,12 @@ import { useIdMemo } from "@salt-ds/core";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
 import cx from "clsx";
-import type { CSSProperties, HTMLAttributes, ReactElement } from "react";
+import {
+  cloneElement,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactElement,
+} from "react";
 import { DragDropProviderNext } from "./drag-drop-next/DragDropProviderNext";
 import { getGridArea } from "./grid-layout-utils";
 import { GridLayoutContext } from "./GridLayoutContext";
@@ -78,15 +83,18 @@ export const GridLayout = ({
     children,
     containerCallback,
     dispatchGridLayoutAction,
+    gridController,
     gridLayoutModel,
     gridModel,
-    nonContentGridItems: { placeholders, splitters, stackedItems },
+    gridSnapshot,
+    nonContentGridItems: { placeholderIds, splitters, stackIds },
     onCancelTabDrag,
     onDetachTab,
     onDragEnd,
     onDragStart,
     onDrop,
     onDropStackedItem,
+    stackTemplates,
   } = useGridLayout({
     children: childrenProp,
     id,
@@ -97,6 +105,7 @@ export const GridLayout = ({
   const splitterLayoutProps = useGridSplitterResizing({
     gridLayoutModel,
     gridModel,
+    gridController,
     id,
     onClick,
     rowResizeDistribution,
@@ -105,16 +114,22 @@ export const GridLayout = ({
   // const splitterProps = useGridSplitter();
 
   const style = {
-    ...gridModel.tracks.css,
+    gridTemplateColumns: gridSnapshot.columns.map(({ size }) => size).join(" "),
+    gridTemplateRows: gridSnapshot.rows.map(({ size }) => size).join(" "),
     ...styleProp,
   } as CSSProperties;
+  const snapshotItemById = new Map(
+    gridSnapshot.items.map((item) => [item.id, item]),
+  );
 
   return (
     <GridLayoutContext.Provider
       value={{
         dispatchGridLayoutAction,
+        gridController,
         gridLayoutModel,
         gridModel,
+        gridSnapshot,
         id,
         onDragEnd,
         onDragStart,
@@ -137,25 +152,32 @@ export const GridLayout = ({
             vuuFullPage: fullPage,
           })}
         >
-          {stackedItems.map((stackedItem) => (
-            <GridLayoutStackedItem
-              id={stackedItem.id}
-              key={stackedItem.id}
-              style={{
-                gridArea: getGridArea(stackedItem),
-              }}
-            />
-          ))}
+          {stackIds.map((stackId) => {
+            const template = stackTemplates.get(stackId);
+            return template ? (
+              cloneElement(template, { key: stackId })
+            ) : (
+              <GridLayoutStackedItem id={stackId} key={stackId} />
+            );
+          })}
           {children}
-          {placeholders.map((placeholder) => (
-            <GridPlaceholder
-              id={placeholder.id}
-              key={placeholder.id}
-              style={{
-                gridArea: getGridArea(placeholder),
-              }}
-            />
-          ))}
+          {placeholderIds.map((placeholderId) => {
+            const placeholder = snapshotItemById.get(placeholderId);
+            if (!placeholder) {
+              throw Error(
+                `[GridLayout] canonical placeholder #${placeholderId} not found`,
+              );
+            }
+            return (
+              <GridPlaceholder
+                id={placeholderId}
+                key={placeholderId}
+                style={{
+                  gridArea: `${placeholder.row.start}/${placeholder.column.start}/${placeholder.row.start + placeholder.row.span}/${placeholder.column.start + placeholder.column.span}`,
+                }}
+              />
+            );
+          })}
           {splitters.map((splitter) => (
             <GridSplitter
               // {...splitterProps}

--- a/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
@@ -1,9 +1,16 @@
-import { createContext, Dispatch, DragEvent, useContext } from "react";
-import { GridLayoutDragEndHandler } from "./GridLayoutProvider";
-import { GridModel, TabStateTab, TrackSize } from "./GridModel";
-import { GridLayoutDragStartHandler } from "./useDraggable";
-import { GridLayoutModel } from "./GridLayoutModel";
-import { GridLayoutDropPosition } from "@vuu-ui/vuu-utils";
+import {
+  createContext,
+  type Dispatch,
+  type DragEvent,
+  useContext,
+} from "react";
+import type { GridLayoutDragEndHandler } from "./GridLayoutProvider";
+import type { GridModel, TabStateTab, TrackSize } from "./GridModel";
+import type { GridLayoutDragStartHandler } from "./useDraggable";
+import type { GridLayoutModel } from "./GridLayoutModel";
+import type { GridLayoutDropPosition } from "@vuu-ui/vuu-utils";
+import type { GridController } from "./GridController";
+import type { GridSnapshot } from "./GridSnapshot";
 
 export type GridLayoutActionType = "close";
 
@@ -160,8 +167,10 @@ export type GridLayoutDropHandler = (
 
 export interface GridLayoutContextProps {
   dispatchGridLayoutAction: GridLayoutDispatch;
+  gridController?: GridController;
   gridLayoutModel?: GridLayoutModel;
   gridModel?: GridModel;
+  gridSnapshot?: GridSnapshot;
   id: string;
   onDragEnd?: GridLayoutDragEndHandler;
   onDragStart: GridLayoutDragStartHandler;
@@ -204,6 +213,26 @@ export const useGridModel = () => {
       "[useGridModel] no gridModel, did you forget to use a GridLayout",
     );
   }
+};
+
+export const useGridController = () => {
+  const { gridController } = useContext(GridLayoutContext);
+  if (gridController) {
+    return gridController;
+  }
+  throw Error(
+    "[useGridController] no gridController, did you forget to use a GridLayout",
+  );
+};
+
+export const useGridSnapshot = () => {
+  const { gridSnapshot } = useContext(GridLayoutContext);
+  if (gridSnapshot) {
+    return gridSnapshot;
+  }
+  throw Error(
+    "[useGridSnapshot] no gridSnapshot, did you forget to use a GridLayout",
+  );
 };
 
 export const useGridLayoutId = () => {

--- a/vuu-ui/packages/grid-layout/src/GridLayoutStackedtem.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutStackedtem.tsx
@@ -1,10 +1,4 @@
-import {
-  TabBar,
-  TabList,
-  Tab,
-  TabTrigger,
-  Tabs,
-} from "@salt-ds/core";
+import { TabBar, TabList, Tab, TabTrigger, Tabs } from "@salt-ds/core";
 import { IconButton } from "@vuu-ui/vuu-ui-controls";
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
@@ -20,7 +14,7 @@ import { useDragContext } from "./drag-drop-next/DragDropProviderNext";
 import {
   type ComponentTemplate,
   useGridLayoutDispatch,
-  useGridModel,
+  useGridSnapshot,
 } from "./GridLayoutContext";
 import type { GridLayoutItemProps } from "./GridLayoutItem";
 import { resolveMinimumGridItemSize } from "./GridModel";
@@ -85,9 +79,13 @@ export const GridLayoutStackedItem = ({
     type: "stacked-content",
   });
 
-  const { getTabState } = useGridModel();
   const dispatch = useGridLayoutDispatch();
-  const tabState = getTabState(id, "create");
+  const snapshot = useGridSnapshot();
+  const stack = snapshot.stacks.find((candidate) => candidate.id === id);
+  if (!stack) {
+    throw Error(`[GridLayoutStackedItem] canonical stack #${id} not found`);
+  }
+  const itemById = new Map(snapshot.items.map((item) => [item.id, item]));
 
   const handleTabSelectionChange = useCallback(
     (_: SyntheticEvent | null, value: string) => {
@@ -129,32 +127,36 @@ export const GridLayoutStackedItem = ({
         key={id}
         style={style}
       >
-        <Tabs
-          onChange={handleTabSelectionChange}
-          value={tabState.tabs[tabState.active]?.id ?? null}
-        >
+        <Tabs onChange={handleTabSelectionChange} value={stack.selectedItemId}>
           <TabBar divider>
             <TabList
               appearance="transparent"
               className="vuuDragContainer"
               id={tabsId}
             >
-              {tabState.tabs.map(({ id: gridLayoutItemId, label }, index) => (
-                <Tab
-                  className="vuuDraggableItem"
-                  data-index={index}
-                  data-grid-layout-item-id={gridLayoutItemId}
-                  data-label={label}
-                  draggable
-                  value={gridLayoutItemId}
-                  key={gridLayoutItemId}
-                >
-                  <TabTrigger>{label}</TabTrigger>
-                  {showMenu ? (
-                    <TabMenu layoutItemId={gridLayoutItemId} tabLabel={label} />
-                  ) : null}
-                </Tab>
-              ))}
+              {stack.itemIds.map((gridLayoutItemId, index) => {
+                const label =
+                  itemById.get(gridLayoutItemId)?.title ?? gridLayoutItemId;
+                return (
+                  <Tab
+                    className="vuuDraggableItem"
+                    data-index={index}
+                    data-grid-layout-item-id={gridLayoutItemId}
+                    data-label={label}
+                    draggable
+                    value={gridLayoutItemId}
+                    key={gridLayoutItemId}
+                  >
+                    <TabTrigger>{label}</TabTrigger>
+                    {showMenu ? (
+                      <TabMenu
+                        layoutItemId={gridLayoutItemId}
+                        tabLabel={label}
+                      />
+                    ) : null}
+                  </Tab>
+                );
+              })}
             </TabList>
             {allowAddTab ? (
               <IconButton

--- a/vuu-ui/packages/grid-layout/src/index.ts
+++ b/vuu-ui/packages/grid-layout/src/index.ts
@@ -31,11 +31,14 @@ export {
 export {
   useGridLayoutDispatch,
   useGridLayoutDragStartHandler,
+  useGridController,
   useGridModel,
+  useGridSnapshot,
   type ComponentTemplate,
   type DragSource,
   type TemplateSource,
 } from "./GridLayoutContext";
+export { useGridControllerSnapshot } from "./useGridControllerSnapshot";
 export { GridLayoutItem } from "./GridLayoutItem";
 export {
   GridLayoutProvider,

--- a/vuu-ui/packages/grid-layout/src/useGridChildProps.ts
+++ b/vuu-ui/packages/grid-layout/src/useGridChildProps.ts
@@ -1,63 +1,63 @@
-import { useContext } from "react";
-import { GridModelChildItem, GridModelChildItemProps } from "./GridModel";
+import type { GridModelChildItemProps } from "./GridModel";
 import { GridLayoutContext } from "./GridLayoutContext";
 import { getGridPosition } from "./grid-layout-utils";
+import { useContext } from "react";
 
-export const useGridChildProps = ({
-  contentVisible,
-  dropTarget,
-  header,
-  height,
-  id,
-  minHeight,
-  minWidth,
-  stackId,
-  resizeable,
-  style,
-  title,
-  type = "content",
-  width,
-
-  // no need to store gridStyle separately, we already have it in childItem row, column
-}: GridModelChildItemProps) => {
-  const { gridModel } = useContext(GridLayoutContext);
-
-  let childItem = gridModel?.getChildItem(id);
-  if (childItem) {
-    // console.log(`already registered child item ${id}`);
-  } else {
-    const { column, row } = getGridPosition(style?.gridArea ?? "1/1/2/2");
-    childItem = new GridModelChildItem({
-      contentVisible,
-      dropTarget,
-      header,
-      height,
-      id,
-      column,
-      fixed: false,
-      minHeight,
-      minWidth,
-      stackId,
-      resizeable,
-      row,
-      title,
-      type,
-      width,
-    });
-
-    gridModel?.addChildItem(childItem);
-  }
+export const useGridChildProps = (props: GridModelChildItemProps) => {
+  const { contentVisible, dropTarget, header, id, stackId, style, title } =
+    props;
+  const { gridModel, gridSnapshot } = useContext(GridLayoutContext);
+  const snapshotItem = gridSnapshot?.items.find((item) => item.id === id);
+  const stack =
+    gridSnapshot?.stacks.find(
+      ({ id: snapshotStackId }) => snapshotStackId === id,
+    ) ?? gridSnapshot?.stacks.find(({ itemIds }) => itemIds.includes(id));
+  const modelItem = gridModel?.getChildItem(id);
+  const fallbackPosition = getGridPosition(style?.gridArea ?? "1/1/2/2");
+  const position = snapshotItem
+    ? {
+        column: {
+          end: snapshotItem.column.start + snapshotItem.column.span,
+          start: snapshotItem.column.start,
+        },
+        row: {
+          end: snapshotItem.row.start + snapshotItem.row.span,
+          start: snapshotItem.row.start,
+        },
+      }
+    : stack
+      ? (() => {
+          const firstMember = gridSnapshot?.items.find(
+            ({ id: itemId }) => itemId === stack.itemIds[0],
+          );
+          return firstMember
+            ? {
+                column: {
+                  end: firstMember.column.start + firstMember.column.span,
+                  start: firstMember.column.start,
+                },
+                row: {
+                  end: firstMember.row.start + firstMember.row.span,
+                  start: firstMember.row.start,
+                },
+              }
+            : fallbackPosition;
+        })()
+      : fallbackPosition;
+  const isStackMember = stack !== undefined && stack.id !== id;
 
   return {
-    contentDetached: childItem.contentDetached,
-    contentVisible: childItem.contentVisible,
-    dragging: childItem.dragging,
-    dropTarget: childItem.dropTarget,
-    gridArea: childItem.gridArea,
-    header: childItem.header,
-    horizontalSplitter: childItem.horizontalSplitter,
-    stacked: childItem.stackId !== undefined,
-    title: childItem.title,
-    verticalSplitter: childItem.verticalSplitter,
+    contentDetached: modelItem?.contentDetached,
+    contentVisible: isStackMember
+      ? stack?.selectedItemId === id
+      : (snapshotItem?.contentVisible ?? contentVisible),
+    dragging: modelItem?.dragging,
+    dropTarget: snapshotItem?.dropTarget ?? dropTarget,
+    gridArea: `${position.row.start}/${position.column.start}/${position.row.end}/${position.column.end}`,
+    header: snapshotItem?.header ?? header,
+    horizontalSplitter: modelItem?.horizontalSplitter,
+    stacked: isStackMember || stackId !== undefined,
+    title: snapshotItem?.title ?? title,
+    verticalSplitter: modelItem?.verticalSplitter,
   };
 };

--- a/vuu-ui/packages/grid-layout/src/useGridControllerSnapshot.ts
+++ b/vuu-ui/packages/grid-layout/src/useGridControllerSnapshot.ts
@@ -1,0 +1,34 @@
+import { useCallback, useSyncExternalStore } from "react";
+import type { GridController } from "./GridController";
+import type { GridSnapshot } from "./GridSnapshot";
+
+const visibleSnapshots = new WeakMap<
+  GridController,
+  { signature: string; snapshot: GridSnapshot }
+>();
+
+const getVisibleSnapshot = (controller: GridController) => {
+  const snapshot = controller.getSnapshot();
+  const { revision: _revision, ...visibleState } = snapshot;
+  const signature = JSON.stringify(visibleState);
+  const cached = visibleSnapshots.get(controller);
+  if (cached?.signature === signature) {
+    return cached.snapshot;
+  }
+  visibleSnapshots.set(controller, { signature, snapshot });
+  return snapshot;
+};
+
+/**
+ * Subscribe React to the canonical snapshot owned by a GridController.
+ * Revision-only transaction commits preserve the visible snapshot identity.
+ */
+export const useGridControllerSnapshot = (
+  controller: GridController,
+): GridSnapshot => {
+  const getSnapshot = useCallback(
+    () => getVisibleSnapshot(controller),
+    [controller],
+  );
+  return useSyncExternalStore(controller.subscribe, getSnapshot, getSnapshot);
+};

--- a/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
@@ -6,75 +6,72 @@ import {
   uuid,
 } from "@vuu-ui/vuu-utils";
 import {
-  ReactElement,
-  ReactNode,
-  RefCallback,
-  SetStateAction,
+  type ReactElement,
+  type ReactNode,
+  type RefCallback,
+  type SetStateAction,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import {
+import type {
   DragContextCancelTabDragHandler,
   DragContextDetachTabHandler,
   DragContextDropHandler,
 } from "./drag-drop-next/DragContextNext";
 import { layoutFromJson } from "./layoutFromJson";
-import {
-  getClosestGridLayout,
-  setGridColumn,
-  setGridRow,
-} from "./grid-dom-utils";
+import { getClosestGridLayout } from "./grid-dom-utils";
 import {
   getActiveIndex,
   getGridArea,
   getSharedGridPosition,
 } from "./grid-layout-utils";
 import {
-  GridLayoutDispatch,
-  GridLayoutDropHandler,
+  type GridLayoutDispatch,
+  type GridLayoutDropHandler,
   sourceIsComponent,
   sourceIsTabbedComponent,
   sourceIsTemplate,
-  useGridLayoutId,
 } from "./GridLayoutContext";
-import { GridLayoutItem, GridLayoutItemProps } from "./GridLayoutItem";
-import { GridItemRemoveReason, GridLayoutModel } from "./GridLayoutModel";
 import {
-  GridLayoutDragEndHandler,
+  GridLayoutItem,
+  type GridLayoutItemProps,
+  isGridLayoutItem,
+} from "./GridLayoutItem";
+import { type GridItemRemoveReason, GridLayoutModel } from "./GridLayoutModel";
+import {
+  type GridLayoutDragEndHandler,
   useGridChangeHandler,
   useGridLayoutOptions,
   useSavedGrid,
 } from "./GridLayoutProvider";
 import {
-  GridChildPositionChangeHandler,
-  GridColumnsAndRows,
-  GridLayoutChangeHandler,
-  GridLayoutDescriptor,
+  type GridColumnsAndRows,
+  type GridLayoutChangeHandler,
+  type GridLayoutDescriptor,
   GridModel,
   GridModelChildItem,
-  GridTrackResizeHandler,
-  ISplitter,
+  type ISplitter,
   isStackedItem,
-  NonContentResetOptions,
-  TabsChangeHandler,
-  TabSelectionChangeHandler,
 } from "./GridModel";
 import {
   addChildToStackedGridItem,
   getGridItemChild,
 } from "./react-element-utils";
-import { GridLayoutDragStartHandler } from "./useDraggable";
-import { LayoutJSON } from "./componentToJson";
+import type { GridLayoutDragStartHandler } from "./useDraggable";
+import type { LayoutJSON } from "./componentToJson";
 import {
   GridCommandExecutionError,
   LegacyGridCommandExecutor,
   throwForGridCommandFailure,
 } from "./GridCommand";
 import { GridController } from "./GridController";
+import type { GridTransaction } from "./GridController";
+import { gridSnapshotToGridLayoutDescriptor } from "./grid-snapshot-adapters";
+import { isGridLayoutStackedItem } from "./GridLayoutStackedtem";
+import { useGridControllerSnapshot } from "./useGridControllerSnapshot";
 
 export type GridLayoutHookProps = {
   children: ReactNode;
@@ -87,8 +84,57 @@ type GridLayoutItemElements = Array<ReactElement<GridLayoutItemProps>>;
 
 type NonContentGridItems = {
   splitters: ISplitter[];
-  placeholders: GridModelChildItem[];
-  stackedItems: GridModelChildItem[];
+  placeholderIds: string[];
+  stackIds: string[];
+};
+
+const layoutDescriptorFromChildren = (
+  colsAndRows: GridColumnsAndRows,
+  children: GridLayoutItemElements,
+): GridLayoutDescriptor => {
+  const stackTemplates = new Map(
+    children
+      .filter(isGridLayoutStackedItem)
+      .map((element) => [element.props.id, element.props]),
+  );
+  return {
+    ...colsAndRows,
+    gridLayoutItems: Object.fromEntries(
+      children.filter(isGridLayoutItem).map(({ props }) => {
+        const {
+          contentVisible,
+          "data-drop-target": dropTarget,
+          header,
+          id,
+          minHeight,
+          minWidth,
+          resizeable,
+          stackId,
+          style,
+          title,
+        } = props;
+        const stackTemplate = stackId ? stackTemplates.get(stackId) : undefined;
+        const gridArea = style?.gridArea ?? stackTemplate?.style?.gridArea;
+        if (!gridArea) {
+          throw Error(`[useGridLayout] GridLayoutItem #${id} has no gridArea`);
+        }
+        return [
+          id,
+          {
+            contentVisible,
+            dropTarget,
+            gridArea,
+            header,
+            minHeight: minHeight ?? stackTemplate?.minHeight,
+            minWidth: minWidth ?? stackTemplate?.minWidth,
+            resizeable: resizeable ?? stackTemplate?.resizeable,
+            stackId,
+            title,
+          },
+        ];
+      }),
+    ),
+  };
 };
 
 const assertNeverGridLayoutAction = (action: never): never => {
@@ -116,10 +162,7 @@ export const useGridLayout = ({
   const { onChangeChildElements, onChangeLayout } = useGridChangeHandler();
   const layoutOptions = useGridLayoutOptions();
 
-  const layoutId = useGridLayoutId();
   const getSavedGrid = useSavedGrid();
-
-  const [, forceRender] = useState({});
 
   /**
    * Construct the initial set of child elements and the GridLayoutDescriptor
@@ -134,11 +177,13 @@ export const useGridLayout = ({
       const { components: savedChildren, layout: savedLayout } = savedGrid;
       return [Object.values(savedChildren), savedLayout];
     } else if (colsAndRows) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const reactElements = asReactElements(childrenProp) as any;
-      const layoutDescriptor = {
-        ...colsAndRows,
-      };
+      const reactElements = asReactElements(
+        childrenProp,
+      ) as GridLayoutItemElements;
+      const layoutDescriptor = layoutDescriptorFromChildren(
+        colsAndRows,
+        reactElements,
+      );
 
       return [reactElements, layoutDescriptor];
     } else {
@@ -151,7 +196,9 @@ export const useGridLayout = ({
   // Note we initialise this ref with the initial children from props. We subsequently
   // only update it in response to manipulation of the GridLayout NOT in case of the
   // children prop changing.
-  const childrenRef = useRef<GridLayoutItemElements>(children);
+  const [childElements, setChildElements] =
+    useState<GridLayoutItemElements>(children);
+  const childrenRef = useRef<GridLayoutItemElements>(childElements);
 
   const setChildren = useCallback(
     (
@@ -166,19 +213,11 @@ export const useGridLayout = ({
         childrenRef.current = newChildren(prev);
       }
 
-      onChangeChildElements?.(id, childrenRef.current);
-
-      forceRender({});
+      setChildElements(childrenRef.current);
+      onChangeChildElements?.(id, childrenRef.current.filter(isGridLayoutItem));
     },
     [id, onChangeChildElements],
   );
-
-  const [nonContentGridItems, setNonContentGridItems] =
-    useState<NonContentGridItems>({
-      splitters: [],
-      placeholders: [],
-      stackedItems: [],
-    });
 
   const [gridModel, gridLayoutModel, containerCallback] = useMemo(
     // TODO handling runtime change of cols, rows etc currently not supported
@@ -188,6 +227,28 @@ export const useGridLayout = ({
       //   "color: green",
       // );
       const gridModel = new GridModel(id, layout);
+      for (const [stackId, items] of gridModel.getStackedChildItems()) {
+        if (gridModel.getChildItem(stackId) === undefined) {
+          const { column, row } = getSharedGridPosition(items);
+          const stackTemplate = children.find(
+            (element) =>
+              isGridLayoutStackedItem(element) && element.props.id === stackId,
+          );
+          gridModel.setTabState(stackId, items, getActiveIndex(items));
+          gridModel.addChildItem(
+            new GridModelChildItem({
+              column,
+              id: stackId,
+              minHeight: stackTemplate?.props.minHeight,
+              minWidth: stackTemplate?.props.minWidth,
+              resizeable: stackTemplate?.props.resizeable,
+              row,
+              type: "stacked-content",
+            }),
+          );
+        }
+      }
+      gridModel.createPlaceholders();
       const gridLayoutModel = new GridLayoutModel(gridModel);
       const callbackRef: RefCallback<HTMLDivElement> = (el) => {
         if (el) {
@@ -197,11 +258,12 @@ export const useGridLayout = ({
 
       return [gridModel, gridLayoutModel, callbackRef];
     },
-    [id, layout],
+    [children, id, layout],
   );
   const dragStartLayoutRef = useRef<GridLayoutDescriptor | undefined>(
     undefined,
   );
+  const dragTransactionRef = useRef<GridTransaction | undefined>(undefined);
   const gridController = useMemo(
     () =>
       new GridController(
@@ -211,6 +273,81 @@ export const useGridLayout = ({
       ),
     [gridLayoutModel, gridModel],
   );
+  const snapshot = useGridControllerSnapshot(gridController);
+  const beginLegacyDragTransaction = useCallback(() => {
+    if (dragTransactionRef.current) {
+      return dragTransactionRef.current;
+    }
+    const result = gridController.beginTransaction("drag");
+    if (!result.ok) {
+      throw Error(result.error.message);
+    }
+    dragTransactionRef.current = result.transaction;
+    return result.transaction;
+  }, [gridController]);
+  const publishLegacyDragMutation = useCallback(() => {
+    const transaction = dragTransactionRef.current;
+    const result = transaction
+      ? transaction.dispatch({ type: "regenerate-placeholders" })
+      : gridController.dispatch({ type: "regenerate-placeholders" });
+    throwForGridCommandFailure(result);
+  }, [gridController]);
+  const commitLegacyDragTransaction = useCallback(() => {
+    const transaction = dragTransactionRef.current;
+    if (transaction) {
+      const result = transaction.commit();
+      if (!result.ok) {
+        throw Error(result.error.message);
+      }
+      dragTransactionRef.current = undefined;
+    }
+  }, []);
+  const rollbackLegacyDragTransaction = useCallback(() => {
+    const transaction = dragTransactionRef.current;
+    if (transaction) {
+      const result = transaction.rollback();
+      if (!result.ok) {
+        throw Error(result.error.message);
+      }
+      dragTransactionRef.current = undefined;
+    }
+  }, []);
+  const contentIds = useMemo(
+    () =>
+      new Set(
+        childElements.filter(isGridLayoutItem).map(({ props: { id } }) => id),
+      ),
+    [childElements],
+  );
+  const stackTemplates = useMemo(
+    () =>
+      new Map(
+        childElements
+          .filter(isGridLayoutStackedItem)
+          .map((element) => [element.props.id, element]),
+      ),
+    [childElements],
+  );
+  const renderedChildren = useMemo(
+    () =>
+      snapshot.items.flatMap(({ id: itemId }) => {
+        const element = childElements.find(
+          ({ props: { id: elementId } }) => elementId === itemId,
+        );
+        return element ? [element] : [];
+      }),
+    [childElements, snapshot],
+  );
+  const nonContentGridItems = useMemo<NonContentGridItems>(
+    () => ({
+      placeholderIds: snapshot.items
+        .filter(({ id: itemId }) => !contentIds.has(itemId))
+        .map(({ id: itemId }) => itemId),
+      splitters: gridLayoutModel.createSplitters(),
+      stackIds: snapshot.stacks.map(({ id: stackId }) => stackId),
+    }),
+    [contentIds, gridLayoutModel, snapshot],
+  );
 
   const saveGridLayout = useCallback<GridLayoutChangeHandler>(
     (id, gridLayout) => {
@@ -218,29 +355,6 @@ export const useGridLayout = ({
       onChangeLayout?.(id, gridLayout);
     },
     [onChangeLayout, onChange],
-  );
-
-  const updateGridChildItems = useCallback<GridChildPositionChangeHandler>(
-    (updates, { placeholders, splitters } = NonContentResetOptions) => {
-      updates.forEach(([id, { column: columnPosition, row: rowPosition }]) => {
-        if (columnPosition) {
-          setGridColumn(id, columnPosition);
-        }
-        if (rowPosition) {
-          setGridRow(id, rowPosition);
-        }
-      });
-
-      if (splitters) {
-        const splitters = gridLayoutModel.createSplitters();
-        setNonContentGridItems((items) => ({ ...items, splitters }));
-      }
-      if (placeholders) {
-        const placeholders = gridModel.getPlaceholders();
-        setNonContentGridItems((items) => ({ ...items, placeholders }));
-      }
-    },
-    [gridLayoutModel, gridModel],
   );
 
   const removeGridItem = useCallback(
@@ -260,22 +374,29 @@ export const useGridLayout = ({
   );
 
   const handleDragStart = useCallback<GridLayoutDragStartHandler>(
-    (evt, options) => {
+    (_evt, options) => {
       const { current: grid } = containerRef;
       if (grid) {
         if (options.type === "text/plain") {
           dragStartLayoutRef.current = gridModel.toGridLayoutDescriptor();
+          beginLegacyDragTransaction();
         }
         requestAnimationFrame(() => {
           grid.classList.add("vuuDragging");
           //TODO make this check more explicit
           if (options.type === "text/plain") {
             removeGridItem(options.id, "drag");
+            publishLegacyDragMutation();
           }
         });
       }
     },
-    [gridModel, removeGridItem],
+    [
+      beginLegacyDragTransaction,
+      gridModel,
+      publishLegacyDragMutation,
+      removeGridItem,
+    ],
   );
 
   const handleDragEnd = useCallback<GridLayoutDragEndHandler>(
@@ -283,15 +404,13 @@ export const useGridLayout = ({
       containerRef.current?.classList.remove("vuuDragging");
       if (!dropped && dragStartLayoutRef.current) {
         gridModel.restoreLayout(dragStartLayoutRef.current);
-        setNonContentGridItems((items) => ({
-          ...items,
-          placeholders: gridModel.getPlaceholders(),
-          splitters: gridLayoutModel.createSplitters(),
-        }));
+        rollbackLegacyDragTransaction();
+      } else if (dropped) {
+        commitLegacyDragTransaction();
       }
       dragStartLayoutRef.current = undefined;
     },
-    [gridLayoutModel, gridModel],
+    [commitLegacyDragTransaction, gridModel, rollbackLegacyDragTransaction],
   );
 
   const addChildComponent = useCallback(
@@ -309,8 +428,7 @@ export const useGridLayout = ({
         const newChild = addChildToStackedGridItem(
           stackedGridItem,
           component,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ) as any;
+        ) as ReactElement<GridLayoutItemProps>;
         setChildren((c) =>
           c.map((child) => (child.props.id === id ? newChild : child)),
         );
@@ -395,11 +513,7 @@ export const useGridLayout = ({
         if (sourceIsComponent(dragSource) && dragStartLayoutRef.current) {
           gridModel.restoreLayout(dragStartLayoutRef.current);
           dragStartLayoutRef.current = undefined;
-          setNonContentGridItems((items) => ({
-            ...items,
-            placeholders: gridModel.getPlaceholders(),
-            splitters: gridLayoutModel.createSplitters(),
-          }));
+          rollbackLegacyDragTransaction();
         }
         return false;
       }
@@ -419,22 +533,8 @@ export const useGridLayout = ({
 
         if (isGridLayoutSplitDirection(position)) {
           gridLayoutModel.dropSplitGridItem(droppedItemId, targetId, position);
-
-          const placeholders = gridModel.getPlaceholders();
-          const splitters = gridLayoutModel.createSplitters();
-          setNonContentGridItems(({ stackedItems }) => ({
-            placeholders,
-            splitters,
-            stackedItems,
-          }));
         } else if (position === "centre") {
-          const { column, row } = gridLayoutModel.dropReplaceGridItem(
-            droppedItemId,
-            targetItemId,
-          );
-          setGridColumn(droppedItemId, column);
-          setGridRow(droppedItemId, row);
-
+          gridLayoutModel.dropReplaceGridItem(droppedItemId, targetItemId);
           setChildren((c) =>
             c.filter((child) => child.props.id !== targetItemId),
           );
@@ -447,7 +547,6 @@ export const useGridLayout = ({
             );
           }
           gridModel.selectStackItem(stackId, droppedItemId);
-          gridModel.notifyChange();
         }
       } else if (sourceIsTabbedComponent(dragSource)) {
         // We are dropping a component dragged from a tabstrip and dropping it into
@@ -482,14 +581,6 @@ export const useGridLayout = ({
         if (!removed.ok) {
           throw Error(removed.error.message);
         }
-
-        const placeholders = gridModel.getPlaceholders();
-        const splitters = gridLayoutModel.createSplitters();
-        setNonContentGridItems(({ stackedItems }) => ({
-          placeholders,
-          splitters,
-          stackedItems,
-        }));
       } else if (sourceIsTemplate(dragSource)) {
         // dragging from palette or similar
         const { label = "New Item", ...restJSON } = JSON.parse(
@@ -519,7 +610,6 @@ export const useGridLayout = ({
             targetItemId,
           );
           replaceChildComponent(targetItemId, component, newGridItem);
-          gridModel.notifyChange();
         } else if (position === "header") {
           gridModel.stackChildItems(targetItemId, newChildId);
           const stackId = gridModel.getChildItem(newChildId, true).stackId;
@@ -530,7 +620,6 @@ export const useGridLayout = ({
           }
           gridModel.selectStackItem(stackId, newChildId);
           addChildComponent(component, gridModelChildItem);
-          gridModel.notifyChange();
         } else {
           gridLayoutModel.dropSplitGridItem(
             gridModelChildItem.id,
@@ -538,21 +627,26 @@ export const useGridLayout = ({
             position,
           );
           addChildComponent(component, gridModelChildItem);
-          gridModel.notifyChange();
         }
       } else {
         throw Error(
           `[useGridLayout#${id}] unsupported drag source type for GridLayout drop`,
         );
       }
+      publishLegacyDragMutation();
+      commitLegacyDragTransaction();
       return true;
     },
     [
       addChildComponent,
       gridLayoutModel,
       gridModel,
+      id,
       layoutOptions?.newChildItem.header,
+      commitLegacyDragTransaction,
+      publishLegacyDragMutation,
       replaceChildComponent,
+      rollbackLegacyDragTransaction,
       setChildren,
     ],
   );
@@ -560,19 +654,21 @@ export const useGridLayout = ({
   const handleDetachTab = useCallback<DragContextDetachTabHandler>(
     ({ gridId, tabsId, value }) => {
       if (gridId === id) {
+        beginLegacyDragTransaction();
         gridModel.detachTab(tabsId, value);
+        publishLegacyDragMutation();
       }
     },
-    [gridModel, id],
+    [beginLegacyDragTransaction, gridModel, id, publishLegacyDragMutation],
   );
 
   const handleCancelTabDrag = useCallback<DragContextCancelTabDragHandler>(
-    ({ gridId, tabsId, value }) => {
+    ({ gridId }) => {
       if (gridId === id) {
-        gridModel.restoreDetachedTab(tabsId, value);
+        rollbackLegacyDragTransaction();
       }
     },
-    [gridModel, id],
+    [id, rollbackLegacyDragTransaction],
   );
 
   const handleDropStackedItem = useCallback<DragContextDropHandler>(
@@ -655,7 +751,6 @@ export const useGridLayout = ({
 
             const component = layoutFromJson(restJSON as LayoutJSON);
             addChildComponent(component, gridModelChildItem);
-            gridModel.notifyChange();
           }
         }
       } else {
@@ -663,43 +758,18 @@ export const useGridLayout = ({
           "[useGridLayout] handleDropStackedItem no details of the stacked drop target",
         );
       }
+      publishLegacyDragMutation();
+      commitLegacyDragTransaction();
     },
-    [addChildComponent, gridModel, id, layoutOptions?.newChildItem.header],
+    [
+      addChildComponent,
+      commitLegacyDragTransaction,
+      gridModel,
+      id,
+      layoutOptions?.newChildItem.header,
+      publishLegacyDragMutation,
+    ],
   );
-
-  const handleTabsChange = useCallback<TabsChangeHandler>(() => {
-    const splitters = gridLayoutModel.createSplitters();
-    setNonContentGridItems((items) => ({ ...items, splitters }));
-  }, [gridLayoutModel]);
-
-  const handleTabsCreated = useCallback(
-    (stackItem: GridModelChildItem) => {
-      const splitters = gridLayoutModel.createSplitters();
-      setNonContentGridItems(({ stackedItems, ...rest }) => ({
-        ...rest,
-        splitters,
-        stackedItems: stackedItems.concat(stackItem),
-      }));
-    },
-    [gridLayoutModel],
-  );
-
-  const handleTabsRemoved = useCallback(
-    (stackId: string) => {
-      const splitters = gridLayoutModel.createSplitters();
-      setNonContentGridItems(({ stackedItems, ...rest }) => ({
-        ...rest,
-        splitters,
-        stackedItems: stackedItems.filter(({ id }) => id !== stackId),
-      }));
-    },
-    [gridLayoutModel],
-  );
-
-  const handleTabSelectionChange =
-    useCallback<TabSelectionChangeHandler>(() => {
-      forceRender({});
-    }, []);
 
   const dispatchGridLayoutAction = useCallback<GridLayoutDispatch>(
     (action) => {
@@ -767,7 +837,6 @@ export const useGridLayout = ({
                 type: "select-stack-item",
               }),
             );
-            gridModel.notifyChange();
           }
           break;
         case "resize-grid-column":
@@ -818,82 +887,21 @@ export const useGridLayout = ({
     ],
   );
 
-  const handleTrackResize = useCallback<GridTrackResizeHandler>(
-    (trackType, tracks) => {
-      if (containerRef.current) {
-        if (trackType === "column") {
-          containerRef.current.style.gridTemplateColumns = tracks.join(" ");
-        } else {
-          containerRef.current.style.gridTemplateRows = tracks.join(" ");
-        }
-      }
-    },
-    [],
-  );
-
-  useLayoutEffect(() => {
-    /*
-     * Initialise Splitters, Placeholders and UI controls for sets of stacked items.
-     * Initially, stacked items will always use tabs.
-     */
-    const stackedItems: GridModelChildItem[] = [];
-    for (const [stackId, items] of gridModel.getStackedChildItems()) {
-      const tabs = gridModel.getChildItem(stackId);
-      if (tabs === undefined) {
-        const { column, row } = getSharedGridPosition(items);
-        const activeIndex = getActiveIndex(items);
-        gridModel.setTabState(stackId, items, activeIndex);
-        const stackedItem = new GridModelChildItem({
-          column,
-          id: stackId,
-          row,
-          type: "stacked-content",
-        });
-        gridModel?.addChildItem(stackedItem);
-        stackedItems.push(stackedItem);
-      }
-    }
-
-    gridModel.createPlaceholders();
-    const splitters = gridLayoutModel.createSplitters();
-    const placeholders = gridModel.getPlaceholders();
-    setNonContentGridItems({ placeholders, splitters, stackedItems });
-  }, [gridModel, gridLayoutModel]);
-
   useEffect(() => {
-    gridModel.addListener("grid-layout-change", saveGridLayout);
-    gridModel.addListener("child-position-updates", updateGridChildItems);
-    gridModel.addListener("tab-selection-change", handleTabSelectionChange);
-    gridModel.addListener("tabs-change", handleTabsChange);
-    gridModel.addListener("tabs-created", handleTabsCreated);
-    gridModel.addListener("tabs-removed", handleTabsRemoved);
-
-    gridModel.tracks.on("grid-track-resize", handleTrackResize);
-
-    gridLayoutModel.addListener("child-position-updates", updateGridChildItems);
-
-    return () => {
-      gridModel.removeAllListeners();
-    };
-  }, [
-    gridLayoutModel,
-    gridModel,
-    handleTabsChange,
-    handleTabSelectionChange,
-    saveGridLayout,
-    updateGridChildItems,
-    handleTabsCreated,
-    handleTabsRemoved,
-    handleTrackResize,
-  ]);
+    return gridController.subscribeCommitted(({ snapshot }) => {
+      saveGridLayout(id, gridSnapshotToGridLayoutDescriptor(snapshot));
+    });
+  }, [gridController, id, saveGridLayout]);
 
   return {
-    children: childrenRef.current,
+    children: renderedChildren,
     containerCallback,
     containerRef,
     dispatchGridLayoutAction,
+    gridController,
     gridLayoutModel,
     gridModel,
+    gridSnapshot: snapshot,
     nonContentGridItems,
     onCancelTabDrag: handleCancelTabDrag,
     onDetachTab: handleDetachTab,
@@ -901,5 +909,6 @@ export const useGridLayout = ({
     onDragStart: handleDragStart,
     onDrop: handleDrop,
     onDropStackedItem: handleDropStackedItem,
+    stackTemplates,
   };
 };

--- a/vuu-ui/packages/grid-layout/src/useGridSplitterResizing.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridSplitterResizing.tsx
@@ -1,4 +1,4 @@
-import { type MouseEventHandler, useCallback, useRef } from "react";
+import { type MouseEventHandler, useCallback, useEffect, useRef } from "react";
 import {
   classNameLayoutItem,
   getGridLayoutItem,
@@ -17,16 +17,20 @@ import {
   type GridTrackResizeConstraint,
 } from "./GridModel";
 import { queryClosest } from "@vuu-ui/vuu-utils";
+import type { GridController, GridTransaction } from "./GridController";
+import { throwForGridCommandFailure } from "./GridCommand";
 
 export type SplitterResizingHookProps = Pick<
   GridLayoutProps,
   "id" | "onClick" | "rowResizeDistribution"
 > & {
+  gridController: GridController;
   gridLayoutModel: GridLayoutModel;
   gridModel: GridModel;
 };
 
 export const useGridSplitterResizing = ({
+  gridController,
   gridLayoutModel: layoutModel,
   gridModel,
   onClick: onClickProp,
@@ -34,6 +38,7 @@ export const useGridSplitterResizing = ({
 }: SplitterResizingHookProps) => {
   const resizingState = useRef<ResizeState | undefined>(undefined);
   const splitterRef = useRef<HTMLElement>(undefined);
+  const transactionRef = useRef<GridTransaction | undefined>(undefined);
 
   const getResizeAllowance = useCallback(
     (
@@ -301,6 +306,12 @@ export const useGridSplitterResizing = ({
               createNewTrackForResize(moveBy);
             }
             moveSplitter(moveBy);
+            const transaction = transactionRef.current;
+            if (transaction) {
+              throwForGridCommandFailure(
+                transaction.dispatch({ type: "regenerate-placeholders" }),
+              );
+            }
           }
         }
       }
@@ -317,9 +328,16 @@ export const useGridSplitterResizing = ({
       splitterRef.current = undefined;
     }
 
-    // TODO make sure a resize has actually taken place
-    gridModel.notifyChange();
-  }, [gridModel, mouseMove]);
+    const transaction = transactionRef.current;
+    if (transaction) {
+      const result = transaction.commit();
+      if (!result.ok) {
+        throw Error(result.error.message);
+      }
+      transactionRef.current = undefined;
+    }
+    resizingState.current = undefined;
+  }, [mouseMove]);
 
   // TODO need to identify the expanding track and the contracting track
   // these may not necessarily be adjacent, when resizeable attribute of
@@ -334,6 +352,11 @@ export const useGridSplitterResizing = ({
       const gridLayout = queryClosest(splitterElement, ".vuuGridLayout", true);
       if (gridLayout.id === gridModel.id) {
         e.preventDefault();
+        const transactionResult = gridController.beginTransaction("resize");
+        if (!transactionResult.ok) {
+          throw Error(transactionResult.error.message);
+        }
+        transactionRef.current = transactionResult.transaction;
         const splitter = layoutModel.getSplitterById(splitterElement.id);
         const resizeTrackIsShared = layoutModel.isResizeTrackShared(splitter);
         const candidateTrackGroups =
@@ -411,12 +434,26 @@ export const useGridSplitterResizing = ({
       getProportionalTrackGroups,
       getProportionalTrackConstraints,
       getResizeAllowance,
+      gridController,
       gridModel,
       layoutModel,
       mouseMove,
       mouseUp,
       rowResizeDistribution,
     ],
+  );
+
+  useEffect(
+    () => () => {
+      document.removeEventListener("mousemove", mouseMove);
+      document.removeEventListener("mouseup", mouseUp);
+      const transaction = transactionRef.current;
+      if (transaction) {
+        transaction.rollback();
+        transactionRef.current = undefined;
+      }
+    },
+    [mouseMove, mouseUp],
   );
 
   const selectedRef = useRef<string>(undefined);

--- a/vuu-ui/packages/grid-layout/test/GridLayout.snapshot-rendering.react.test.tsx
+++ b/vuu-ui/packages/grid-layout/test/GridLayout.snapshot-rendering.react.test.tsx
@@ -1,0 +1,274 @@
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type GridController,
+  GridLayout,
+  GridLayoutItem,
+  GridLayoutProvider,
+  GridLayoutStackedItem,
+  useGridController,
+  useGridLayoutDispatch,
+} from "../src";
+
+const ControllerCapture = ({
+  capture,
+}: {
+  capture: (controller: GridController) => void;
+}) => {
+  capture(useGridController());
+  return null;
+};
+
+const RemountableStack = ({
+  capture,
+}: {
+  capture: (controller: GridController) => void;
+}) => {
+  const [mounted, setMounted] = useState(true);
+  const StackContent = () => {
+    const dispatch = useGridLayoutDispatch();
+    return (
+      <>
+        <ControllerCapture capture={capture} />
+        <button
+          onClick={() => dispatch({ id: "second", type: "close" })}
+          type="button"
+        >
+          Close second
+        </button>
+      </>
+    );
+  };
+  return (
+    <GridLayoutProvider>
+      <button onClick={() => setMounted((value) => !value)} type="button">
+        Toggle
+      </button>
+      {mounted ? (
+        <GridLayout
+          colsAndRows={{ cols: ["1fr"], rows: ["1fr"] }}
+          id="persisted-stack"
+        >
+          <GridLayoutStackedItem
+            id="persisted-tabs"
+            style={{ gridArea: "1/1/2/2" }}
+          />
+          <GridLayoutItem
+            contentVisible
+            id="first"
+            stackId="persisted-tabs"
+            title="First"
+          >
+            <StackContent />
+          </GridLayoutItem>
+          <GridLayoutItem
+            contentVisible={false}
+            id="second"
+            stackId="persisted-tabs"
+            title="Second"
+          >
+            Second
+          </GridLayoutItem>
+        </GridLayout>
+      ) : null}
+    </GridLayoutProvider>
+  );
+};
+
+describe("GridLayout canonical snapshot rendering", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("renders descriptor tracks and item placement from controller snapshots", () => {
+    let controller: GridController | undefined;
+    act(() => {
+      root.render(
+        <GridLayout
+          colsAndRows={{ cols: ["100px", "1fr"], rows: ["1fr"] }}
+          id="snapshot-grid"
+        >
+          <GridLayoutItem id="left" style={{ gridArea: "1/1/2/2" }}>
+            <ControllerCapture capture={(value) => (controller = value)} />
+          </GridLayoutItem>
+          <GridLayoutItem id="right" style={{ gridArea: "1/2/2/3" }}>
+            Right
+          </GridLayoutItem>
+        </GridLayout>,
+      );
+    });
+
+    const grid = container.querySelector<HTMLElement>("#snapshot-grid");
+    const left = container.querySelector<HTMLElement>("#left");
+    expect(grid?.style.gridTemplateColumns).toBe("100px 1fr");
+    expect(left?.style.gridArea).toBe("1/1/2/2");
+
+    act(() => {
+      controller?.dispatch({
+        index: 0,
+        size: "140px",
+        track: "column",
+        type: "resize-track",
+      });
+    });
+    expect(grid?.style.gridTemplateColumns).toBe("140px 1fr");
+  });
+
+  it("renders stack order, selection, and duplicate-title identity canonically", () => {
+    let controller: GridController | undefined;
+    act(() => {
+      root.render(
+        <GridLayout
+          colsAndRows={{ cols: ["1fr"], rows: ["1fr"] }}
+          id="stack-grid"
+        >
+          <GridLayoutStackedItem
+            id="stack"
+            minWidth={120}
+            resizeable="hv"
+            style={{ gridArea: "1/1/2/2" }}
+          />
+          <GridLayoutItem
+            contentVisible
+            id="alpha"
+            stackId="stack"
+            title="Duplicate"
+          >
+            <ControllerCapture capture={(value) => (controller = value)} />
+          </GridLayoutItem>
+          <GridLayoutItem
+            contentVisible={false}
+            id="beta"
+            stackId="stack"
+            title="Duplicate"
+          >
+            Beta
+          </GridLayoutItem>
+        </GridLayout>,
+      );
+    });
+
+    const tabIds = () =>
+      [
+        ...container.querySelectorAll<HTMLElement>(
+          "[data-grid-layout-item-id]",
+        ),
+      ].map((tab) => tab.dataset.gridLayoutItemId);
+    expect(tabIds()).toEqual(["alpha", "beta"]);
+    expect(controller?.getSnapshot().items[0]).toMatchObject({
+      column: { span: 1, start: 1 },
+      minWidth: 120,
+      resizeable: "hv",
+      row: { span: 1, start: 1 },
+    });
+    expect(container.querySelector("#alpha")).not.toBeNull();
+    expect(container.querySelector("#beta")).toBeNull();
+
+    act(() => {
+      controller?.dispatch({
+        itemId: "beta",
+        stackId: "stack",
+        type: "select-stack-item",
+      });
+      controller?.dispatch({
+        itemId: "beta",
+        position: "before",
+        stackId: "stack",
+        targetItemId: "alpha",
+        type: "reorder-stack-item",
+      });
+      controller?.dispatch({
+        itemId: "beta",
+        title: "Renamed",
+        type: "rename-item",
+      });
+    });
+
+    expect(tabIds()).toEqual(["beta", "alpha"]);
+    expect(container.querySelector("#beta")).not.toBeNull();
+    expect(container.querySelector("#alpha")).toBeNull();
+    expect(
+      container.querySelector('[data-grid-layout-item-id="beta"]')?.textContent,
+    ).toContain("Renamed");
+  });
+
+  it("keeps nested controllers stable and subscriptions isolated", () => {
+    let parentController: GridController | undefined;
+    let childController: GridController | undefined;
+    act(() => {
+      root.render(
+        <GridLayout
+          colsAndRows={{ cols: ["1fr", "1fr"], rows: ["1fr"] }}
+          id="parent-grid"
+        >
+          <GridLayoutItem id="nested-owner" style={{ gridArea: "1/1/2/2" }}>
+            <ControllerCapture
+              capture={(value) => (parentController = value)}
+            />
+            <GridLayout
+              colsAndRows={{ cols: ["1fr"], rows: ["1fr"] }}
+              id="child-grid"
+            >
+              <GridLayoutItem id="child" style={{ gridArea: "1/1/2/2" }}>
+                <ControllerCapture
+                  capture={(value) => (childController = value)}
+                />
+              </GridLayoutItem>
+            </GridLayout>
+          </GridLayoutItem>
+          <GridLayoutItem id="peer" style={{ gridArea: "1/2/2/3" }}>
+            Peer
+          </GridLayoutItem>
+        </GridLayout>,
+      );
+    });
+    const initialChildController = childController;
+    const initialChildSnapshot = childController?.getSnapshot();
+
+    act(() => {
+      parentController?.dispatch({
+        index: 0,
+        size: "120px",
+        track: "column",
+        type: "resize-track",
+      });
+    });
+
+    expect(childController).toBe(initialChildController);
+    expect(childController?.getSnapshot()).toBe(initialChildSnapshot);
+  });
+
+  it("persists content without treating stack templates as serializable items", () => {
+    act(() => {
+      root.render(<RemountableStack capture={() => undefined} />);
+    });
+    const buttons = container.querySelectorAll("button");
+    act(() => buttons[1]?.click());
+    act(() => buttons[0]?.click());
+    expect(container.querySelector("#persisted-stack")).toBeNull();
+    act(() => buttons[0]?.click());
+    expect(container.querySelector("#persisted-stack")).not.toBeNull();
+    expect(container.querySelector("#first")).not.toBeNull();
+  });
+});

--- a/vuu-ui/packages/grid-layout/test/useGridControllerSnapshot.test.tsx
+++ b/vuu-ui/packages/grid-layout/test/useGridControllerSnapshot.test.tsx
@@ -1,0 +1,164 @@
+import { StrictMode, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GridController } from "../src/GridController";
+import { GridModel } from "../src/GridModel";
+import { useGridControllerSnapshot } from "../src/useGridControllerSnapshot";
+import { descriptor, item } from "./model-scenario-harness";
+
+const createController = () =>
+  new GridController(
+    new GridModel(
+      "react-store",
+      descriptor(["100px", "100px"], ["1fr"], {
+        left: item("1/1/2/2", { title: "Left" }),
+        right: item("1/2/2/3", { title: "Right" }),
+      }),
+    ),
+  );
+
+const SnapshotView = ({
+  controller,
+  onRender,
+}: {
+  controller: GridController;
+  onRender: () => void;
+}) => {
+  const snapshot = useGridControllerSnapshot(controller);
+  onRender();
+  return (
+    <output data-revision={snapshot.revision}>
+      {snapshot.columns.map(({ size }) => size).join(" ")}
+    </output>
+  );
+};
+
+describe("useGridControllerSnapshot", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("renders once per semantic dispatch and ignores rejected and no-op commands", () => {
+    const controller = createController();
+    const onRender = vi.fn();
+    act(() => root.render(<SnapshotView {...{ controller, onRender }} />));
+    expect(onRender).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      controller.dispatch({
+        itemId: "missing",
+        title: "Missing",
+        type: "rename-item",
+      });
+      controller.dispatch({
+        itemId: "left",
+        title: "Left",
+        type: "rename-item",
+      });
+    });
+    expect(onRender).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      controller.dispatch({
+        index: 0,
+        size: "125px",
+        track: "column",
+        type: "resize-track",
+      });
+    });
+    expect(onRender).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toBe("125px 100px");
+  });
+
+  it("renders previews and rollback, without rerendering an unchanged commit", () => {
+    const controller = createController();
+    const onRender = vi.fn();
+    act(() => root.render(<SnapshotView {...{ controller, onRender }} />));
+    const start = controller.beginTransaction("resize");
+    expect(start.ok).toBe(true);
+    if (!start.ok) {
+      return;
+    }
+
+    act(() => {
+      start.transaction.dispatch({
+        index: 0,
+        size: "125px",
+        track: "column",
+        type: "resize-track",
+      });
+    });
+    expect(onRender).toHaveBeenCalledTimes(2);
+    act(() => start.transaction.commit());
+    expect(onRender).toHaveBeenCalledTimes(2);
+
+    const rollback = controller.beginTransaction("resize");
+    expect(rollback.ok).toBe(true);
+    if (!rollback.ok) {
+      return;
+    }
+    act(() => {
+      rollback.transaction.dispatch({
+        index: 0,
+        size: "150px",
+        track: "column",
+        type: "resize-track",
+      });
+    });
+    expect(onRender).toHaveBeenCalledTimes(3);
+    act(() => rollback.transaction.rollback());
+    expect(onRender).toHaveBeenCalledTimes(4);
+    expect(container.textContent).toBe("125px 100px");
+  });
+
+  it("cleans up every StrictMode subscription on unmount", () => {
+    const controller = createController();
+    const originalSubscribe = controller.subscribe;
+    let activeSubscriptions = 0;
+    vi.spyOn(controller, "subscribe").mockImplementation((listener) => {
+      activeSubscriptions += 1;
+      const unsubscribe = originalSubscribe(listener);
+      let active = true;
+      return () => {
+        if (active) {
+          active = false;
+          activeSubscriptions -= 1;
+          unsubscribe();
+        }
+      };
+    });
+
+    act(() =>
+      root.render(
+        <StrictMode>
+          <SnapshotView controller={controller} onRender={() => undefined} />
+        </StrictMode>,
+      ),
+    );
+    expect(activeSubscriptions).toBe(1);
+    act(() => root.unmount());
+    expect(activeSubscriptions).toBe(0);
+    root = createRoot(container);
+  });
+});


### PR DESCRIPTION
## Summary
- make each `GridLayout` subscribe to its `GridController` through a strict-mode-safe `useSyncExternalStore` hook
- render tracks, placements, placeholders, stack containers, tab order, tab selection, and durable item metadata from the canonical immutable snapshot
- keep React elements in a separate stable-ID content/template registry, including explicit stack templates whose members may omit `gridArea`
- derive live splitters on every canonical transition and route resize previews through controller transactions
- contain deferred palette/internal drag mutations in a named legacy transaction bridge that publishes canonical previews and commits or rolls back atomically

## Rendering authority
Before this change React rerenders were driven by `GridModel`/`GridLayoutModel` EventEmitter callbacks, `forceRender`, non-content state copies, direct item-position DOM writes, and direct track-template DOM writes. After this change durable rendering has one authority: the per-grid controller snapshot. Mutable models remain available only for compatibility execution, DOM measurements, transient drag flags, and the increment-7 drag coordinator bridge.

`useGridControllerSnapshot` uses stable subscribe/get callbacks, an SSR snapshot path, controller identity semantics for rejects/no-ops, and visible-state identity caching so revision-only transaction commits notify external-store consumers without causing a duplicate visible render.

## Stack, splitter, and compatibility behavior
- tab order, labels, selection, add/remove/rename/reorder, duplicate-title identity, and dissolution render from stable canonical IDs
- explicit stack templates remain presentation-only and contribute area/minimum/resize metadata without entering serializable state
- splitter participants are rebuilt from current live placements, preserving #2379/#2380 and the PaletteSplitAndReplace resize path
- pointer resize publishes transaction previews without persistence notifications; commit and rollback retain controller semantics
- existing palette/internal drag behavior remains deferred to increment 7, but model mutations now publish through the `publishLegacyDragMutation` transaction bridge rather than remaining model-only
- nested layouts retain independent controllers, subscriptions, drag scopes, and opaque React content

## Tests and validation
- 240 GridLayout Vitest tests passed; 2 existing todos
- added focused external-store, no-op, preview/commit/rollback, StrictMode cleanup, canonical track/placement, duplicate-title stack, explicit-stack descriptor, persistence/remount, and nested-controller tests
- GridLayout package build passed
- changed-file Biome check passed
- type-definition generation has zero errors in changed GridLayout files; it remains blocked by existing errors in `vuu-data-react` and `vuu-utils`
- targeted Playwright component run remains blocked before fixture mount by existing Showcase-wide imports: missing `UserSettingsPanel` export and unresolved `feature-filter-table`

## Explicit deferrals
This PR does not migrate the complex drag/drop coordinator (increment 7), versioned persistence/settings (increment 8), or consumer/legacy removal (increment 9).