### PR TITLE
feat(grid-layout): coordinate drag transactions

### DIFF
--- a/vuu-ui/packages/grid-layout/src/GridCommand.ts
+++ b/vuu-ui/packages/grid-layout/src/GridCommand.ts
@@ -79,6 +79,12 @@ export type GridCommand =
     }
   | {
       readonly itemId: GridItemId;
+      readonly stackId: StackId;
+      readonly targetId: GridItemId;
+      readonly type: "replace-stack-item";
+    }
+  | {
+      readonly itemId: GridItemId;
       readonly reason: GridItemRemoveReason;
       readonly type: "remove-item";
     }
@@ -96,13 +102,30 @@ export type GridCommand =
     }
   | {
       readonly item: GridCommandItem;
+      readonly position?: "after" | "before";
       readonly stackId: StackId;
+      readonly targetItemId?: GridItemId;
       readonly type: "add-stack-item";
     }
   | {
       readonly itemId: GridItemId;
       readonly stackId: StackId;
       readonly type: "remove-stack-item";
+    }
+  | {
+      readonly fromStackId?: StackId;
+      readonly itemId: GridItemId;
+      readonly position?: "after" | "before";
+      readonly stackId: StackId;
+      readonly targetItemId?: GridItemId;
+      readonly type: "move-item-to-stack";
+    }
+  | {
+      readonly itemId: GridItemId;
+      readonly position: GridLayoutSplitDirection;
+      readonly stackId: StackId;
+      readonly targetId: GridItemId;
+      readonly type: "move-stack-item-to-grid";
     }
   | {
       readonly itemId: GridItemId;
@@ -317,6 +340,43 @@ export class LegacyGridCommandExecutor {
         this.gridLayoutModel.applyReplaceTransition(replaced.value);
         return success(command);
       }
+      case "replace-stack-item": {
+        const invalid =
+          this.requireTab(command, command.stackId, command.itemId) ??
+          this.requireItem(command, command.targetId);
+        if (invalid) {
+          return invalid;
+        }
+        const target = this.gridModel.getChildItem(command.targetId, true);
+        if (target.stackId || target.type === "stacked-content") {
+          return failure(
+            command,
+            "INVALID_TARGET",
+            "A stack member can only replace a standalone grid item",
+          );
+        }
+        const removed = this.gridModel.removeStackItem(
+          command.stackId,
+          command.itemId,
+        );
+        if (!removed.ok) {
+          return stackFailure(command, removed.error);
+        }
+        const item = this.gridModel.getChildItem(command.itemId, true);
+        item.stackId = undefined;
+        item.contentDetached = undefined;
+        item.contentVisible = true;
+        item.dragging = false;
+        const replaced = replaceGridItem(this.gridModel.toGeometry(), {
+          droppedItemId: command.itemId,
+          targetItemId: command.targetId,
+        });
+        if (!replaced.ok) {
+          return geometryFailure(command, replaced.error);
+        }
+        this.gridLayoutModel.applyReplaceTransition(replaced.value);
+        return success(command);
+      }
       case "remove-item": {
         const invalid = this.requireItem(command, command.itemId);
         if (invalid) {
@@ -473,6 +533,16 @@ export class LegacyGridCommandExecutor {
         if (invalid) {
           return invalid;
         }
+        if (
+          (command.position === undefined) !==
+          (command.targetItemId === undefined)
+        ) {
+          return failure(
+            command,
+            "INVALID_TARGET",
+            "A stack placement requires both position and targetItemId",
+          );
+        }
         const stack = this.gridModel.getChildItem(command.stackId, true);
         const added = this.gridModel.addStackItem(
           command.stackId,
@@ -490,6 +560,12 @@ export class LegacyGridCommandExecutor {
             },
             command.stackId,
           ),
+          command.position && command.targetItemId
+            ? {
+                position: command.position,
+                target: command.targetItemId,
+              }
+            : undefined,
         );
         if (!added.ok) {
           return stackFailure(command, added.error);
@@ -506,6 +582,120 @@ export class LegacyGridCommandExecutor {
           return invalid;
         }
         return this.removeItem(command, command.itemId, "close");
+      }
+      case "move-item-to-stack": {
+        const invalid =
+          this.requireItem(command, command.itemId) ??
+          this.requireStack(command, command.stackId);
+        if (invalid) {
+          return invalid;
+        }
+        if (
+          (command.position === undefined) !==
+          (command.targetItemId === undefined)
+        ) {
+          return failure(
+            command,
+            "INVALID_TARGET",
+            "A stack placement requires both position and targetItemId",
+          );
+        }
+        if (command.fromStackId) {
+          const tabFailure = this.requireTab(
+            command,
+            command.fromStackId,
+            command.itemId,
+          );
+          if (tabFailure) {
+            return tabFailure;
+          }
+          const removed = this.gridModel.removeStackItem(
+            command.fromStackId,
+            command.itemId,
+          );
+          if (!removed.ok) {
+            return stackFailure(command, removed.error);
+          }
+        } else {
+          const removed = this.removeItem(command, command.itemId, "drag");
+          if (!removed.ok) {
+            return removed;
+          }
+        }
+        const item = this.gridModel.getChildItem(command.itemId, true);
+        item.stackId = undefined;
+        item.contentDetached = undefined;
+        item.dragging = false;
+        const added = this.gridModel.addStackMember(
+          command.stackId,
+          command.itemId,
+          command.position && command.targetItemId
+            ? {
+                position: command.position,
+                target: command.targetItemId,
+              }
+            : undefined,
+        );
+        if (!added.ok) {
+          return stackFailure(command, added.error);
+        }
+        const selected = this.gridModel.selectStackItem(
+          command.stackId,
+          command.itemId,
+        );
+        return selected.ok
+          ? success(command)
+          : stackFailure(command, selected.error);
+      }
+      case "move-stack-item-to-grid": {
+        const invalid =
+          this.requireTab(command, command.stackId, command.itemId) ??
+          this.requireItem(command, command.targetId);
+        if (invalid) {
+          return invalid;
+        }
+        const stackItemIds = gridStackItemIds(
+          this.gridModel.getStackState(command.stackId),
+        );
+        const targetId =
+          command.targetId === command.stackId && stackItemIds.length === 2
+            ? stackItemIds.find((itemId) => itemId !== command.itemId)
+            : command.targetId;
+        if (!targetId) {
+          return failure(
+            command,
+            "INVALID_TARGET",
+            `Grid stack #${command.stackId} has no remaining split target`,
+          );
+        }
+        const removed = this.gridModel.removeStackItem(
+          command.stackId,
+          command.itemId,
+        );
+        if (!removed.ok) {
+          return stackFailure(command, removed.error);
+        }
+        const item = this.gridModel.getChildItem(command.itemId, true);
+        item.stackId = undefined;
+        item.contentDetached = undefined;
+        item.contentVisible = true;
+        item.dragging = false;
+        const split = this.gridModel.runGeometry((measurements) =>
+          splitGridItem(
+            this.gridModel.toGeometry(),
+            {
+              droppedItemId: command.itemId,
+              splitDirection: command.position,
+              targetItemId: targetId,
+            },
+            measurements,
+          ),
+        );
+        if (!split.ok) {
+          return geometryFailure(command, split.error);
+        }
+        this.gridLayoutModel.applySplitTransition(split.value);
+        return success(command);
       }
       case "select-stack-item": {
         const invalid = this.requireTab(

--- a/vuu-ui/packages/grid-layout/src/GridController.ts
+++ b/vuu-ui/packages/grid-layout/src/GridController.ts
@@ -35,6 +35,7 @@ export interface GridTransaction {
   readonly kind: GridTransactionKind;
   commit(): GridTransactionCloseResult;
   dispatch(command: GridCommand): GridCommandResult;
+  replace(commands: readonly GridCommand[]): GridCommandResult;
   rollback(): GridTransactionCloseResult;
 }
 
@@ -61,7 +62,7 @@ export class GridController {
   readonly #executor: LegacyGridCommandExecutor;
   readonly #listeners = new Set<GridControllerListener>();
   readonly #commitListeners = new Set<GridCommittedTransitionListener>();
-  #activeTransaction: LegacyGridTransaction | undefined;
+  #activeTransaction: GridControllerTransaction | undefined;
   #snapshot: GridSnapshot;
 
   constructor(
@@ -134,12 +135,13 @@ export class GridController {
         ok: false,
       };
     }
-    let transaction: LegacyGridTransaction;
-    transaction = new LegacyGridTransaction(
+    let transaction: GridControllerTransaction;
+    transaction = new GridControllerTransaction(
       kind,
       this.gridModel.createCheckpoint(),
       this.#snapshot,
       (command) => this.#executePreview(transaction, command),
+      (commands) => this.#replacePreview(transaction, commands),
       (commands) =>
         this.#commitTransaction(
           transaction,
@@ -159,7 +161,7 @@ export class GridController {
   }
 
   #executePreview(
-    transaction: LegacyGridTransaction,
+    transaction: GridControllerTransaction,
     command: GridCommand,
   ): GridCommandResult {
     if (this.#activeTransaction !== transaction) {
@@ -172,6 +174,7 @@ export class GridController {
         ok: false,
       };
     }
+
     const checkpoint = this.gridModel.createCheckpoint();
     const result = this.#executeAtomically(command, checkpoint);
     if (!result.ok) {
@@ -188,8 +191,59 @@ export class GridController {
     return result;
   }
 
+  #replacePreview(
+    transaction: GridControllerTransaction,
+    commands: readonly GridCommand[],
+  ): GridCommandResult {
+    const representative =
+      commands[0] ?? ({ type: "regenerate-placeholders" } as const);
+    if (this.#activeTransaction !== transaction) {
+      return {
+        command: representative.type,
+        error: transactionError(
+          "TRANSACTION_CLOSED",
+          "Cannot replace preview; the grid transaction is closed",
+        ),
+        ok: false,
+      };
+    }
+
+    this.gridModel.restoreCheckpoint(transaction.checkpoint);
+    this.#snapshot = transaction.baseline;
+    try {
+      for (const command of commands) {
+        const checkpoint = this.gridModel.createCheckpoint();
+        const result = this.#executeAtomically(command, checkpoint);
+        if (!result.ok) {
+          this.gridModel.restoreCheckpoint(transaction.checkpoint);
+          this.#snapshot = transaction.baseline;
+          transaction.setCommands([]);
+          this.#notifyState();
+          return result;
+        }
+      }
+    } catch (error) {
+      this.gridModel.restoreCheckpoint(transaction.checkpoint);
+      this.#snapshot = transaction.baseline;
+      transaction.setCommands([]);
+      this.#notifyState();
+      throw error;
+    }
+    transaction.setCommands(commands);
+    const candidate = this.#readSnapshot(transaction.baseline.revision);
+    this.#snapshot =
+      semanticSnapshot(candidate) === semanticSnapshot(transaction.baseline)
+        ? transaction.baseline
+        : candidate;
+    this.#notifyState();
+    return {
+      command: representative.type,
+      ok: true,
+    };
+  }
+
   #commitTransaction(
-    transaction: LegacyGridTransaction,
+    transaction: GridControllerTransaction,
     kind: GridTransactionKind,
     baseline: GridSnapshot,
     commands: readonly GridCommand[],
@@ -216,7 +270,7 @@ export class GridController {
   }
 
   #rollbackTransaction(
-    transaction: LegacyGridTransaction,
+    transaction: GridControllerTransaction,
     checkpoint: GridModelCheckpoint,
     baseline: GridSnapshot,
   ): GridTransactionCloseResult {
@@ -249,7 +303,11 @@ export class GridController {
     checkpoint: GridModelCheckpoint,
   ): GridCommandResult {
     try {
-      return this.#executor.execute(command);
+      const result = this.#executor.execute(command);
+      if (!result.ok) {
+        this.gridModel.restoreCheckpoint(checkpoint);
+      }
+      return result;
     } catch (error) {
       this.gridModel.restoreCheckpoint(checkpoint);
       throw error;
@@ -288,7 +346,7 @@ export class GridController {
   }
 }
 
-class LegacyGridTransaction implements GridTransaction {
+class GridControllerTransaction implements GridTransaction {
   readonly #commands: GridCommand[] = [];
   #closed = false;
 
@@ -298,6 +356,9 @@ class LegacyGridTransaction implements GridTransaction {
     readonly baseline: GridSnapshot,
     private readonly executePreview: (
       command: GridCommand,
+    ) => GridCommandResult,
+    private readonly replacePreview: (
+      commands: readonly GridCommand[],
     ) => GridCommandResult,
     private readonly commitTransaction: (
       commands: readonly GridCommand[],
@@ -316,11 +377,30 @@ class LegacyGridTransaction implements GridTransaction {
         ok: false,
       };
     }
+
     const result = this.executePreview(command);
     if (result.ok) {
       this.#commands.push(command);
     }
     return result;
+  }
+
+  replace(commands: readonly GridCommand[]): GridCommandResult {
+    if (this.#closed) {
+      return {
+        command: commands[0]?.type ?? "regenerate-placeholders",
+        error: transactionError(
+          "TRANSACTION_CLOSED",
+          "Cannot replace preview; the grid transaction is closed",
+        ),
+        ok: false,
+      };
+    }
+    return this.replacePreview(commands);
+  }
+
+  setCommands(commands: readonly GridCommand[]) {
+    this.#commands.splice(0, this.#commands.length, ...commands);
   }
 
   commit(): GridTransactionCloseResult {

--- a/vuu-ui/packages/grid-layout/src/GridDragCoordinator.ts
+++ b/vuu-ui/packages/grid-layout/src/GridDragCoordinator.ts
@@ -1,0 +1,356 @@
+import type {
+  GridCommand,
+  GridCommandItem,
+  GridCommandResult,
+} from "./GridCommand";
+import type {
+  GridController,
+  GridControllerError,
+  GridTransaction,
+} from "./GridController";
+import type { GridId, GridItemId, StackId } from "./GridSnapshot";
+
+export type GridDragSource =
+  | {
+      readonly itemId: GridItemId;
+      readonly kind: "existing-item";
+      readonly sourceGridId: GridId;
+    }
+  | {
+      readonly itemId: GridItemId;
+      readonly kind: "stack-member";
+      readonly selected: boolean;
+      readonly sourceGridId: GridId;
+      readonly stackId: StackId;
+    }
+  | {
+      readonly item: GridCommandItem;
+      readonly kind: "palette-template";
+      readonly templateId: string;
+    };
+
+export type GridDropIntent =
+  | { readonly kind: "replace" }
+  | {
+      readonly kind: "split";
+      readonly position: "east" | "north" | "south" | "west";
+    }
+  | { readonly kind: "create-stack" }
+  | {
+      readonly kind: "stack";
+      readonly position?: "after" | "before";
+      readonly targetItemId?: GridItemId;
+    };
+
+export interface GridDropTarget {
+  readonly gridId: GridId;
+  readonly intent: GridDropIntent;
+  readonly targetId: GridItemId | StackId;
+}
+
+export type GridDragCoordinatorState =
+  | { readonly phase: "idle" }
+  | { readonly phase: "dragging"; readonly source: GridDragSource }
+  | {
+      readonly phase: "previewing";
+      readonly plan: GridDropPlan;
+      readonly source: GridDragSource;
+      readonly target: GridDropTarget;
+    }
+  | {
+      readonly phase: "committed" | "cancelled";
+      readonly source: GridDragSource;
+    };
+
+export type GridDropPlan = {
+  readonly commands: readonly GridCommand[];
+  readonly source: GridDragSource;
+  readonly target: GridDropTarget;
+};
+
+export type GridDragCoordinatorErrorCode =
+  | "CROSS_GRID_DRAG"
+  | "INVALID_TRANSITION"
+  | "TRANSACTION_FAILURE"
+  | "UNSUPPORTED_DROP";
+
+export interface GridDragCoordinatorError {
+  readonly code: GridDragCoordinatorErrorCode;
+  readonly message: string;
+}
+
+export type GridDragCoordinatorResult =
+  | { readonly ok: true; readonly state: GridDragCoordinatorState }
+  | {
+      readonly error: GridDragCoordinatorError | GridControllerError;
+      readonly ok: false;
+    };
+
+const failure = (
+  code: GridDragCoordinatorErrorCode,
+  message: string,
+): GridDragCoordinatorResult => ({ error: { code, message }, ok: false });
+
+const stackPlacement = (intent: Extract<GridDropIntent, { kind: "stack" }>) =>
+  intent.position && intent.targetItemId
+    ? {
+        position: intent.position,
+        targetItemId: intent.targetItemId,
+      }
+    : {};
+
+export const createGridDropPlan = (
+  source: GridDragSource,
+  target: GridDropTarget,
+): GridDropPlan | GridDragCoordinatorError => {
+  if (
+    source.kind !== "palette-template" &&
+    source.sourceGridId !== target.gridId
+  ) {
+    return {
+      code: "CROSS_GRID_DRAG",
+      message: `Grid item #${source.itemId} cannot move from #${source.sourceGridId} to #${target.gridId}`,
+    };
+  }
+
+  const commands: GridCommand[] = [];
+  if (source.kind === "palette-template") {
+    if (target.intent.kind === "stack") {
+      commands.push({
+        item: source.item,
+        ...stackPlacement(target.intent),
+        stackId: target.targetId,
+        type: "add-stack-item",
+      });
+      commands.push({
+        itemId: source.item.id,
+        stackId: target.targetId,
+        type: "select-stack-item",
+      });
+    } else {
+      commands.push({ item: source.item, type: "add-item" });
+    }
+  }
+
+  const itemId =
+    source.kind === "palette-template" ? source.item.id : source.itemId;
+  switch (target.intent.kind) {
+    case "split":
+      if (source.kind === "stack-member") {
+        commands.push({
+          itemId,
+          stackId: source.stackId,
+          targetId: target.targetId,
+          position: target.intent.position,
+          type: "move-stack-item-to-grid",
+        });
+      } else {
+        commands.push({
+          itemId,
+          position: target.intent.position,
+          targetId: target.targetId,
+          type: "move-item",
+        });
+      }
+      break;
+    case "replace":
+      if (source.kind === "stack-member") {
+        commands.push({
+          itemId,
+          stackId: source.stackId,
+          targetId: target.targetId,
+          type: "replace-stack-item",
+        });
+      } else {
+        commands.push({
+          itemId,
+          targetId: target.targetId,
+          type: "replace-item",
+        });
+      }
+      break;
+    case "create-stack":
+      if (source.kind === "stack-member") {
+        return {
+          code: "UNSUPPORTED_DROP",
+          message:
+            "A stack member cannot create a stack without first becoming standalone",
+        };
+      }
+      commands.push({
+        itemId,
+        targetId: target.targetId,
+        type: "create-stack",
+      });
+      break;
+    case "stack":
+      if (source.kind === "palette-template") {
+        break;
+      }
+      if (
+        source.kind === "stack-member" &&
+        source.stackId === target.targetId
+      ) {
+        if (!target.intent.position || !target.intent.targetItemId) {
+          return {
+            code: "UNSUPPORTED_DROP",
+            message:
+              "Reordering a stack member requires a target item and position",
+          };
+        }
+        commands.push({
+          activate: source.selected,
+          itemId,
+          position: target.intent.position,
+          stackId: source.stackId,
+          targetItemId: target.intent.targetItemId,
+          type: "reorder-stack-item",
+        });
+      } else {
+        commands.push({
+          ...stackPlacement(target.intent),
+          fromStackId:
+            source.kind === "stack-member" ? source.stackId : undefined,
+          itemId,
+          stackId: target.targetId,
+          type: "move-item-to-stack",
+        });
+      }
+      break;
+  }
+  commands.push({ type: "regenerate-placeholders" });
+  return { commands, source, target };
+};
+
+const isPlanError = (
+  value: GridDropPlan | GridDragCoordinatorError,
+): value is GridDragCoordinatorError => "code" in value;
+
+export class GridDragCoordinator {
+  #state: GridDragCoordinatorState = { phase: "idle" };
+  #transaction: GridTransaction | undefined;
+
+  constructor(
+    readonly gridId: GridId,
+    private readonly controller: GridController,
+  ) {}
+
+  get state() {
+    return this.#state;
+  }
+
+  begin(source: GridDragSource): GridDragCoordinatorResult {
+    if (
+      this.#state.phase === "dragging" ||
+      this.#state.phase === "previewing"
+    ) {
+      return failure(
+        "INVALID_TRANSITION",
+        `Cannot begin a drag while ${this.#state.phase}`,
+      );
+    }
+    this.#state = { phase: "dragging", source };
+    return { ok: true, state: this.#state };
+  }
+
+  preview(target: GridDropTarget): GridDragCoordinatorResult {
+    if (
+      this.#state.phase !== "dragging" &&
+      this.#state.phase !== "previewing"
+    ) {
+      return failure(
+        "INVALID_TRANSITION",
+        `Cannot preview a drop while ${this.#state.phase}`,
+      );
+    }
+    if (target.gridId !== this.gridId) {
+      return failure(
+        "CROSS_GRID_DRAG",
+        `Coordinator #${this.gridId} cannot preview target grid #${target.gridId}`,
+      );
+    }
+    const source = this.#state.source;
+    const plan = createGridDropPlan(source, target);
+    if (isPlanError(plan)) {
+      this.#rollbackPreview();
+      return { error: plan, ok: false };
+    }
+    if (!this.#transaction) {
+      const result = this.controller.beginTransaction("drag");
+      if (!result.ok) {
+        return { error: result.error, ok: false };
+      }
+      this.#transaction = result.transaction;
+    }
+    const result = this.#transaction.replace(plan.commands);
+    if (!result.ok) {
+      this.#rollbackPreview();
+      return this.#commandFailure(result);
+    }
+    this.#state = { phase: "previewing", plan, source, target };
+    return { ok: true, state: this.#state };
+  }
+
+  commit(): GridDragCoordinatorResult {
+    if (this.#state.phase !== "previewing" || !this.#transaction) {
+      return failure(
+        "INVALID_TRANSITION",
+        `Cannot commit a drag while ${this.#state.phase}`,
+      );
+    }
+    const source = this.#state.source;
+    const result = this.#transaction.commit();
+    if (!result.ok) {
+      return { error: result.error, ok: false };
+    }
+    this.#transaction = undefined;
+    this.#state = { phase: "committed", source };
+    return { ok: true, state: this.#state };
+  }
+
+  cancel(): GridDragCoordinatorResult {
+    if (
+      this.#state.phase !== "dragging" &&
+      this.#state.phase !== "previewing"
+    ) {
+      return failure(
+        "INVALID_TRANSITION",
+        `Cannot cancel a drag while ${this.#state.phase}`,
+      );
+    }
+    const source = this.#state.source;
+    const result = this.#rollbackPreview();
+    if (result && !result.ok) {
+      return { error: result.error, ok: false };
+    }
+    this.#state = { phase: "cancelled", source };
+    return { ok: true, state: this.#state };
+  }
+
+  dispose() {
+    if (this.#transaction) {
+      const result = this.#transaction.rollback();
+      this.#transaction = undefined;
+      if (!result.ok) {
+        throw Error(result.error.message);
+      }
+    }
+    this.#state = { phase: "idle" };
+  }
+
+  #rollbackPreview() {
+    const result = this.#transaction?.rollback();
+    this.#transaction = undefined;
+    if (this.#state.phase === "previewing") {
+      this.#state = { phase: "dragging", source: this.#state.source };
+    }
+    return result;
+  }
+
+  #commandFailure(result: Extract<GridCommandResult, { ok: false }>) {
+    return failure(
+      "TRANSACTION_FAILURE",
+      `${result.error.code}: ${result.error.message}`,
+    );
+  }
+}

--- a/vuu-ui/packages/grid-layout/src/GridDragCoordinator.ts
+++ b/vuu-ui/packages/grid-layout/src/GridDragCoordinator.ts
@@ -298,6 +298,7 @@ export class GridDragCoordinator {
         `Cannot commit a drag while ${this.#state.phase}`,
       );
     }
+
     const source = this.#state.source;
     const result = this.#transaction.commit();
     if (!result.ok) {
@@ -305,6 +306,20 @@ export class GridDragCoordinator {
     }
     this.#transaction = undefined;
     this.#state = { phase: "committed", source };
+    return { ok: true, state: this.#state };
+  }
+
+  clearPreview(): GridDragCoordinatorResult {
+    if (this.#state.phase !== "previewing") {
+      return failure(
+        "INVALID_TRANSITION",
+        `Cannot clear a preview while ${this.#state.phase}`,
+      );
+    }
+    const result = this.#rollbackPreview();
+    if (result && !result.ok) {
+      return { error: result.error, ok: false };
+    }
     return { ok: true, state: this.#state };
   }
 

--- a/vuu-ui/packages/grid-layout/src/GridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayout.tsx
@@ -91,6 +91,8 @@ export const GridLayout = ({
     onCancelTabDrag,
     onDetachTab,
     onDragEnd,
+    onDragLeave,
+    onDragPreview,
     onDragStart,
     onDrop,
     onDropStackedItem,
@@ -132,6 +134,8 @@ export const GridLayout = ({
         gridSnapshot,
         id,
         onDragEnd,
+        onDragLeave,
+        onDragPreview,
         onDragStart,
         onDrop,
       }}

--- a/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
@@ -165,6 +165,8 @@ export type GridLayoutDropHandler = (
   position: GridLayoutDropPosition,
 ) => boolean;
 
+export type GridLayoutDragLeaveHandler = () => void;
+
 export interface GridLayoutContextProps {
   dispatchGridLayoutAction: GridLayoutDispatch;
   gridController?: GridController;
@@ -173,6 +175,8 @@ export interface GridLayoutContextProps {
   gridSnapshot?: GridSnapshot;
   id: string;
   onDragEnd?: GridLayoutDragEndHandler;
+  onDragLeave: GridLayoutDragLeaveHandler;
+  onDragPreview: GridLayoutDropHandler;
   onDragStart: GridLayoutDragStartHandler;
   onDrop: GridLayoutDropHandler;
 }
@@ -180,6 +184,8 @@ export interface GridLayoutContextProps {
 export const GridLayoutContext = createContext<GridLayoutContextProps>({
   dispatchGridLayoutAction: unconfiguredGridLayoutDispatch,
   id: "",
+  onDragLeave: () => undefined,
+  onDragPreview: () => false,
   onDragStart: () => console.log("no GridLayoutProvider"),
   onDrop: () => false,
 });
@@ -192,6 +198,16 @@ export const useGridLayoutDispatch = () => {
 export const useGridLayoutDropHandler = () => {
   const { onDrop } = useContext(GridLayoutContext);
   return onDrop;
+};
+
+export const useGridLayoutDragPreviewHandler = () => {
+  const { onDragPreview } = useContext(GridLayoutContext);
+  return onDragPreview;
+};
+
+export const useGridLayoutDragLeaveHandler = () => {
+  const { onDragLeave } = useContext(GridLayoutContext);
+  return onDragLeave;
 };
 
 export const useGridLayoutDragEndHandler = () => {

--- a/vuu-ui/packages/grid-layout/src/drag-drop-next/DragContextNext.tsx
+++ b/vuu-ui/packages/grid-layout/src/drag-drop-next/DragContextNext.tsx
@@ -1,6 +1,6 @@
 import { EventEmitter, type orientationType } from "@vuu-ui/vuu-utils";
 import {
-  DragSource,
+  type DragSource,
   sourceIsComponent,
   sourceIsTabbedComponent,
   sourceIsTemplate,
@@ -36,8 +36,6 @@ export type DropHandler<T extends DragSource = DragSource> = (
   dropProps: DropProps<T>,
 ) => void;
 
-const defaultDropHandler = () => {};
-
 export type DragContextDropEvent = {
   type: "drop";
   dragSource: DragSource;
@@ -46,6 +44,7 @@ export type DragContextDropEvent = {
 };
 export type DragContextDetachTabEvent = {
   gridId: string;
+  itemId: string;
   type: "detach-tab";
   tabsId: string;
   value: string;
@@ -72,13 +71,11 @@ export type DragContextEvents = {
 };
 
 export class DragContext extends EventEmitter<DragContextEvents> {
-  #dragElementHeight?: number;
   #dragElementWidth?: number;
   #dragLabelWidth?: number;
   #dragStateCleanups = new Set<() => void>();
   #dragSource?: DragSource;
   #dragSources: Map<string, DragSourceDescriptor> = new Map();
-  #dropHandler: DropHandler = defaultDropHandler;
   #dropped = false;
   #dropPending = false;
   #dropZoneCache = new Map<HTMLElement, boolean>();
@@ -112,7 +109,6 @@ export class DragContext extends EventEmitter<DragContextEvents> {
       this.#dragSource = dragSource;
       this.#dropped = false;
       this.#dropPending = false;
-      this.#dragElementHeight = height;
       this.#dragElementWidth = width;
       this.#dragLabelWidth = dragLabelWidth;
       this.#mouseX = x;
@@ -136,7 +132,6 @@ export class DragContext extends EventEmitter<DragContextEvents> {
     this.#dropZoneCache.clear();
     this.#dragSource = undefined;
     this.#element = undefined;
-    this.#dragElementHeight = undefined;
     this.#dragElementWidth = undefined;
   }
 
@@ -150,6 +145,7 @@ export class DragContext extends EventEmitter<DragContextEvents> {
       this.emit("cancel-tab-drag", {
         type: "cancel-tab-drag",
         gridId,
+        itemId: this.#dragSource.tab.id,
         tabsId,
         value,
       });
@@ -180,12 +176,18 @@ export class DragContext extends EventEmitter<DragContextEvents> {
    * TabPanel can be assigned its new location (might still be within tabstrip, might
    * not be) and made visible, without ever having to unmount/remount.
    */
-  detachTab(gridId: string, tabsId: string, value: string) {
+  detachTab(gridId: string, tabsId: string, itemId: string, value: string) {
     // console.log(
     //   `%c[DragContextNext] #${gridId}detachTab #${tabsId} tab (${value})`,
     //   "color:blue;font-weight:bold;",
     // );
-    this.emit("detach-tab", { type: "detach-tab", gridId, tabsId, value });
+    this.emit("detach-tab", {
+      type: "detach-tab",
+      gridId,
+      itemId,
+      tabsId,
+      value,
+    });
   }
 
   drop = ({
@@ -285,10 +287,6 @@ export class DragContext extends EventEmitter<DragContextEvents> {
   //     };
   //   }
   // }
-
-  set dropHandler(dropHandler: DropHandler) {
-    this.#dropHandler = dropHandler;
-  }
 
   get dropped() {
     const dragSource = this.dragSource;

--- a/vuu-ui/packages/grid-layout/src/drag-drop-next/DragDropProviderNext.tsx
+++ b/vuu-ui/packages/grid-layout/src/drag-drop-next/DragDropProviderNext.tsx
@@ -1,6 +1,6 @@
 import {
   createContext,
-  ReactNode,
+  type ReactNode,
   useContext,
   useEffect,
   useMemo,
@@ -9,8 +9,8 @@ import {
 import {
   DragContext,
   type DragContextCancelTabDragHandler,
-  DragContextDetachTabHandler,
-  DragContextDropHandler,
+  type DragContextDetachTabHandler,
+  type DragContextDropHandler,
   type DragSources,
 } from "./DragContextNext";
 import { useComponentCssInjection } from "@salt-ds/styles";
@@ -65,9 +65,24 @@ export const DragDropProviderNext = ({
   );
 
   useEffect(() => {
+    if (!targetWindow) {
+      return;
+    }
+    const cancelActiveDrag = () => {
+      if (dragContext.ownsDrag) {
+        dragContext.cancelDrag();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        cancelActiveDrag();
+      }
+    };
     dragContext.on("cancel-tab-drag", onCancelTabDrag);
     dragContext.on("detach-tab", onDetachTab);
     dragContext.on("drop", onDrop);
+    targetWindow.addEventListener("keydown", handleKeyDown);
+    targetWindow.addEventListener("pointercancel", cancelActiveDrag);
 
     const cleanupCallbacks: Array<() => void> = [];
     // console.log(
@@ -90,9 +105,14 @@ export const DragDropProviderNext = ({
       dragContext.removeListener("cancel-tab-drag", onCancelTabDrag);
       dragContext.removeListener("detach-tab", onDetachTab);
       dragContext.removeListener("drop", onDrop);
-      cleanupCallbacks.forEach((cleanup) => cleanup());
+      targetWindow.removeEventListener("keydown", handleKeyDown);
+      targetWindow.removeEventListener("pointercancel", cancelActiveDrag);
+      cancelActiveDrag();
+      cleanupCallbacks.forEach((cleanup) => {
+        cleanup();
+      });
     };
-  }, [dragContext, onCancelTabDrag, onDetachTab, onDrop]);
+  }, [dragContext, onCancelTabDrag, onDetachTab, onDrop, targetWindow]);
 
   return (
     <DragDropContext.Provider value={dragContext}>

--- a/vuu-ui/packages/grid-layout/src/drag-drop-next/SpaceMan.tsx
+++ b/vuu-ui/packages/grid-layout/src/drag-drop-next/SpaceMan.tsx
@@ -56,7 +56,10 @@ export class SpaceMan {
       if (siblingElement) {
         return {
           position: "before",
-          target: siblingElement.dataset.label ?? siblingElement.id,
+          target:
+            siblingElement.dataset.gridLayoutItemId ??
+            siblingElement.dataset.label ??
+            siblingElement.id,
         };
       }
 
@@ -67,7 +70,10 @@ export class SpaceMan {
       if (siblingElement) {
         return {
           position: "after",
-          target: siblingElement.dataset.label ?? siblingElement.id,
+          target:
+            siblingElement.dataset.gridLayoutItemId ??
+            siblingElement.dataset.label ??
+            siblingElement.id,
         };
       }
 

--- a/vuu-ui/packages/grid-layout/src/drag-drop-next/tabstrip-drag-drop.ts
+++ b/vuu-ui/packages/grid-layout/src/drag-drop-next/tabstrip-drag-drop.ts
@@ -1,5 +1,5 @@
-import { orientationType, queryClosest } from "@vuu-ui/vuu-utils";
-import { DragContext, type DropPosition } from "./DragContextNext";
+import { type orientationType, queryClosest } from "@vuu-ui/vuu-utils";
+import type { DragContext, DropPosition } from "./DragContextNext";
 import { SpaceMan } from "./SpaceMan";
 import { sourceIsTabbedComponent } from "../GridLayoutContext";
 import { getClosestGridLayout } from "../grid-dom-utils";
@@ -58,7 +58,10 @@ const getDropPositionAtEnd = (
   );
   const lastTab = tabs.item(tabs.length - 1);
   return lastTab
-    ? { position: "after", target: getDataLabel(lastTab) }
+    ? {
+        position: "after",
+        target: lastTab.dataset.gridLayoutItemId ?? getDataLabel(lastTab),
+      }
     : undefined;
 };
 
@@ -125,7 +128,12 @@ export function initializeDragContainer(
         type: "tabbed-component",
       });
 
-      dragContext.detachTab(gridId, gridLayoutItem.id, label);
+      dragContext.detachTab(
+        gridId,
+        gridLayoutItem.id,
+        gridLayoutItemId ?? "",
+        label,
+      );
       spaceMan.dragStart(tabIndex);
     }
   };

--- a/vuu-ui/packages/grid-layout/src/index.ts
+++ b/vuu-ui/packages/grid-layout/src/index.ts
@@ -5,6 +5,18 @@ export type {
 export { DragDropProviderNext } from "./drag-drop-next/DragDropProviderNext";
 export { GridLayout, type GridResizeDistribution } from "./GridLayout";
 export {
+  GridDragCoordinator,
+  createGridDropPlan,
+  type GridDragCoordinatorError,
+  type GridDragCoordinatorErrorCode,
+  type GridDragCoordinatorResult,
+  type GridDragCoordinatorState,
+  type GridDragSource,
+  type GridDropIntent,
+  type GridDropPlan,
+  type GridDropTarget,
+} from "./GridDragCoordinator";
+export {
   GridController,
   type GridCommittedTransition,
   type GridCommittedTransitionListener,

--- a/vuu-ui/packages/grid-layout/src/useAsDropTarget.ts
+++ b/vuu-ui/packages/grid-layout/src/useAsDropTarget.ts
@@ -5,8 +5,13 @@ import {
   queryClosest,
   type rect,
 } from "@vuu-ui/vuu-utils";
-import { DragEventHandler, useCallback, useRef } from "react";
-import { useGridLayoutDropHandler, useGridLayoutId } from "./GridLayoutContext";
+import { type DragEventHandler, useCallback, useRef } from "react";
+import {
+  useGridLayoutDragLeaveHandler,
+  useGridLayoutDragPreviewHandler,
+  useGridLayoutDropHandler,
+  useGridLayoutId,
+} from "./GridLayoutContext";
 import { useDragContext } from "./drag-drop-next/DragDropProviderNext";
 
 const DROPTARGET_CLASSNAME = "vuuDropTarget";
@@ -144,6 +149,8 @@ export const useAsDropTarget = () => {
   const dropTargetStateRef = useRef<DropTargetState>(NULL_STATE);
 
   const drop = useGridLayoutDropHandler();
+  const leave = useGridLayoutDragLeaveHandler();
+  const preview = useGridLayoutDragPreviewHandler();
   const dragContext = useDragContext();
   const layoutId = useGridLayoutId();
   const onDragEnter = useCallback<DragEventHandler>(
@@ -175,6 +182,8 @@ export const useAsDropTarget = () => {
           rect.top = top;
         } else if (currentDropTarget) {
           dropTargetStateRef.current.dropTarget = undefined;
+          dropTargetStateRef.current.position = undefined;
+          leave();
           // console.log(
           //   `%c[useAsDropTarget] clear droptarget ${currentDropTarget?.gridLayoutItemId}`,
           //   "color:brown;font-weight: bold;",
@@ -183,7 +192,7 @@ export const useAsDropTarget = () => {
         }
       }
     },
-    [dragContext, layoutId],
+    [dragContext, layoutId, leave],
   );
 
   // We could replace this with mouse move to reduce event rate
@@ -232,13 +241,18 @@ export const useAsDropTarget = () => {
                   addDropTargetPositionClassName(dropTarget.target, position);
                 }
                 dropTargetStateRef.current.position = position;
+                preview(
+                  dropTarget.gridLayoutItemId,
+                  dragContext.dragSource,
+                  position,
+                );
               }
             }
           }
         }
       }
     },
-    [dragContext, layoutId],
+    [dragContext, layoutId, preview],
   );
 
   const onDragLeave = useCallback<DragEventHandler>(
@@ -258,12 +272,13 @@ export const useAsDropTarget = () => {
         if (dropTarget === currentDropTarget) {
           dropTargetStateRef.current.dropTarget = undefined;
           dropTargetStateRef.current.position = undefined;
+          leave();
         }
 
         removeDropTargetPositionClassName(dropTarget.target);
       }
     },
-    [dragContext, layoutId],
+    [dragContext, layoutId, leave],
   );
 
   const onDrop = useCallback<DragEventHandler>(

--- a/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
@@ -2,7 +2,6 @@ import {
   asReactElements,
   isGridLayoutSplitDirection,
   isSimpleStateValue,
-  queryClosest,
   uuid,
 } from "@vuu-ui/vuu-utils";
 import {
@@ -22,7 +21,6 @@ import type {
   DragContextDropHandler,
 } from "./drag-drop-next/DragContextNext";
 import { layoutFromJson } from "./layoutFromJson";
-import { getClosestGridLayout } from "./grid-dom-utils";
 import {
   getActiveIndex,
   getGridArea,
@@ -40,7 +38,7 @@ import {
   type GridLayoutItemProps,
   isGridLayoutItem,
 } from "./GridLayoutItem";
-import { type GridItemRemoveReason, GridLayoutModel } from "./GridLayoutModel";
+import { GridLayoutModel } from "./GridLayoutModel";
 import {
   type GridLayoutDragEndHandler,
   useGridChangeHandler,
@@ -68,7 +66,11 @@ import {
   throwForGridCommandFailure,
 } from "./GridCommand";
 import { GridController } from "./GridController";
-import type { GridTransaction } from "./GridController";
+import {
+  GridDragCoordinator,
+  type GridDragSource,
+  type GridDropIntent,
+} from "./GridDragCoordinator";
 import { gridSnapshotToGridLayoutDescriptor } from "./grid-snapshot-adapters";
 import { isGridLayoutStackedItem } from "./GridLayoutStackedtem";
 import { useGridControllerSnapshot } from "./useGridControllerSnapshot";
@@ -199,6 +201,9 @@ export const useGridLayout = ({
   const [childElements, setChildElements] =
     useState<GridLayoutItemElements>(children);
   const childrenRef = useRef<GridLayoutItemElements>(childElements);
+  const contentRegistryRef = useRef(
+    new Map(children.map((element) => [element.props.id, element])),
+  );
 
   const setChildren = useCallback(
     (
@@ -213,6 +218,9 @@ export const useGridLayout = ({
         childrenRef.current = newChildren(prev);
       }
 
+      contentRegistryRef.current = new Map(
+        childrenRef.current.map((element) => [element.props.id, element]),
+      );
       setChildElements(childrenRef.current);
       onChangeChildElements?.(id, childrenRef.current.filter(isGridLayoutItem));
     },
@@ -260,10 +268,6 @@ export const useGridLayout = ({
     },
     [children, id, layout],
   );
-  const dragStartLayoutRef = useRef<GridLayoutDescriptor | undefined>(
-    undefined,
-  );
-  const dragTransactionRef = useRef<GridTransaction | undefined>(undefined);
   const gridController = useMemo(
     () =>
       new GridController(
@@ -274,44 +278,11 @@ export const useGridLayout = ({
     [gridLayoutModel, gridModel],
   );
   const snapshot = useGridControllerSnapshot(gridController);
-  const beginLegacyDragTransaction = useCallback(() => {
-    if (dragTransactionRef.current) {
-      return dragTransactionRef.current;
-    }
-    const result = gridController.beginTransaction("drag");
-    if (!result.ok) {
-      throw Error(result.error.message);
-    }
-    dragTransactionRef.current = result.transaction;
-    return result.transaction;
-  }, [gridController]);
-  const publishLegacyDragMutation = useCallback(() => {
-    const transaction = dragTransactionRef.current;
-    const result = transaction
-      ? transaction.dispatch({ type: "regenerate-placeholders" })
-      : gridController.dispatch({ type: "regenerate-placeholders" });
-    throwForGridCommandFailure(result);
-  }, [gridController]);
-  const commitLegacyDragTransaction = useCallback(() => {
-    const transaction = dragTransactionRef.current;
-    if (transaction) {
-      const result = transaction.commit();
-      if (!result.ok) {
-        throw Error(result.error.message);
-      }
-      dragTransactionRef.current = undefined;
-    }
-  }, []);
-  const rollbackLegacyDragTransaction = useCallback(() => {
-    const transaction = dragTransactionRef.current;
-    if (transaction) {
-      const result = transaction.rollback();
-      if (!result.ok) {
-        throw Error(result.error.message);
-      }
-      dragTransactionRef.current = undefined;
-    }
-  }, []);
+  const dragCoordinator = useMemo(
+    () => new GridDragCoordinator(id, gridController),
+    [gridController, id],
+  );
+  useEffect(() => () => dragCoordinator.dispose(), [dragCoordinator]);
   const contentIds = useMemo(
     () =>
       new Set(
@@ -328,16 +299,10 @@ export const useGridLayout = ({
       ),
     [childElements],
   );
-  const renderedChildren = useMemo(
-    () =>
-      snapshot.items.flatMap(({ id: itemId }) => {
-        const element = childElements.find(
-          ({ props: { id: elementId } }) => elementId === itemId,
-        );
-        return element ? [element] : [];
-      }),
-    [childElements, snapshot],
-  );
+  const renderedChildren = snapshot.items.flatMap(({ id: itemId }) => {
+    const element = contentRegistryRef.current.get(itemId);
+    return element ? [element] : [];
+  });
   const nonContentGridItems = useMemo<NonContentGridItems>(
     () => ({
       placeholderIds: snapshot.items
@@ -357,60 +322,43 @@ export const useGridLayout = ({
     [onChangeLayout, onChange],
   );
 
-  const removeGridItem = useCallback(
-    (id: string, reason: Extract<GridItemRemoveReason, "close" | "drag">) => {
-      if (reason === "close") {
-        setChildren((c) => c.filter((c) => c.props.id !== id));
-      } else {
-        // set a className
-        // this should be set in code that handles dragging, not code that handles close
-        const gridLayoutItem = gridModel.getChildItem(id, true);
-        gridLayoutItem.dragging = true;
-      }
-
-      gridLayoutModel.removeGridItem(id, reason);
-    },
-    [gridLayoutModel, gridModel, setChildren],
-  );
-
   const handleDragStart = useCallback<GridLayoutDragStartHandler>(
     (_evt, options) => {
       const { current: grid } = containerRef;
       if (grid) {
         if (options.type === "text/plain") {
-          dragStartLayoutRef.current = gridModel.toGridLayoutDescriptor();
-          beginLegacyDragTransaction();
+          const result = dragCoordinator.begin({
+            itemId: options.id,
+            kind: "existing-item",
+            sourceGridId: id,
+          });
+          if (!result.ok) {
+            throw Error(result.error.message);
+          }
         }
         requestAnimationFrame(() => {
           grid.classList.add("vuuDragging");
-          //TODO make this check more explicit
-          if (options.type === "text/plain") {
-            removeGridItem(options.id, "drag");
-            publishLegacyDragMutation();
-          }
         });
       }
     },
-    [
-      beginLegacyDragTransaction,
-      gridModel,
-      publishLegacyDragMutation,
-      removeGridItem,
-    ],
+    [dragCoordinator, id],
   );
 
   const handleDragEnd = useCallback<GridLayoutDragEndHandler>(
     (_evt, dropped) => {
       containerRef.current?.classList.remove("vuuDragging");
-      if (!dropped && dragStartLayoutRef.current) {
-        gridModel.restoreLayout(dragStartLayoutRef.current);
-        rollbackLegacyDragTransaction();
-      } else if (dropped) {
-        commitLegacyDragTransaction();
+      if (
+        !dropped &&
+        (dragCoordinator.state.phase === "dragging" ||
+          dragCoordinator.state.phase === "previewing")
+      ) {
+        const result = dragCoordinator.cancel();
+        if (!result.ok) {
+          throw Error(result.error.message);
+        }
       }
-      dragStartLayoutRef.current = undefined;
     },
-    [commitLegacyDragTransaction, gridModel, rollbackLegacyDragTransaction],
+    [dragCoordinator],
   );
 
   const addChildComponent = useCallback(
@@ -493,281 +441,262 @@ export const useGridLayout = ({
    */
   const handleDrop = useCallback<GridLayoutDropHandler>(
     (targetItemId, dragSource, position) => {
-      // console.log(`[useGridLayout#${id}] handleDrop`, {
-      //   targetItemId,
-      //   dragSource,
-      //   position,
-      // });
-
       const targetGridItem = gridModel.getChildItem(targetItemId, true);
-      const splitTargetId = isStackedItem(targetGridItem)
+      const targetId = isStackedItem(targetGridItem)
         ? targetGridItem.stackId
         : targetItemId;
-
       containerRef.current?.classList.remove("vuuDragging");
 
-      if (
-        isGridLayoutSplitDirection(position) &&
-        !gridLayoutModel.canSplitGridItem(splitTargetId, position)
-      ) {
-        if (sourceIsComponent(dragSource) && dragStartLayoutRef.current) {
-          gridModel.restoreLayout(dragStartLayoutRef.current);
-          dragStartLayoutRef.current = undefined;
-          rollbackLegacyDragTransaction();
-        }
-        return false;
-      }
-
-      if (sourceIsComponent(dragSource)) {
-        dragStartLayoutRef.current = undefined;
-        const droppedItemId = gridModel.validateChildId(dragSource.id);
-        const targetId = isStackedItem(targetGridItem)
-          ? targetGridItem.stackId
-          : targetItemId;
-
-        const droppedGridItem = gridModel.getChildItem(droppedItemId, true);
-        droppedGridItem.dragging = false;
-
-        // const gridItemElement = document.getElementById(droppedItemId);
-        // gridItemElement?.classList.remove("vuuGridLayoutItem-dragging");
-
-        if (isGridLayoutSplitDirection(position)) {
-          gridLayoutModel.dropSplitGridItem(droppedItemId, targetId, position);
-        } else if (position === "centre") {
-          gridLayoutModel.dropReplaceGridItem(droppedItemId, targetItemId);
-          setChildren((c) =>
-            c.filter((child) => child.props.id !== targetItemId),
-          );
-        } else if (position === "header") {
-          gridModel.stackChildItems(targetId, dragSource.id);
-          const stackId = droppedGridItem.stackId;
-          if (!stackId) {
-            throw Error(
-              `[useGridLayout#${id}] stacked component #${droppedItemId} has no stack id`,
-            );
-          }
-          gridModel.selectStackItem(stackId, droppedItemId);
-        }
-      } else if (sourceIsTabbedComponent(dragSource)) {
-        // We are dropping a component dragged from a tabstrip and dropping it into
-        // a regular grid position (i.e. not into another or same tabstrip)
-        if (!isGridLayoutSplitDirection(position)) {
-          return false;
-        }
-
-        const sourceGridItem = gridModel.getChildItem(dragSource.tab.id, true);
-
-        const targetId = isStackedItem(targetGridItem)
-          ? targetGridItem.stackId
-          : targetItemId;
-
-        sourceGridItem.stackId = undefined;
-        sourceGridItem.contentVisible = true;
-        sourceGridItem.contentDetached = undefined;
-
-        gridLayoutModel.dropSplitGridItem(
-          dragSource.tab.id,
-          targetId,
-          position,
-        );
-
-        // Important that we defer removing the tab until after the drop
-        // handling. Removing the tab will remove the entire tabstrip if
-        // only one tab remains after removing the dragged tab.
-        const removed = gridModel.removeStackItem(
-          dragSource.tabsId,
-          sourceGridItem.id,
-        );
-        if (!removed.ok) {
-          throw Error(removed.error.message);
-        }
-      } else if (sourceIsTemplate(dragSource)) {
-        // dragging from palette or similar
+      let coordinatorSource: GridDragSource;
+      let templateComponent: ReactElement | undefined;
+      let templateItemId: string | undefined;
+      if (sourceIsTemplate(dragSource)) {
         const { label = "New Item", ...restJSON } = JSON.parse(
           dragSource.componentJson,
         );
-
         const newChildId = uuid();
-        const gridModelChildItem = new GridModelChildItem({
-          id: newChildId,
-          column: { start: 1, end: 1 },
-          dropTarget: true,
-          header: layoutOptions?.newChildItem.header,
-          resizeable: "hv",
-          row: { start: 1, end: 1 },
-          title: label,
-        });
-        gridModel.addChildItem(gridModelChildItem);
-
-        const targetId = isStackedItem(targetGridItem)
-          ? targetGridItem.stackId
-          : targetItemId;
-
-        const component = layoutFromJson(restJSON as LayoutJSON);
-        if (position === "centre") {
-          const newGridItem = gridLayoutModel.dropReplaceGridItem(
-            gridModelChildItem.id,
-            targetItemId,
-          );
-          replaceChildComponent(targetItemId, component, newGridItem);
-        } else if (position === "header") {
-          gridModel.stackChildItems(targetItemId, newChildId);
-          const stackId = gridModel.getChildItem(newChildId, true).stackId;
-          if (!stackId) {
-            throw Error(
-              `[useGridLayout#${id}] stacked template #${newChildId} has no stack id`,
-            );
-          }
-          gridModel.selectStackItem(stackId, newChildId);
-          addChildComponent(component, gridModelChildItem);
-        } else {
-          gridLayoutModel.dropSplitGridItem(
-            gridModelChildItem.id,
-            targetId,
-            position,
-          );
-          addChildComponent(component, gridModelChildItem);
+        templateItemId = newChildId;
+        coordinatorSource = {
+          item: {
+            column: { span: 1, start: 1 },
+            dropTarget: true,
+            header: layoutOptions?.newChildItem.header,
+            id: newChildId,
+            resizeable: "hv",
+            row: { span: 1, start: 1 },
+            title: label,
+          },
+          kind: "palette-template",
+          templateId: dragSource.componentJson,
+        };
+        templateComponent = layoutFromJson(restJSON as LayoutJSON);
+        const begun = dragCoordinator.begin(coordinatorSource);
+        if (!begun.ok) {
+          throw Error(begun.error.message);
         }
+      } else if (sourceIsComponent(dragSource)) {
+        coordinatorSource = {
+          itemId: dragSource.id,
+          kind: "existing-item",
+          sourceGridId: dragSource.layoutId,
+        };
+        if (dragCoordinator.state.phase === "idle") {
+          const begun = dragCoordinator.begin(coordinatorSource);
+          if (!begun.ok) {
+            throw Error(begun.error.message);
+          }
+        }
+      } else if (sourceIsTabbedComponent(dragSource)) {
+        coordinatorSource = {
+          itemId: dragSource.tab.id,
+          kind: "stack-member",
+          selected: dragSource.isSelectedTab,
+          sourceGridId: dragSource.layoutId,
+          stackId: dragSource.tabsId,
+        };
       } else {
         throw Error(
           `[useGridLayout#${id}] unsupported drag source type for GridLayout drop`,
         );
       }
-      publishLegacyDragMutation();
-      commitLegacyDragTransaction();
+
+      let intent: GridDropIntent;
+      if (isGridLayoutSplitDirection(position)) {
+        intent = { kind: "split", position };
+      } else if (position === "centre") {
+        if (isStackedItem(targetGridItem)) {
+          return false;
+        }
+        intent = { kind: "replace" };
+      } else if (position === "header") {
+        intent = isStackedItem(targetGridItem)
+          ? { kind: "stack" }
+          : { kind: "create-stack" };
+      } else {
+        return false;
+      }
+      const preview = dragCoordinator.preview({
+        gridId: id,
+        intent,
+        targetId,
+      });
+      if (!preview.ok) {
+        if (
+          dragCoordinator.state.phase === "dragging" ||
+          dragCoordinator.state.phase === "previewing"
+        ) {
+          dragCoordinator.cancel();
+        }
+        return false;
+      }
+      const committed = dragCoordinator.commit();
+      if (!committed.ok) {
+        throw Error(committed.error.message);
+      }
+
+      if (!sourceIsTemplate(dragSource) && position === "centre") {
+        setChildren((current) =>
+          current.filter((child) => child.props.id !== targetItemId),
+        );
+      } else if (templateComponent) {
+        if (!templateItemId) {
+          throw Error(`[useGridLayout#${id}] template item id not allocated`);
+        }
+        const newItem = gridModel.getChildItem(templateItemId, true);
+        if (position === "centre") {
+          replaceChildComponent(targetItemId, templateComponent, newItem);
+        } else {
+          addChildComponent(templateComponent, newItem);
+        }
+      }
       return true;
     },
     [
       addChildComponent,
-      gridLayoutModel,
       gridModel,
       id,
       layoutOptions?.newChildItem.header,
-      commitLegacyDragTransaction,
-      publishLegacyDragMutation,
+      dragCoordinator,
       replaceChildComponent,
-      rollbackLegacyDragTransaction,
       setChildren,
     ],
   );
 
   const handleDetachTab = useCallback<DragContextDetachTabHandler>(
-    ({ gridId, tabsId, value }) => {
+    ({ gridId, itemId, tabsId }) => {
       if (gridId === id) {
-        beginLegacyDragTransaction();
-        gridModel.detachTab(tabsId, value);
-        publishLegacyDragMutation();
+        const stack = snapshot.stacks.find(({ id }) => id === tabsId);
+        if (!itemId || !stack?.itemIds.includes(itemId)) {
+          throw Error(
+            `[useGridLayout#${id}] cannot identify dragged tab #${itemId}`,
+          );
+        }
+        const result = dragCoordinator.begin({
+          itemId,
+          kind: "stack-member",
+          selected: stack?.selectedItemId === itemId,
+          sourceGridId: id,
+          stackId: tabsId,
+        });
+        if (!result.ok) {
+          throw Error(result.error.message);
+        }
       }
     },
-    [beginLegacyDragTransaction, gridModel, id, publishLegacyDragMutation],
+    [dragCoordinator, id, snapshot],
   );
 
   const handleCancelTabDrag = useCallback<DragContextCancelTabDragHandler>(
     ({ gridId }) => {
-      if (gridId === id) {
-        rollbackLegacyDragTransaction();
+      if (
+        gridId === id &&
+        (dragCoordinator.state.phase === "dragging" ||
+          dragCoordinator.state.phase === "previewing")
+      ) {
+        const result = dragCoordinator.cancel();
+        if (!result.ok) {
+          throw Error(result.error.message);
+        }
       }
     },
-    [id, rollbackLegacyDragTransaction],
+    [dragCoordinator, id],
   );
 
   const handleDropStackedItem = useCallback<DragContextDropHandler>(
     ({ dragSource, tabsId: targetStackItemId, dropPosition }) => {
-      if (sourceIsTabbedComponent(dragSource)) {
-        const { id: sourceStackItemId } = queryClosest(
-          document.getElementById(dragSource.tabsId),
-          ".vuuGridLayoutItem",
-          true,
-        );
-
-        if (sourceStackItemId === targetStackItemId) {
-          // ignore a drag within tabstrip this is not the closest layout, it will
-          // be handled by closest layout to tabstrip.
-          if (dragSource.layoutId === id) {
-            if (dropPosition) {
-              gridModel.moveItemWithinTabs(
-                sourceStackItemId,
-                dragSource.tab,
-                dropPosition,
-                dragSource.isSelectedTab,
-              );
-            } else {
-              throw Error(
-                "[useGridLayout] handleDropStackedItem no dropPosition for drop onto tabs",
-              );
-            }
-          }
-        } else if (sourceStackItemId && targetStackItemId && dropPosition) {
-          gridModel.moveItemBetweenTabs(
-            sourceStackItemId,
-            targetStackItemId,
-            dragSource.tab,
-            dropPosition,
-          );
-        }
-      } else if (targetStackItemId && dropPosition) {
-        if (sourceIsComponent(dragSource)) {
-          // console.log(
-          //   `[useGridLayout] dropping a standalone component #${dragSource.id} into a stack ${targetStackItemId}`,
-          //   {
-          //     dragSource,
-          //   },
-          // );
-          const added = gridModel.addStackMember(
-            targetStackItemId,
-            dragSource.id,
-            dropPosition,
-          );
-          if (!added.ok) {
-            throw Error(added.error.message);
-          }
-          const gridModelItem = gridModel.getChildItem(dragSource.id, true);
-          gridModelItem.dragging = false;
-        } else if (sourceIsTemplate(dragSource)) {
-          // we're dropping a template item onto a tabstrip. Check that
-          // we are handling this in the context of the correct layout
-          const gridId = getClosestGridLayout(targetStackItemId);
-          if (gridId === id) {
-            const { label = "New Item", ...restJSON } = JSON.parse(
-              dragSource.componentJson,
-            );
-            const { column, row } = gridModel.getChildItem(
-              targetStackItemId,
-              true,
-            );
-
-            const newChildId = uuid();
-            const gridModelChildItem = new GridModelChildItem({
-              id: newChildId,
-              column,
-              dropTarget: true,
-              header: layoutOptions?.newChildItem.header,
-              resizeable: "hv",
-              row,
-              stackId: targetStackItemId,
-              title: label,
-            });
-            gridModel.addChildItem(gridModelChildItem, dropPosition);
-
-            const component = layoutFromJson(restJSON as LayoutJSON);
-            addChildComponent(component, gridModelChildItem);
-          }
-        }
-      } else {
+      if (!targetStackItemId || !dropPosition) {
         throw Error(
           "[useGridLayout] handleDropStackedItem no details of the stacked drop target",
         );
       }
-      publishLegacyDragMutation();
-      commitLegacyDragTransaction();
+      const targetStack = snapshot.stacks.find(
+        ({ id }) => id === targetStackItemId,
+      );
+      if (!targetStack) {
+        return;
+      }
+      const targetItemId =
+        targetStack.itemIds.find(
+          (itemId) =>
+            itemId === dropPosition.target ||
+            snapshot.items.find(({ id }) => id === itemId)?.title ===
+              dropPosition.target,
+        ) ?? targetStack.itemIds.at(-1);
+      if (!targetItemId) {
+        return;
+      }
+
+      let component: ReactElement | undefined;
+      let newChildId: string | undefined;
+      if (sourceIsTemplate(dragSource)) {
+        const { label = "New Item", ...restJSON } = JSON.parse(
+          dragSource.componentJson,
+        );
+        newChildId = uuid();
+        component = layoutFromJson(restJSON as LayoutJSON);
+        const begun = dragCoordinator.begin({
+          item: {
+            column: { span: 1, start: 1 },
+            dropTarget: true,
+            header: layoutOptions?.newChildItem.header,
+            id: newChildId,
+            resizeable: "hv",
+            row: { span: 1, start: 1 },
+            title: label,
+          },
+          kind: "palette-template",
+          templateId: dragSource.componentJson,
+        });
+        if (!begun.ok) {
+          throw Error(begun.error.message);
+        }
+      } else if (
+        sourceIsComponent(dragSource) &&
+        dragCoordinator.state.phase === "idle"
+      ) {
+        const begun = dragCoordinator.begin({
+          itemId: dragSource.id,
+          kind: "existing-item",
+          sourceGridId: dragSource.layoutId,
+        });
+        if (!begun.ok) {
+          throw Error(begun.error.message);
+        }
+      }
+
+      const preview = dragCoordinator.preview({
+        gridId: id,
+        intent: {
+          kind: "stack",
+          position: dropPosition.position,
+          targetItemId,
+        },
+        targetId: targetStackItemId,
+      });
+      if (!preview.ok) {
+        if (
+          dragCoordinator.state.phase === "dragging" ||
+          dragCoordinator.state.phase === "previewing"
+        ) {
+          dragCoordinator.cancel();
+        }
+        return;
+      }
+      const committed = dragCoordinator.commit();
+      if (!committed.ok) {
+        throw Error(committed.error.message);
+      }
+      if (component && newChildId) {
+        addChildComponent(component, gridModel.getChildItem(newChildId, true));
+      }
     },
     [
       addChildComponent,
-      commitLegacyDragTransaction,
+      dragCoordinator,
       gridModel,
       id,
       layoutOptions?.newChildItem.header,
-      publishLegacyDragMutation,
+      snapshot,
     ],
   );
 

--- a/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
@@ -68,7 +68,6 @@ import {
 import { GridController } from "./GridController";
 import {
   GridDragCoordinator,
-  type GridDragSource,
   type GridDropIntent,
 } from "./GridDragCoordinator";
 import { gridSnapshotToGridLayoutDescriptor } from "./grid-snapshot-adapters";
@@ -282,6 +281,14 @@ export const useGridLayout = ({
     () => new GridDragCoordinator(id, gridController),
     [gridController, id],
   );
+  const provisionalTemplateRef = useRef<
+    | {
+        component: ReactElement;
+        componentJson: string;
+        itemId: string;
+      }
+    | undefined
+  >();
   useEffect(() => () => dragCoordinator.dispose(), [dragCoordinator]);
   const contentIds = useMemo(
     () =>
@@ -357,6 +364,7 @@ export const useGridLayout = ({
           throw Error(result.error.message);
         }
       }
+      provisionalTemplateRef.current = undefined;
     },
     [dragCoordinator],
   );
@@ -439,94 +447,169 @@ export const useGridLayout = ({
    * payload is either the id of an existing gridLayoutItem that we are dragging
    * of a json description of a new component
    */
-  const handleDrop = useCallback<GridLayoutDropHandler>(
-    (targetItemId, dragSource, position) => {
-      const targetGridItem = gridModel.getChildItem(targetItemId, true);
-      const targetId = isStackedItem(targetGridItem)
-        ? targetGridItem.stackId
-        : targetItemId;
-      containerRef.current?.classList.remove("vuuDragging");
-
-      let coordinatorSource: GridDragSource;
-      let templateComponent: ReactElement | undefined;
-      let templateItemId: string | undefined;
+  const prepareDragSource = useCallback(
+    (dragSource: Parameters<GridLayoutDropHandler>[1]) => {
       if (sourceIsTemplate(dragSource)) {
-        const { label = "New Item", ...restJSON } = JSON.parse(
-          dragSource.componentJson,
-        );
-        const newChildId = uuid();
-        templateItemId = newChildId;
-        coordinatorSource = {
-          item: {
-            column: { span: 1, start: 1 },
-            dropTarget: true,
-            header: layoutOptions?.newChildItem.header,
-            id: newChildId,
-            resizeable: "hv",
-            row: { span: 1, start: 1 },
-            title: label,
-          },
-          kind: "palette-template",
-          templateId: dragSource.componentJson,
-        };
-        templateComponent = layoutFromJson(restJSON as LayoutJSON);
-        const begun = dragCoordinator.begin(coordinatorSource);
-        if (!begun.ok) {
-          throw Error(begun.error.message);
+        let provisional = provisionalTemplateRef.current;
+        if (
+          !provisional ||
+          provisional.componentJson !== dragSource.componentJson
+        ) {
+          const { label = "New Item", ...restJSON } = JSON.parse(
+            dragSource.componentJson,
+          );
+          provisional = {
+            component: layoutFromJson(restJSON as LayoutJSON),
+            componentJson: dragSource.componentJson,
+            itemId: uuid(),
+          };
+          provisionalTemplateRef.current = provisional;
         }
-      } else if (sourceIsComponent(dragSource)) {
-        coordinatorSource = {
-          itemId: dragSource.id,
-          kind: "existing-item",
-          sourceGridId: dragSource.layoutId,
-        };
-        if (dragCoordinator.state.phase === "idle") {
-          const begun = dragCoordinator.begin(coordinatorSource);
+        if (
+          dragCoordinator.state.phase !== "dragging" &&
+          dragCoordinator.state.phase !== "previewing"
+        ) {
+          const begun = dragCoordinator.begin({
+            item: {
+              column: { span: 1, start: 1 },
+              dropTarget: true,
+              header: layoutOptions?.newChildItem.header,
+              id: provisional.itemId,
+              resizeable: "hv",
+              row: { span: 1, start: 1 },
+              title: JSON.parse(dragSource.componentJson).label ?? "New Item",
+            },
+            kind: "palette-template",
+            templateId: dragSource.componentJson,
+          });
           if (!begun.ok) {
             throw Error(begun.error.message);
           }
         }
-      } else if (sourceIsTabbedComponent(dragSource)) {
-        coordinatorSource = {
+      } else if (
+        sourceIsComponent(dragSource) &&
+        dragCoordinator.state.phase !== "dragging" &&
+        dragCoordinator.state.phase !== "previewing"
+      ) {
+        const begun = dragCoordinator.begin({
+          itemId: dragSource.id,
+          kind: "existing-item",
+          sourceGridId: dragSource.layoutId,
+        });
+        if (!begun.ok) {
+          throw Error(begun.error.message);
+        }
+      } else if (
+        sourceIsTabbedComponent(dragSource) &&
+        dragCoordinator.state.phase !== "dragging" &&
+        dragCoordinator.state.phase !== "previewing"
+      ) {
+        const begun = dragCoordinator.begin({
           itemId: dragSource.tab.id,
           kind: "stack-member",
           selected: dragSource.isSelectedTab,
           sourceGridId: dragSource.layoutId,
           stackId: dragSource.tabsId,
-        };
-      } else {
-        throw Error(
-          `[useGridLayout#${id}] unsupported drag source type for GridLayout drop`,
-        );
-      }
-
-      let intent: GridDropIntent;
-      if (isGridLayoutSplitDirection(position)) {
-        intent = { kind: "split", position };
-      } else if (position === "centre") {
-        if (isStackedItem(targetGridItem)) {
-          return false;
+        });
+        if (!begun.ok) {
+          throw Error(begun.error.message);
         }
-        intent = { kind: "replace" };
-      } else if (position === "header") {
-        intent = isStackedItem(targetGridItem)
-          ? { kind: "stack" }
-          : { kind: "create-stack" };
-      } else {
+      }
+    },
+    [dragCoordinator, layoutOptions?.newChildItem.header],
+  );
+
+  const handleDragLeave = useCallback(() => {
+    const templateDrag =
+      dragCoordinator.state.phase !== "idle" &&
+      dragCoordinator.state.source.kind === "palette-template";
+    if (dragCoordinator.state.phase === "previewing") {
+      const result = dragCoordinator.clearPreview();
+      if (!result.ok) {
+        throw Error(result.error.message);
+      }
+    }
+    if (templateDrag && dragCoordinator.state.phase === "dragging") {
+      const result = dragCoordinator.cancel();
+      if (!result.ok) {
+        throw Error(result.error.message);
+      }
+    }
+    provisionalTemplateRef.current = undefined;
+  }, [dragCoordinator]);
+
+  const handleDragPreview = useCallback<GridLayoutDropHandler>(
+    (targetItemId, dragSource, position) => {
+      const targetGridItem = gridModel.getChildItem(targetItemId, true);
+      if (position === "centre" && isStackedItem(targetGridItem)) {
         return false;
       }
-      const preview = dragCoordinator.preview({
-        gridId: id,
-        intent,
-        targetId,
-      });
-      if (!preview.ok) {
+      prepareDragSource(dragSource);
+      const targetId =
+        isGridLayoutSplitDirection(position) && isStackedItem(targetGridItem)
+          ? targetGridItem.stackId
+          : targetItemId;
+      const intent: GridDropIntent | undefined = isGridLayoutSplitDirection(
+        position,
+      )
+        ? { kind: "split", position }
+        : position === "centre"
+          ? { kind: "replace" }
+          : position === "header"
+            ? { kind: "create-stack" }
+            : undefined;
+      if (!intent) {
+        return false;
+      }
+      if (intent.kind !== "split") {
+        if (dragCoordinator.state.phase === "previewing") {
+          const cleared = dragCoordinator.clearPreview();
+          if (!cleared.ok) {
+            throw Error(cleared.error.message);
+          }
+        }
+        return true;
+      }
+      return dragCoordinator.preview({ gridId: id, intent, targetId }).ok;
+    },
+    [dragCoordinator, gridModel, id, prepareDragSource],
+  );
+
+  const handleDrop = useCallback<GridLayoutDropHandler>(
+    (targetItemId, dragSource, position) => {
+      const targetGridItem = gridModel.getChildItem(targetItemId, true);
+      containerRef.current?.classList.remove("vuuDragging");
+
+      prepareDragSource(dragSource);
+
+      if (
+        !isGridLayoutSplitDirection(position) &&
+        position !== "centre" &&
+        position !== "header"
+      ) {
+        return false;
+      }
+      if (position === "centre" && isStackedItem(targetGridItem)) {
+        return false;
+      }
+      const preview = isGridLayoutSplitDirection(position)
+        ? handleDragPreview(targetItemId, dragSource, position)
+        : dragCoordinator.preview({
+            gridId: id,
+            intent:
+              position === "centre"
+                ? { kind: "replace" }
+                : { kind: "create-stack" },
+            targetId: targetItemId,
+          }).ok;
+      if (!preview) {
         if (
           dragCoordinator.state.phase === "dragging" ||
           dragCoordinator.state.phase === "previewing"
         ) {
           dragCoordinator.cancel();
         }
+        provisionalTemplateRef.current = undefined;
         return false;
       }
       const committed = dragCoordinator.commit();
@@ -538,16 +621,18 @@ export const useGridLayout = ({
         setChildren((current) =>
           current.filter((child) => child.props.id !== targetItemId),
         );
-      } else if (templateComponent) {
-        if (!templateItemId) {
+      } else if (sourceIsTemplate(dragSource)) {
+        const provisional = provisionalTemplateRef.current;
+        if (!provisional) {
           throw Error(`[useGridLayout#${id}] template item id not allocated`);
         }
-        const newItem = gridModel.getChildItem(templateItemId, true);
+        const newItem = gridModel.getChildItem(provisional.itemId, true);
         if (position === "centre") {
-          replaceChildComponent(targetItemId, templateComponent, newItem);
+          replaceChildComponent(targetItemId, provisional.component, newItem);
         } else {
-          addChildComponent(templateComponent, newItem);
+          addChildComponent(provisional.component, newItem);
         }
+        provisionalTemplateRef.current = undefined;
       }
       return true;
     },
@@ -555,8 +640,9 @@ export const useGridLayout = ({
       addChildComponent,
       gridModel,
       id,
-      layoutOptions?.newChildItem.header,
       dragCoordinator,
+      handleDragPreview,
+      prepareDragSource,
       replaceChildComponent,
       setChildren,
     ],
@@ -835,6 +921,8 @@ export const useGridLayout = ({
     onCancelTabDrag: handleCancelTabDrag,
     onDetachTab: handleDetachTab,
     onDragEnd: handleDragEnd,
+    onDragLeave: handleDragLeave,
+    onDragPreview: handleDragPreview,
     onDragStart: handleDragStart,
     onDrop: handleDrop,
     onDropStackedItem: handleDropStackedItem,

--- a/vuu-ui/packages/grid-layout/test/GridController.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridController.test.ts
@@ -150,6 +150,48 @@ describe("GridController external store", () => {
 });
 
 describe("GridController transactions", () => {
+  it("atomically replaces a preview from the transaction baseline", () => {
+    const controller = new GridController(modelWithTwoItems(), 3);
+    const start = controller.beginTransaction("drag");
+    expect(start.ok).toBe(true);
+    if (!start.ok) {
+      return;
+    }
+
+    expect(start.transaction.replace([resizeColumn(0, "125px")])).toMatchObject(
+      {
+        ok: true,
+      },
+    );
+    expect(controller.getSnapshot().columns[0].size).toBe("125px");
+    expect(start.transaction.replace([resizeColumn(1, "80px")])).toMatchObject({
+      ok: true,
+    });
+    expect(controller.getSnapshot().columns.map(({ size }) => size)).toEqual([
+      "100px",
+      "80px",
+    ]);
+
+    expect(
+      start.transaction.replace([
+        {
+          itemId: "missing",
+          title: "Missing",
+          type: "rename-item",
+        },
+      ]),
+    ).toMatchObject({ error: { code: "ITEM_NOT_FOUND" }, ok: false });
+    expect(controller.getSnapshot().columns.map(({ size }) => size)).toEqual([
+      "100px",
+      "100px",
+    ]);
+    expect(start.transaction.commit()).toEqual({
+      ok: true,
+      snapshot: controller.getSnapshot(),
+    });
+    expect(controller.getSnapshot().revision).toBe(3);
+  });
+
   it("publishes previews at the committed revision and commits once", () => {
     const controller = new GridController(modelWithTwoItems(), 4);
     const stateListener = vi.fn();

--- a/vuu-ui/packages/grid-layout/test/GridDragCoordinator.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridDragCoordinator.test.ts
@@ -1,0 +1,456 @@
+import { describe, expect, it, vi } from "vitest";
+import { GridController } from "../src/GridController";
+import {
+  GridDragCoordinator,
+  createGridDropPlan,
+  type GridDragSource,
+} from "../src/GridDragCoordinator";
+import { GridModel } from "../src/GridModel";
+import { descriptor, item } from "./model-scenario-harness";
+
+const createController = (id = "grid") =>
+  new GridController(
+    new GridModel(
+      id,
+      descriptor(["1fr", "1fr"], ["1fr"], {
+        left: item("1/1/2/2", { resizeable: "hv", title: "Duplicate" }),
+        right: item("1/2/2/3", { resizeable: "hv", title: "Duplicate" }),
+      }),
+    ),
+  );
+
+const createThreeItemController = () =>
+  new GridController(
+    new GridModel(
+      "grid",
+      descriptor(["1fr", "1fr", "1fr"], ["1fr"], {
+        alpha: item("1/1/2/2", { resizeable: "hv", title: "Same" }),
+        beta: item("1/2/2/3", { resizeable: "hv", title: "Same" }),
+        gamma: item("1/3/2/4", { resizeable: "hv", title: "Gamma" }),
+      }),
+    ),
+  );
+
+const existing = (itemId: string, sourceGridId = "grid"): GridDragSource => ({
+  itemId,
+  kind: "existing-item",
+  sourceGridId,
+});
+
+const template: GridDragSource = {
+  item: {
+    column: { span: 1, start: 1 },
+    dropTarget: true,
+    header: true,
+    id: "template-instance",
+    resizeable: "hv",
+    row: { span: 1, start: 1 },
+    title: "Template",
+  },
+  kind: "palette-template",
+  templateId: "palette-template",
+};
+
+describe("createGridDropPlan", () => {
+  it.each([
+    "north",
+    "south",
+    "east",
+    "west",
+  ] as const)("translates an existing-item %s split to typed commands", (position) => {
+    expect(
+      createGridDropPlan(existing("left"), {
+        gridId: "grid",
+        intent: { kind: "split", position },
+        targetId: "right",
+      }),
+    ).toMatchObject({
+      commands: [
+        { itemId: "left", position, targetId: "right", type: "move-item" },
+        { type: "regenerate-placeholders" },
+      ],
+    });
+  });
+
+  it("materializes a template before replace, stack create, or stack add", () => {
+    expect(
+      createGridDropPlan(template, {
+        gridId: "grid",
+        intent: { kind: "replace" },
+        targetId: "left",
+      }),
+    ).toMatchObject({
+      commands: [
+        { item: { id: "template-instance" }, type: "add-item" },
+        {
+          itemId: "template-instance",
+          targetId: "left",
+          type: "replace-item",
+        },
+        { type: "regenerate-placeholders" },
+      ],
+    });
+    expect(
+      createGridDropPlan(template, {
+        gridId: "grid",
+        intent: { kind: "create-stack" },
+        targetId: "left",
+      }),
+    ).toMatchObject({
+      commands: [
+        { item: { id: "template-instance" }, type: "add-item" },
+        {
+          itemId: "template-instance",
+          targetId: "left",
+          type: "create-stack",
+        },
+        { type: "regenerate-placeholders" },
+      ],
+    });
+    expect(
+      createGridDropPlan(template, {
+        gridId: "grid",
+        intent: {
+          kind: "stack",
+          position: "after",
+          targetItemId: "left",
+        },
+        targetId: "stack",
+      }),
+    ).toMatchObject({
+      commands: [
+        {
+          item: { id: "template-instance" },
+          stackId: "stack",
+          type: "add-stack-item",
+        },
+        {
+          itemId: "template-instance",
+          stackId: "stack",
+          type: "select-stack-item",
+        },
+        { type: "regenerate-placeholders" },
+      ],
+    });
+  });
+
+  it("blocks existing items across controller scopes while allowing templates", () => {
+    expect(
+      createGridDropPlan(existing("left", "parent"), {
+        gridId: "child",
+        intent: { kind: "replace" },
+        targetId: "child-item",
+      }),
+    ).toMatchObject({ code: "CROSS_GRID_DRAG" });
+    expect(
+      createGridDropPlan(template, {
+        gridId: "child",
+        intent: { kind: "replace" },
+        targetId: "child-item",
+      }),
+    ).toMatchObject({
+      commands: [
+        { type: "add-item" },
+        { itemId: "template-instance", type: "replace-item" },
+        { type: "regenerate-placeholders" },
+      ],
+    });
+  });
+
+  it("uses stable IDs for reorder even when titles are duplicated", () => {
+    expect(
+      createGridDropPlan(
+        {
+          itemId: "right",
+          kind: "stack-member",
+          selected: true,
+          sourceGridId: "grid",
+          stackId: "stack",
+        },
+        {
+          gridId: "grid",
+          intent: {
+            kind: "stack",
+            position: "before",
+            targetItemId: "left",
+          },
+          targetId: "stack",
+        },
+      ),
+    ).toMatchObject({
+      commands: [
+        {
+          activate: true,
+          itemId: "right",
+          position: "before",
+          stackId: "stack",
+          targetItemId: "left",
+          type: "reorder-stack-item",
+        },
+        { type: "regenerate-placeholders" },
+      ],
+    });
+  });
+});
+
+describe("GridDragCoordinator", () => {
+  it.each([
+    "north",
+    "south",
+    "east",
+    "west",
+  ] as const)("commits a palette template %s split as one revision", (position) => {
+    const controller = createController();
+    const coordinator = new GridDragCoordinator("grid", controller);
+    const committed = vi.fn();
+    controller.subscribeCommitted(committed);
+    coordinator.begin(template);
+
+    expect(
+      coordinator.preview({
+        gridId: "grid",
+        intent: { kind: "split", position },
+        targetId: "left",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(coordinator.commit()).toMatchObject({ ok: true });
+
+    expect(controller.getSnapshot().revision).toBe(1);
+    expect(
+      controller
+        .getSnapshot()
+        .items.some(({ id }) => id === "template-instance"),
+    ).toBe(true);
+    expect(committed).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a stack and moves standalone and stacked members through commands", () => {
+    const controller = createThreeItemController();
+    const create = new GridDragCoordinator("grid", controller);
+    create.begin(existing("beta"));
+    create.preview({
+      gridId: "grid",
+      intent: { kind: "create-stack" },
+      targetId: "alpha",
+    });
+
+    expect(create.commit()).toMatchObject({ ok: true });
+    const stackId = controller.getSnapshot().stacks[0]?.id;
+    expect(stackId).toBeDefined();
+    if (!stackId) {
+      return;
+    }
+
+    const stackedReplacement = new GridDragCoordinator("grid", controller);
+    stackedReplacement.begin({
+      itemId: "beta",
+      kind: "stack-member",
+      selected: true,
+      sourceGridId: "grid",
+      stackId,
+    });
+    expect(
+      stackedReplacement.preview({
+        gridId: "grid",
+        intent: { kind: "replace" },
+        targetId: "alpha",
+      }),
+    ).toMatchObject({
+      error: { code: "TRANSACTION_FAILURE" },
+      ok: false,
+    });
+    expect(controller.getSnapshot().stacks[0].itemIds).toEqual([
+      "alpha",
+      "beta",
+    ]);
+    stackedReplacement.cancel();
+
+    const baseline = controller.getSnapshot();
+    expect(
+      controller.dispatch({
+        itemId: "gamma",
+        position: "before",
+        stackId,
+        targetItemId: "missing",
+        type: "move-item-to-stack",
+      }),
+    ).toMatchObject({ error: { code: "TAB_NOT_FOUND" }, ok: false });
+    expect(controller.getSnapshot()).toBe(baseline);
+
+    const add = new GridDragCoordinator("grid", controller);
+    add.begin(existing("gamma"));
+    add.preview({
+      gridId: "grid",
+      intent: {
+        kind: "stack",
+        position: "after",
+        targetItemId: "alpha",
+      },
+      targetId: stackId,
+    });
+    expect(add.commit()).toMatchObject({ ok: true });
+    expect(controller.getSnapshot().stacks[0].itemIds).toEqual([
+      "alpha",
+      "gamma",
+      "beta",
+    ]);
+    expect(controller.getSnapshot().stacks[0].selectedItemId).toBe("gamma");
+
+    const detach = new GridDragCoordinator("grid", controller);
+    detach.begin({
+      itemId: "gamma",
+      kind: "stack-member",
+      selected: true,
+      sourceGridId: "grid",
+      stackId,
+    });
+    detach.preview({
+      gridId: "grid",
+      intent: { kind: "split", position: "south" },
+      targetId: stackId,
+    });
+    expect(detach.commit()).toMatchObject({ ok: true });
+    expect(controller.getSnapshot().stacks[0].itemIds).toEqual([
+      "alpha",
+      "beta",
+    ]);
+    expect(
+      controller.getSnapshot().items.find(({ id }) => id === "gamma"),
+    ).toMatchObject({ id: "gamma", title: "Gamma" });
+  });
+
+  it("moves a member out of a two-item stack without losing the dissolved target", () => {
+    const controller = createController();
+    const create = new GridDragCoordinator("grid", controller);
+    create.begin(existing("right"));
+    create.preview({
+      gridId: "grid",
+      intent: { kind: "create-stack" },
+      targetId: "left",
+    });
+    create.commit();
+    const stackId = controller.getSnapshot().stacks[0]?.id;
+    expect(stackId).toBeDefined();
+    if (!stackId) {
+      return;
+    }
+
+    const detach = new GridDragCoordinator("grid", controller);
+    detach.begin({
+      itemId: "right",
+      kind: "stack-member",
+      selected: true,
+      sourceGridId: "grid",
+      stackId,
+    });
+    expect(
+      detach.preview({
+        gridId: "grid",
+        intent: { kind: "split", position: "south" },
+        targetId: stackId,
+      }),
+    ).toMatchObject({ ok: true });
+    expect(detach.commit()).toMatchObject({ ok: true });
+    expect(controller.getSnapshot().stacks).toEqual([]);
+    expect(
+      controller
+        .getSnapshot()
+        .items.filter(({ id }) => id === "left" || id === "right"),
+    ).toHaveLength(2);
+  });
+
+  it("replaces each preview from the exact baseline and commits once", () => {
+    const controller = createController();
+    const coordinator = new GridDragCoordinator("grid", controller);
+    const committed = vi.fn();
+    controller.subscribeCommitted(committed);
+
+    expect(coordinator.begin(existing("left"))).toMatchObject({ ok: true });
+    expect(
+      coordinator.preview({
+        gridId: "grid",
+        intent: { kind: "split", position: "north" },
+        targetId: "right",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(controller.getSnapshot().rows).toHaveLength(2);
+
+    expect(
+      coordinator.preview({
+        gridId: "grid",
+        intent: { kind: "split", position: "west" },
+        targetId: "right",
+      }),
+    ).toMatchObject({ ok: true });
+    expect(controller.getSnapshot().rows).toHaveLength(1);
+    expect(controller.getSnapshot().columns.length).toBeGreaterThanOrEqual(2);
+
+    expect(coordinator.commit()).toMatchObject({ ok: true });
+    expect(controller.getSnapshot().revision).toBe(1);
+    expect(committed).toHaveBeenCalledTimes(1);
+    expect(committed.mock.calls[0][0].commands).toEqual([
+      {
+        itemId: "left",
+        position: "west",
+        targetId: "right",
+        type: "move-item",
+      },
+      { type: "regenerate-placeholders" },
+    ]);
+  });
+
+  it("rolls back cancel, invalid targets, and disposal without a revision", () => {
+    for (const close of ["cancel", "dispose"] as const) {
+      const controller = createController();
+      const baseline = controller.getSnapshot();
+      const coordinator = new GridDragCoordinator("grid", controller);
+      const committed = vi.fn();
+      controller.subscribeCommitted(committed);
+      coordinator.begin(existing("left"));
+      coordinator.preview({
+        gridId: "grid",
+        intent: { kind: "replace" },
+        targetId: "right",
+      });
+
+      coordinator[close]();
+
+      expect(controller.getSnapshot()).toBe(baseline);
+      expect(committed).not.toHaveBeenCalled();
+    }
+
+    const controller = createController();
+    const baseline = controller.getSnapshot();
+    const coordinator = new GridDragCoordinator("grid", controller);
+    coordinator.begin(existing("left"));
+    expect(
+      coordinator.preview({
+        gridId: "other",
+        intent: { kind: "replace" },
+        targetId: "right",
+      }),
+    ).toMatchObject({ error: { code: "CROSS_GRID_DRAG" }, ok: false });
+    expect(controller.getSnapshot()).toBe(baseline);
+  });
+
+  it("returns typed invalid-transition and command failures", () => {
+    const controller = createController();
+    const coordinator = new GridDragCoordinator("grid", controller);
+    expect(coordinator.commit()).toMatchObject({
+      error: { code: "INVALID_TRANSITION" },
+      ok: false,
+    });
+    coordinator.begin(existing("left"));
+    expect(
+      coordinator.preview({
+        gridId: "grid",
+        intent: { kind: "replace" },
+        targetId: "missing",
+      }),
+    ).toMatchObject({
+      error: { code: "TRANSACTION_FAILURE" },
+      ok: false,
+    });
+    expect(controller.getSnapshot().revision).toBe(0);
+  });
+});

--- a/vuu-ui/packages/grid-layout/test/GridLayout.snapshot-rendering.react.test.tsx
+++ b/vuu-ui/packages/grid-layout/test/GridLayout.snapshot-rendering.react.test.tsx
@@ -1,6 +1,6 @@
-import { act, useState } from "react";
+import { act, StrictMode, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type GridController,
   GridLayout,
@@ -243,6 +243,7 @@ describe("GridLayout canonical snapshot rendering", () => {
         </GridLayout>,
       );
     });
+
     const initialChildController = childController;
     const initialChildSnapshot = childController?.getSnapshot();
 
@@ -257,6 +258,39 @@ describe("GridLayout canonical snapshot rendering", () => {
 
     expect(childController).toBe(initialChildController);
     expect(childController?.getSnapshot()).toBe(initialChildSnapshot);
+  });
+
+  it("cleans drag cancellation listeners across StrictMode remounts", () => {
+    const addListener = vi.spyOn(window, "addEventListener");
+    const removeListener = vi.spyOn(window, "removeEventListener");
+    act(() => {
+      root.render(
+        <StrictMode>
+          <GridLayout
+            colsAndRows={{ cols: ["1fr"], rows: ["1fr"] }}
+            id="strict-drag-grid"
+          >
+            <GridLayoutItem id="strict-item" style={{ gridArea: "1/1/2/2" }}>
+              Strict
+            </GridLayoutItem>
+          </GridLayout>
+        </StrictMode>,
+      );
+    });
+    act(() => root.unmount());
+
+    for (const eventName of ["keydown", "pointercancel"]) {
+      const additions = addListener.mock.calls.filter(
+        ([name]) => name === eventName,
+      );
+      const removals = removeListener.mock.calls.filter(
+        ([name]) => name === eventName,
+      );
+      expect(removals).toHaveLength(additions.length);
+      for (const [, listener] of additions) {
+        expect(removals.some(([, removed]) => removed === listener)).toBe(true);
+      }
+    }
   });
 
   it("persists content without treating stack templates as serializable items", () => {

--- a/vuu-ui/packages/grid-layout/test/GridLayout.snapshot-rendering.react.test.tsx
+++ b/vuu-ui/packages/grid-layout/test/GridLayout.snapshot-rendering.react.test.tsx
@@ -10,6 +10,10 @@ import {
   useGridController,
   useGridLayoutDispatch,
 } from "../src";
+import {
+  useGridLayoutDragLeaveHandler,
+  useGridLayoutDragPreviewHandler,
+} from "../src/GridLayoutContext";
 
 const ControllerCapture = ({
   capture,
@@ -17,6 +21,18 @@ const ControllerCapture = ({
   capture: (controller: GridController) => void;
 }) => {
   capture(useGridController());
+  return null;
+};
+
+const DragHandlerCapture = ({
+  capture,
+}: {
+  capture: (
+    preview: ReturnType<typeof useGridLayoutDragPreviewHandler>,
+    leave: ReturnType<typeof useGridLayoutDragLeaveHandler>,
+  ) => void;
+}) => {
+  capture(useGridLayoutDragPreviewHandler(), useGridLayoutDragLeaveHandler());
   return null;
 };
 
@@ -277,6 +293,7 @@ describe("GridLayout canonical snapshot rendering", () => {
         </StrictMode>,
       );
     });
+
     act(() => root.unmount());
 
     for (const eventName of ["keydown", "pointercancel"]) {
@@ -291,6 +308,61 @@ describe("GridLayout canonical snapshot rendering", () => {
         expect(removals.some(([, removed]) => removed === listener)).toBe(true);
       }
     }
+  });
+
+  it("publishes cardinal previews and restores the baseline on drag leave", () => {
+    let controller: GridController | undefined;
+    let preview: ReturnType<typeof useGridLayoutDragPreviewHandler> | undefined;
+    let leave: ReturnType<typeof useGridLayoutDragLeaveHandler> | undefined;
+    act(() => {
+      root.render(
+        <GridLayout
+          colsAndRows={{ cols: ["1fr", "1fr"], rows: ["1fr"] }}
+          id="preview-grid"
+        >
+          <GridLayoutItem
+            id="preview-left"
+            resizeable="hv"
+            style={{ gridArea: "1/1/2/2" }}
+          >
+            <ControllerCapture capture={(value) => (controller = value)} />
+            <DragHandlerCapture
+              capture={(previewHandler, leaveHandler) => {
+                preview = previewHandler;
+                leave = leaveHandler;
+              }}
+            />
+          </GridLayoutItem>
+          <GridLayoutItem
+            id="preview-right"
+            resizeable="hv"
+            style={{ gridArea: "1/2/2/3" }}
+          >
+            Right
+          </GridLayoutItem>
+        </GridLayout>,
+      );
+    });
+    const baseline = controller?.getSnapshot();
+
+    act(() => {
+      preview?.(
+        "preview-right",
+        {
+          element: document.createElement("div"),
+          id: "preview-left",
+          label: "Left",
+          layoutId: "preview-grid",
+          type: "component",
+        },
+        "north",
+      );
+    });
+    expect(controller?.getSnapshot().revision).toBe(0);
+    expect(controller?.getSnapshot().rows).toHaveLength(2);
+
+    act(() => leave?.());
+    expect(controller?.getSnapshot()).toBe(baseline);
   });
 
   it("persists content without treating stack templates as serializable items", () => {


### PR DESCRIPTION
## Summary

- introduce a per-grid `GridDragCoordinator` with typed idle, dragging, previewing, committed, and cancelled states; typed existing-item, stack-member, and palette-template sources; and explicit split, replace, create-stack, stack-add, and reorder plans
- execute every durable drag outcome as typed commands through one target `GridController` transaction, including atomic baseline-replacing previews, exact rollback, one-revision commit, deterministic closed-transaction errors, and typed failure restoration
- route GridLayout drag-over, leave, drop, Escape, pointer-cancel, unmount, and nested ownership changes through the coordinator while retaining only hover classes, tab spacing, and pointer measurements as presentation state
- keep React content in the ID-keyed registry, allocate palette IDs provisionally on first eligible target, retain content only after commit, and discard provisional content/IDs on leave or cancellation
- replace direct drag-time `GridModel`/`GridLayoutModel` mutation, descriptor rollback, detached-tab authority, and the increment-6 legacy transaction bridge; stack movement, dissolution, selection, and stable-ID reorder now use canonical commands

## Transaction and routing semantics

Cardinal target changes restore the original checkpoint before applying the next plan. Centre/header plans are applied on drop so their structural preview cannot unmount the active native HTML drop target. Existing items and tabs are rejected across controller scopes; provider-scoped palette templates may transfer to the deepest eligible nested grid. Leaving a nested/outer target rolls back only that grid’s preview.

## Supported drag matrix

- palette template: placeholder/empty placement, cardinal split, standalone centre replacement, standalone header stack creation, existing stack add
- standalone item: cardinal move/split, standalone centre replacement, header stack creation, existing stack add
- stack member: cardinal detach to standalone, standalone centre replacement, same-stack stable-ID reorder, between-stack move with canonical dissolution
- duplicate titles preserve item identity and selection by ID; two-member stack dissolution retains a valid split target

The existing Playwright fixmes for native placeholder delivery, template centre delivery, and spacer-animation tab reorder remain intentionally unchanged; this increment does not claim those harness limitations are resolved.

## Tests and validation

- complete GridLayout Vitest: **259 passed, 2 existing todo** across 12 files
- added coordinator/plan/transaction tests for all cardinal directions, templates, stack create/add/detach/reorder identity, target replacement, failure atomicity, baseline replacement, rollback, nested scope rejection, no-op revisions, and two-tab dissolution
- added React coverage for real context preview/leave rollback and StrictMode listener cleanup
- GridLayout package build: passed
- targeted Biome check: passed
- type-definition generation: zero changed-GridLayout errors; blocked by existing errors in `vuu-data-react` and `vuu-utils`
- Playwright component attempt: blocked before fixture mount by existing Showcase bundling failures (`UserSettingsPanel` export and missing `feature-filter-table`); 33 tests did not run, 3 existing fixmes skipped

## Deferred

Versioned persistence/settings, catalogs, undo/redo, collaboration, responsive behavior, keyboard/touch redesign, and consumer migration remain in later increments.