### PR TITLE
fix(grid-layout): restore drag drop affordances

### DIFF
--- a/vuu-ui/packages/grid-layout/src/GridCommand.ts
+++ b/vuu-ui/packages/grid-layout/src/GridCommand.ts
@@ -97,6 +97,7 @@ export type GridCommand =
   | ({ readonly type: "resize-tracks" } & GridTrackResize)
   | {
       readonly itemId: GridItemId;
+      readonly selectedItemId?: GridItemId;
       readonly targetId: GridItemId;
       readonly type: "create-stack";
     }
@@ -523,6 +524,15 @@ export class LegacyGridCommandExecutor {
         );
         if (!created.ok) {
           return stackFailure(command, created.error);
+        }
+        if (command.selectedItemId) {
+          const selected = this.gridModel.selectStackItem(
+            created.value.stackId,
+            command.selectedItemId,
+          );
+          if (!selected.ok) {
+            return stackFailure(command, selected.error);
+          }
         }
         return success(command);
       }

--- a/vuu-ui/packages/grid-layout/src/GridDragCoordinator.ts
+++ b/vuu-ui/packages/grid-layout/src/GridDragCoordinator.ts
@@ -179,6 +179,7 @@ export const createGridDropPlan = (
       }
       commands.push({
         itemId,
+        selectedItemId: itemId,
         targetId: target.targetId,
         type: "create-stack",
       });

--- a/vuu-ui/packages/grid-layout/src/GridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayout.tsx
@@ -83,11 +83,13 @@ export const GridLayout = ({
     children,
     containerCallback,
     dispatchGridLayoutAction,
+    dragSourceItemId,
     gridController,
     gridLayoutModel,
     gridModel,
     gridSnapshot,
     nonContentGridItems: { placeholderIds, splitters, stackIds },
+    onCancelDrag,
     onCancelTabDrag,
     onDetachTab,
     onDragEnd,
@@ -128,6 +130,7 @@ export const GridLayout = ({
     <GridLayoutContext.Provider
       value={{
         dispatchGridLayoutAction,
+        dragSourceItemId,
         gridController,
         gridLayoutModel,
         gridModel,
@@ -142,6 +145,7 @@ export const GridLayout = ({
     >
       <DragDropProviderNext
         dragSources={NO_DRAG_SOURCES}
+        onCancelDrag={onCancelDrag}
         onCancelTabDrag={onCancelTabDrag}
         onDetachTab={onDetachTab}
         onDrop={onDropStackedItem}

--- a/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
@@ -169,6 +169,7 @@ export type GridLayoutDragLeaveHandler = () => void;
 
 export interface GridLayoutContextProps {
   dispatchGridLayoutAction: GridLayoutDispatch;
+  dragSourceItemId?: string;
   gridController?: GridController;
   gridLayoutModel?: GridLayoutModel;
   gridModel?: GridModel;
@@ -254,4 +255,9 @@ export const useGridSnapshot = () => {
 export const useGridLayoutId = () => {
   const { id } = useContext(GridLayoutContext);
   return id;
+};
+
+export const useGridLayoutDragSourceItemId = () => {
+  const { dragSourceItemId } = useContext(GridLayoutContext);
+  return dragSourceItemId;
 };

--- a/vuu-ui/packages/grid-layout/src/GridLayoutItem.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutItem.tsx
@@ -15,6 +15,7 @@ import {
   DragSourceProvider,
   useGridLayoutDispatch,
   useGridLayoutDragEndHandler,
+  useGridLayoutDragSourceItemId,
   useGridLayoutDragStartHandler,
 } from "./GridLayoutContext";
 import {
@@ -138,6 +139,7 @@ export const GridLayoutItem = ({
   });
 
   const onDragEnd = useGridLayoutDragEndHandler();
+  const dragSourceItemId = useGridLayoutDragSourceItemId();
   const onDragStart = useGridLayoutDragStartHandler();
 
   const onClose = useCallback<MouseEventHandler<HTMLButtonElement>>(
@@ -158,7 +160,7 @@ export const GridLayoutItem = ({
   });
 
   const className = cx(classBaseItem, {
-    "vuuGridLayoutItem-dragging": dragging,
+    "vuuGridLayoutItem-dragging": dragging || dragSourceItemId === id,
     "vuu-detached": contentDetached,
     "vuu-stacked": stacked && !contentDetached,
     "has-h-splitter": horizontalSplitter,

--- a/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayout.playwright.test.tsx
+++ b/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayout.playwright.test.tsx
@@ -510,8 +510,13 @@ test.describe("GridLayout browser interactions", () => {
     const component = await mount(fixture, { variant: "split-constraints" });
     const grid = new GridLayoutDriver(component, page);
 
-    await grid.dragItem("movable", "locked", "east");
+    const accepted = await grid.attemptRejectedDrag(
+      grid.header("movable"),
+      grid.content("locked"),
+      "east",
+    );
 
+    expect(accepted).toBe(false);
     await expect(grid.item("movable")).toBeVisible();
     await expect(grid.item("locked")).toBeVisible();
     expect(await grid.gridArea("movable")).toBe("1/1/2/2");

--- a/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayoutDriver.ts
+++ b/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayoutDriver.ts
@@ -40,10 +40,11 @@ export class GridLayoutDriver {
   }
 
   separator(orientation?: "horizontal" | "vertical") {
-    const separators = this.root.getByRole("separator");
     return orientation
-      ? separators.locator(`[aria-orientation="${orientation}"]`)
-      : separators;
+      ? this.root.locator(
+          `[role="separator"][aria-orientation="${orientation}"]`,
+        )
+      : this.root.getByRole("separator");
   }
 
   async gridArea(id: string) {
@@ -83,7 +84,9 @@ export class GridLayoutDriver {
     const eventInit = { clientX, clientY, dataTransfer };
 
     await target.dispatchEvent("dragenter", eventInit);
+    await this.observeDragOverDefault(target);
     await target.dispatchEvent("dragover", eventInit);
+    await this.requirePreventedDragOver(target);
     await this.waitForClass(target, `vuuDropTarget-${zone}`);
     await target.dispatchEvent("drop", eventInit);
     if ((await source.count()) > 0) {
@@ -112,7 +115,9 @@ export class GridLayoutDriver {
     }, position);
     const eventInit = { clientX, clientY, dataTransfer };
     await target.dispatchEvent("dragenter", eventInit);
+    await this.observeDragOverDefault(target);
     await target.dispatchEvent("dragover", eventInit);
+    await this.requirePreventedDragOver(target);
     await target.dispatchEvent("dragover", eventInit);
     const dropTargetClass = await target.evaluate((element) =>
       [...element.classList].find((className) =>
@@ -185,7 +190,9 @@ export class GridLayoutDriver {
       dataTransfer,
     };
     await target.dispatchEvent("dragenter", eventInit);
+    await this.observeDragOverDefault(target);
     await target.dispatchEvent("dragover", eventInit);
+    const defaultPrevented = await this.readPreventedDragOver(target);
     const accepted = await target.evaluate((element) =>
       [...element.classList].some((className) =>
         className.startsWith("vuuDropTarget-"),
@@ -194,7 +201,42 @@ export class GridLayoutDriver {
     await target.dispatchEvent("drop", eventInit);
     await source.dispatchEvent("dragend", { dataTransfer });
     await dataTransfer.dispose();
+    if (defaultPrevented) {
+      throw Error("GridLayoutDriver invalid dragover enabled drop");
+    }
     return accepted;
+  }
+
+  private async observeDragOverDefault(target: Locator) {
+    await target.evaluate((element) => {
+      window.addEventListener(
+        "dragover",
+        (event) => {
+          if (event.target === element) {
+            element.setAttribute(
+              "data-dragover-default-prevented",
+              String(event.defaultPrevented),
+            );
+          }
+        },
+        { once: true },
+      );
+    });
+  }
+
+  private async readPreventedDragOver(target: Locator) {
+    return target.evaluate((element) => {
+      const prevented =
+        element.getAttribute("data-dragover-default-prevented") === "true";
+      element.removeAttribute("data-dragover-default-prevented");
+      return prevented;
+    });
+  }
+
+  private async requirePreventedDragOver(target: Locator) {
+    if (!(await this.readPreventedDragOver(target))) {
+      throw Error("GridLayoutDriver valid dragover did not enable drop");
+    }
   }
 
   private async waitForClass(locator: Locator, className: string) {

--- a/vuu-ui/packages/grid-layout/src/drag-drop-next/DragContextNext.tsx
+++ b/vuu-ui/packages/grid-layout/src/drag-drop-next/DragContextNext.tsx
@@ -126,6 +126,7 @@ export class DragContext extends EventEmitter<DragContextEvents> {
   }
 
   endDrag() {
+    this.cleanupDragState();
     if (this.#dragSource && sourceIsTemplate(this.#dragSource)) {
       this.templateDragSession?.end();
     }
@@ -149,9 +150,6 @@ export class DragContext extends EventEmitter<DragContextEvents> {
         tabsId,
         value,
       });
-    }
-    for (const cleanup of this.#dragStateCleanups) {
-      cleanup();
     }
     this.endDrag();
   }
@@ -233,6 +231,12 @@ export class DragContext extends EventEmitter<DragContextEvents> {
     this.#dragStateCleanups.add(cleanup);
     return () => this.#dragStateCleanups.delete(cleanup);
   };
+
+  cleanupDragState() {
+    for (const cleanup of this.#dragStateCleanups) {
+      cleanup();
+    }
+  }
 
   get draggedElement() {
     const element = this.#element;

--- a/vuu-ui/packages/grid-layout/src/drag-drop-next/DragDropProviderNext.tsx
+++ b/vuu-ui/packages/grid-layout/src/drag-drop-next/DragDropProviderNext.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
 } from "react";
 // import { initializeDragContainer } from "./drag-drop-listeners";
 import {
@@ -33,10 +34,13 @@ const DragDropContext = createContext<DragContext | undefined>(undefined);
 export interface DragDropNextProviderProps {
   children: ReactNode;
   dragSources: DragSources;
+  onCancelDrag?: () => void;
   onCancelTabDrag: DragContextCancelTabDragHandler;
   onDetachTab: DragContextDetachTabHandler;
   onDrop: DragContextDropHandler;
 }
+
+const NOOP = () => undefined;
 
 export type MeasuredTarget = {
   bottom: number;
@@ -47,6 +51,7 @@ export type MeasuredTarget = {
 
 export const DragDropProviderNext = ({
   children,
+  onCancelDrag = NOOP,
   onCancelTabDrag,
   onDetachTab,
   onDrop,
@@ -63,14 +68,29 @@ export const DragDropProviderNext = ({
     () => new DragContext(templateDragSession),
     [templateDragSession],
   );
+  const handlersRef = useRef({
+    onCancelDrag,
+    onCancelTabDrag,
+    onDetachTab,
+    onDrop,
+  });
+  handlersRef.current = {
+    onCancelDrag,
+    onCancelTabDrag,
+    onDetachTab,
+    onDrop,
+  };
 
   useEffect(() => {
     if (!targetWindow) {
       return;
     }
     const cancelActiveDrag = () => {
+      handlersRef.current.onCancelDrag();
       if (dragContext.ownsDrag) {
         dragContext.cancelDrag();
+      } else {
+        dragContext.cleanupDragState();
       }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -78,10 +98,17 @@ export const DragDropProviderNext = ({
         cancelActiveDrag();
       }
     };
-    dragContext.on("cancel-tab-drag", onCancelTabDrag);
-    dragContext.on("detach-tab", onDetachTab);
-    dragContext.on("drop", onDrop);
+    const handleCancelTabDrag: DragContextCancelTabDragHandler = (event) =>
+      handlersRef.current.onCancelTabDrag(event);
+    const handleDetachTab: DragContextDetachTabHandler = (event) =>
+      handlersRef.current.onDetachTab(event);
+    const handleDrop: DragContextDropHandler = (event) =>
+      handlersRef.current.onDrop(event);
+    dragContext.on("cancel-tab-drag", handleCancelTabDrag);
+    dragContext.on("detach-tab", handleDetachTab);
+    dragContext.on("drop", handleDrop);
     targetWindow.addEventListener("keydown", handleKeyDown);
+    targetWindow.addEventListener("dragend", cancelActiveDrag);
     targetWindow.addEventListener("pointercancel", cancelActiveDrag);
 
     const cleanupCallbacks: Array<() => void> = [];
@@ -102,17 +129,18 @@ export const DragDropProviderNext = ({
     //   }
     // });
     return () => {
-      dragContext.removeListener("cancel-tab-drag", onCancelTabDrag);
-      dragContext.removeListener("detach-tab", onDetachTab);
-      dragContext.removeListener("drop", onDrop);
+      dragContext.removeListener("cancel-tab-drag", handleCancelTabDrag);
+      dragContext.removeListener("detach-tab", handleDetachTab);
+      dragContext.removeListener("drop", handleDrop);
       targetWindow.removeEventListener("keydown", handleKeyDown);
+      targetWindow.removeEventListener("dragend", cancelActiveDrag);
       targetWindow.removeEventListener("pointercancel", cancelActiveDrag);
       cancelActiveDrag();
       cleanupCallbacks.forEach((cleanup) => {
         cleanup();
       });
     };
-  }, [dragContext, onCancelTabDrag, onDetachTab, onDrop, targetWindow]);
+  }, [dragContext, targetWindow]);
 
   return (
     <DragDropContext.Provider value={dragContext}>

--- a/vuu-ui/packages/grid-layout/src/useAsDropTarget.ts
+++ b/vuu-ui/packages/grid-layout/src/useAsDropTarget.ts
@@ -5,7 +5,7 @@ import {
   queryClosest,
   type rect,
 } from "@vuu-ui/vuu-utils";
-import { type DragEventHandler, useCallback, useRef } from "react";
+import { type DragEventHandler, useCallback, useEffect, useRef } from "react";
 import {
   useGridLayoutDragLeaveHandler,
   useGridLayoutDragPreviewHandler,
@@ -125,6 +125,7 @@ const getDropTarget = (
 };
 
 type DropTargetState = {
+  accepted: boolean;
   mousePos: MousePosition;
   position: GridLayoutDropPosition | undefined;
   rect: rect;
@@ -138,21 +139,35 @@ const NullRect: rect = {
   top: -1,
 };
 
-const NULL_STATE: DropTargetState = {
+const createDropTargetState = (): DropTargetState => ({
+  accepted: false,
   mousePos: { clientX: -1, clientY: -1 },
   position: undefined,
-  rect: NullRect,
+  rect: { ...NullRect },
   dropTarget: undefined,
-};
+});
 
 export const useAsDropTarget = () => {
-  const dropTargetStateRef = useRef<DropTargetState>(NULL_STATE);
+  const dropTargetStateRef = useRef<DropTargetState>(createDropTargetState());
 
   const drop = useGridLayoutDropHandler();
   const leave = useGridLayoutDragLeaveHandler();
   const preview = useGridLayoutDragPreviewHandler();
   const dragContext = useDragContext();
   const layoutId = useGridLayoutId();
+  const clearDropTarget = useCallback(() => {
+    const { dropTarget } = dropTargetStateRef.current;
+    if (dropTarget) {
+      removeDropTargetPositionClassName(dropTarget.target);
+    }
+    dropTargetStateRef.current = createDropTargetState();
+  }, []);
+  useEffect(() => {
+    const unregister = dragContext.registerDragStateCleanup(clearDropTarget);
+    return () => {
+      unregister();
+    };
+  }, [clearDropTarget, dragContext]);
   const onDragEnter = useCallback<DragEventHandler>(
     (evt) => {
       if (dragContext.dragSource === undefined) {
@@ -173,6 +188,7 @@ export const useAsDropTarget = () => {
           // );
 
           dropTargetStateRef.current.dropTarget = dropTarget;
+          dropTargetStateRef.current.accepted = false;
           const { rect } = dropTargetStateRef.current;
           const { bottom, left, right, top } =
             dropTarget.target.getBoundingClientRect();
@@ -182,6 +198,7 @@ export const useAsDropTarget = () => {
           rect.top = top;
         } else if (currentDropTarget) {
           dropTargetStateRef.current.dropTarget = undefined;
+          dropTargetStateRef.current.accepted = false;
           dropTargetStateRef.current.position = undefined;
           leave();
           // console.log(
@@ -204,15 +221,21 @@ export const useAsDropTarget = () => {
       const { dropTarget: currentDropTarget } = dropTargetStateRef.current;
       const dropTarget = getDropTarget(evt.target, currentDropTarget, layoutId);
       if (dropTarget) {
-        // preventDefault on the event to enable drop
-        evt.preventDefault();
         // TODO store dropTarget and rect and tabRect in same ref
         if (dropTarget === currentDropTarget) {
           const { position: lastPosition } = dropTargetStateRef.current;
           if (dropTarget.type === "header") {
             if (lastPosition !== "header") {
-              addDropTargetPositionClassName(dropTarget.target, "header");
+              const accepted = preview(
+                dropTarget.gridLayoutItemId,
+                dragContext.dragSource,
+                "header",
+              );
+              dropTargetStateRef.current.accepted = accepted;
               dropTargetStateRef.current.position = "header";
+              if (accepted) {
+                addDropTargetPositionClassName(dropTarget.target, "header");
+              }
             }
           } else {
             const { clientX, clientY } = evt;
@@ -237,17 +260,24 @@ export const useAsDropTarget = () => {
               //   `[useAsDropTarget] onDragOver ${dropTarget.gridLayoutItemId} position ${position}`,
               // );
               if (position !== lastPosition) {
-                if (dropTargetStateRef.current.dropTarget) {
-                  addDropTargetPositionClassName(dropTarget.target, position);
-                }
-                dropTargetStateRef.current.position = position;
-                preview(
+                const accepted = preview(
                   dropTarget.gridLayoutItemId,
                   dragContext.dragSource,
                   position,
                 );
+                dropTargetStateRef.current.accepted = accepted;
+                if (accepted && dropTargetStateRef.current.dropTarget) {
+                  addDropTargetPositionClassName(dropTarget.target, position);
+                } else {
+                  removeDropTargetPositionClassName(dropTarget.target);
+                }
+                dropTargetStateRef.current.position = position;
               }
             }
+          }
+          if (dropTargetStateRef.current.accepted) {
+            // A dragover must be cancelled for the browser to dispatch drop.
+            evt.preventDefault();
           }
         }
       }
@@ -271,6 +301,7 @@ export const useAsDropTarget = () => {
       if (dropTarget?.target === evt.target) {
         if (dropTarget === currentDropTarget) {
           dropTargetStateRef.current.dropTarget = undefined;
+          dropTargetStateRef.current.accepted = false;
           dropTargetStateRef.current.position = undefined;
           leave();
         }
@@ -299,7 +330,11 @@ export const useAsDropTarget = () => {
           currentDropTarget,
           layoutId,
         );
-        if (dropTarget && dropTargetStateRef.current.position) {
+        if (
+          dropTarget &&
+          dropTargetStateRef.current.accepted &&
+          dropTargetStateRef.current.position
+        ) {
           // this prevents drag-drop-listeners drop firing when tab dragged to another tabstrip
           evt.preventDefault();
           removeDropTargetPositionClassName(dropTarget.target);
@@ -315,6 +350,7 @@ export const useAsDropTarget = () => {
       }
 
       dropTargetStateRef.current.dropTarget = undefined;
+      dropTargetStateRef.current.accepted = false;
       dropTargetStateRef.current.position = undefined;
     },
     [dragContext, drop, layoutId],

--- a/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
@@ -288,8 +288,24 @@ export const useGridLayout = ({
         itemId: string;
       }
     | undefined
-  >();
-  useEffect(() => () => dragCoordinator.dispose(), [dragCoordinator]);
+  >(undefined);
+  const [dragSourceItemId, setDragSourceItemId] = useState<string>();
+  const dragAppearanceFrameRef = useRef<number | undefined>(undefined);
+  const clearDragAppearance = useCallback(() => {
+    if (dragAppearanceFrameRef.current !== undefined) {
+      cancelAnimationFrame(dragAppearanceFrameRef.current);
+      dragAppearanceFrameRef.current = undefined;
+    }
+    containerRef.current?.classList.remove("vuuDragging");
+    setDragSourceItemId(undefined);
+  }, []);
+  useEffect(
+    () => () => {
+      clearDragAppearance();
+      dragCoordinator.dispose();
+    },
+    [clearDragAppearance, dragCoordinator],
+  );
   const contentIds = useMemo(
     () =>
       new Set(
@@ -343,30 +359,41 @@ export const useGridLayout = ({
             throw Error(result.error.message);
           }
         }
-        requestAnimationFrame(() => {
+        dragAppearanceFrameRef.current = requestAnimationFrame(() => {
+          dragAppearanceFrameRef.current = undefined;
           grid.classList.add("vuuDragging");
+          if (options.type === "text/plain") {
+            setDragSourceItemId(options.id);
+          }
         });
       }
     },
     [dragCoordinator, id],
   );
 
+  const handleCancelDrag = useCallback(() => {
+    clearDragAppearance();
+    if (
+      dragCoordinator.state.phase === "dragging" ||
+      dragCoordinator.state.phase === "previewing"
+    ) {
+      const result = dragCoordinator.cancel();
+      if (!result.ok) {
+        throw Error(result.error.message);
+      }
+    }
+    provisionalTemplateRef.current = undefined;
+  }, [clearDragAppearance, dragCoordinator]);
+
   const handleDragEnd = useCallback<GridLayoutDragEndHandler>(
     (_evt, dropped) => {
-      containerRef.current?.classList.remove("vuuDragging");
-      if (
-        !dropped &&
-        (dragCoordinator.state.phase === "dragging" ||
-          dragCoordinator.state.phase === "previewing")
-      ) {
-        const result = dragCoordinator.cancel();
-        if (!result.ok) {
-          throw Error(result.error.message);
-        }
+      clearDragAppearance();
+      if (!dropped) {
+        handleCancelDrag();
       }
       provisionalTemplateRef.current = undefined;
     },
-    [dragCoordinator],
+    [clearDragAppearance, handleCancelDrag],
   );
 
   const addChildComponent = useCallback(
@@ -562,11 +589,17 @@ export const useGridLayout = ({
         return false;
       }
       if (intent.kind !== "split") {
-        if (dragCoordinator.state.phase === "previewing") {
-          const cleared = dragCoordinator.clearPreview();
-          if (!cleared.ok) {
-            throw Error(cleared.error.message);
-          }
+        const previewed = dragCoordinator.preview({
+          gridId: id,
+          intent,
+          targetId,
+        });
+        if (!previewed.ok) {
+          return false;
+        }
+        const cleared = dragCoordinator.clearPreview();
+        if (!cleared.ok) {
+          throw Error(cleared.error.message);
         }
         return true;
       }
@@ -616,6 +649,7 @@ export const useGridLayout = ({
       if (!committed.ok) {
         throw Error(committed.error.message);
       }
+      clearDragAppearance();
 
       if (!sourceIsTemplate(dragSource) && position === "centre") {
         setChildren((current) =>
@@ -638,6 +672,7 @@ export const useGridLayout = ({
     },
     [
       addChildComponent,
+      clearDragAppearance,
       gridModel,
       id,
       dragCoordinator,
@@ -772,12 +807,14 @@ export const useGridLayout = ({
       if (!committed.ok) {
         throw Error(committed.error.message);
       }
+      clearDragAppearance();
       if (component && newChildId) {
         addChildComponent(component, gridModel.getChildItem(newChildId, true));
       }
     },
     [
       addChildComponent,
+      clearDragAppearance,
       dragCoordinator,
       gridModel,
       id,
@@ -913,11 +950,13 @@ export const useGridLayout = ({
     containerCallback,
     containerRef,
     dispatchGridLayoutAction,
+    dragSourceItemId,
     gridController,
     gridLayoutModel,
     gridModel,
     gridSnapshot: snapshot,
     nonContentGridItems,
+    onCancelDrag: handleCancelDrag,
     onCancelTabDrag: handleCancelTabDrag,
     onDetachTab: handleDetachTab,
     onDragEnd: handleDragEnd,

--- a/vuu-ui/packages/grid-layout/test/GridDragCoordinator.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridDragCoordinator.test.ts
@@ -101,6 +101,7 @@ describe("createGridDropPlan", () => {
         { item: { id: "template-instance" }, type: "add-item" },
         {
           itemId: "template-instance",
+          selectedItemId: "template-instance",
           targetId: "left",
           type: "create-stack",
         },
@@ -240,6 +241,7 @@ describe("GridDragCoordinator", () => {
     if (!stackId) {
       return;
     }
+    expect(controller.getSnapshot().stacks[0].selectedItemId).toBe("beta");
 
     const stackedReplacement = new GridDragCoordinator("grid", controller);
     stackedReplacement.begin({

--- a/vuu-ui/packages/grid-layout/test/GridLayout.drag-drop.react.test.tsx
+++ b/vuu-ui/packages/grid-layout/test/GridLayout.drag-drop.react.test.tsx
@@ -1,0 +1,561 @@
+import { queryClosest } from "@vuu-ui/vuu-utils";
+import { act, type DragEvent as ReactDragEvent, useCallback } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GridLayout,
+  GridLayoutItem,
+  GridLayoutProvider,
+  type TemplateSource,
+  useDraggable,
+  useGridLayoutDragStartHandler,
+} from "../src";
+
+class TestDataTransfer {
+  effectAllowed = "uninitialized";
+  readonly values = new Map<string, string>();
+
+  setData(type: string, value: string) {
+    this.values.set(type, value);
+  }
+}
+
+const dispatchDrag = (
+  element: Element,
+  type: string,
+  dataTransfer: TestDataTransfer,
+  point = { clientX: 50, clientY: 50 },
+) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    clientX: { value: point.clientX },
+    clientY: { value: point.clientY },
+    dataTransfer: { value: dataTransfer },
+  });
+  act(() => element.dispatchEvent(event));
+  return event;
+};
+
+const setTargetRect = (element: Element) => {
+  element.getBoundingClientRect = () =>
+    ({
+      bottom: 100,
+      height: 100,
+      left: 0,
+      right: 100,
+      top: 0,
+      width: 100,
+      x: 0,
+      y: 0,
+    }) as DOMRect;
+};
+
+let nextAnimationFrameId = 1;
+let pendingAnimationFrames = new Map<number, FrameRequestCallback>();
+
+const flushAnimationFrames = () => {
+  const callbacks = [...pendingAnimationFrames.values()];
+  pendingAnimationFrames.clear();
+  act(() => {
+    for (const callback of callbacks) {
+      callback(0);
+    }
+  });
+};
+
+const TemplatePalette = () => {
+  const onDragStart = useGridLayoutDragStartHandler();
+  const getDragSource = useCallback(
+    (event: ReactDragEvent<Element>): TemplateSource => {
+      const element = queryClosest(
+        event.target,
+        "[data-testid='palette-item']",
+      );
+      const layout = queryClosest(element, ".vuuGridLayout", true);
+      return {
+        componentJson: JSON.stringify({
+          label: "Template",
+          props: {
+            "data-testid": "template-content",
+            children: "Template",
+          },
+          type: "div",
+        }),
+        element,
+        label: "Template",
+        layoutId: layout.id,
+        type: "template",
+      };
+    },
+    [],
+  );
+  const draggable = useDraggable({ getDragSource, onDragStart });
+
+  return (
+    <button data-testid="palette-item" draggable type="button" {...draggable}>
+      Template
+    </button>
+  );
+};
+
+const ExistingItemFixture = () => (
+  <GridLayoutProvider options={{ newChildItem: { header: true } }}>
+    <GridLayout
+      colsAndRows={{ cols: ["1fr", "1fr"], rows: ["1fr"] }}
+      id="drag-grid"
+    >
+      <GridLayoutItem
+        data-drop-target
+        header
+        id="source"
+        resizeable="hv"
+        style={{ gridArea: "1/1/2/2" }}
+        title="Source"
+      >
+        <div>Source content</div>
+      </GridLayoutItem>
+      <GridLayoutItem
+        data-drop-target
+        header
+        id="target"
+        resizeable="hv"
+        style={{ gridArea: "1/2/2/3" }}
+        title="Target"
+      >
+        <div>Target content</div>
+      </GridLayoutItem>
+    </GridLayout>
+  </GridLayoutProvider>
+);
+
+const PaletteFixture = () => (
+  <GridLayoutProvider options={{ newChildItem: { header: true } }}>
+    <GridLayout
+      colsAndRows={{ cols: ["160px", "1fr"], rows: ["1fr"] }}
+      id="palette-grid"
+    >
+      <GridLayoutItem id="palette" style={{ gridArea: "1/1/2/2" }}>
+        <TemplatePalette />
+      </GridLayoutItem>
+      <GridLayoutItem
+        data-drop-target
+        header
+        id="target"
+        resizeable="hv"
+        style={{ gridArea: "1/2/2/3" }}
+        title="Target"
+      >
+        <div>Target content</div>
+      </GridLayoutItem>
+    </GridLayout>
+  </GridLayoutProvider>
+);
+
+const PlaceholderFixture = () => (
+  <GridLayoutProvider options={{ newChildItem: { header: true } }}>
+    <GridLayout
+      colsAndRows={{ cols: ["160px", "1fr"], rows: ["1fr"] }}
+      id="placeholder-grid"
+    >
+      <GridLayoutItem id="palette" style={{ gridArea: "1/1/2/2" }}>
+        <TemplatePalette />
+      </GridLayoutItem>
+    </GridLayout>
+  </GridLayoutProvider>
+);
+
+const InvalidTargetFixture = () => (
+  <GridLayoutProvider options={{ newChildItem: { header: true } }}>
+    <GridLayout
+      colsAndRows={{ cols: ["1fr", "1fr"], rows: ["1fr"] }}
+      id="invalid-grid"
+    >
+      <GridLayoutItem
+        data-drop-target
+        header
+        id="source"
+        resizeable="hv"
+        style={{ gridArea: "1/1/2/2" }}
+        title="Source"
+      >
+        <div>Source content</div>
+      </GridLayoutItem>
+      <GridLayoutItem
+        data-drop-target
+        id="fixed"
+        resizeable={false}
+        style={{ gridArea: "1/2/2/3" }}
+      >
+        <div>Fixed content</div>
+      </GridLayoutItem>
+    </GridLayout>
+  </GridLayoutProvider>
+);
+
+const NestedPaletteFixture = () => (
+  <GridLayoutProvider options={{ newChildItem: { header: true } }}>
+    <GridLayout
+      colsAndRows={{ cols: ["160px", "1fr"], rows: ["1fr"] }}
+      id="parent-grid"
+    >
+      <GridLayoutItem id="palette" style={{ gridArea: "1/1/2/2" }}>
+        <TemplatePalette />
+      </GridLayoutItem>
+      <GridLayoutItem id="nested-owner" style={{ gridArea: "1/2/2/3" }}>
+        <GridLayout
+          colsAndRows={{ cols: ["1fr"], rows: ["1fr"] }}
+          id="nested-grid"
+        >
+          <GridLayoutItem
+            data-drop-target
+            header
+            id="nested-target"
+            resizeable="hv"
+            style={{ gridArea: "1/1/2/2" }}
+            title="Nested target"
+          >
+            <div>Nested target content</div>
+          </GridLayoutItem>
+        </GridLayout>
+      </GridLayoutItem>
+    </GridLayout>
+  </GridLayoutProvider>
+);
+
+describe("GridLayout React drag/drop lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    nextAnimationFrameId = 1;
+    pendingAnimationFrames = new Map();
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      const id = nextAnimationFrameId++;
+      pendingAnimationFrames.set(id, callback);
+      return id;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+      pendingAnimationFrames.delete(id);
+    });
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = false;
+    vi.unstubAllGlobals();
+  });
+
+  it("previews and commits an existing item through DOM drag events", () => {
+    act(() => root.render(<ExistingItemFixture />));
+    const source = container.querySelector(
+      "#source .vuuGridLayoutItemHeader-title",
+    );
+    const target = container.querySelector("#target .vuuGridLayoutItemContent");
+    if (!source || !target) {
+      throw Error("existing-item drag fixture did not render");
+    }
+    setTargetRect(target);
+    const dataTransfer = new TestDataTransfer();
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    flushAnimationFrames();
+    expect(
+      container
+        .querySelector("#source")
+        ?.classList.contains("vuuGridLayoutItem-dragging"),
+    ).toBe(true);
+    dispatchDrag(target, "dragenter", dataTransfer, {
+      clientX: 90,
+      clientY: 50,
+    });
+    const dragOver = dispatchDrag(target, "dragover", dataTransfer, {
+      clientX: 90,
+      clientY: 50,
+    });
+
+    expect(dragOver.defaultPrevented).toBe(true);
+    expect(target.classList.contains("vuuDropTarget-east")).toBe(true);
+
+    dispatchDrag(target, "drop", dataTransfer, { clientX: 90, clientY: 50 });
+    const renderedSource = container.querySelector(
+      "#source .vuuGridLayoutItemHeader-title",
+    );
+    if (renderedSource) {
+      dispatchDrag(renderedSource, "dragend", dataTransfer);
+    }
+
+    expect(container.querySelector("#source")).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
+    expect(
+      container.querySelector("#source")?.getAttribute("style"),
+    ).not.toContain("grid-area: 1 / 1 / 2 / 2");
+    expect(target.classList.contains("vuuDropTarget-east")).toBe(false);
+  });
+
+  it("previews and commits a palette template through DOM drag events", () => {
+    act(() => root.render(<PaletteFixture />));
+    const source = container.querySelector("[data-testid='palette-item']");
+    const target = container.querySelector("#target .vuuGridLayoutItemContent");
+    if (!source || !target) {
+      throw Error("palette drag fixture did not render");
+    }
+    setTargetRect(source);
+    setTargetRect(target);
+    const dataTransfer = new TestDataTransfer();
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    flushAnimationFrames();
+    dispatchDrag(target, "dragenter", dataTransfer, {
+      clientX: 50,
+      clientY: 10,
+    });
+    const dragOver = dispatchDrag(target, "dragover", dataTransfer, {
+      clientX: 50,
+      clientY: 10,
+    });
+
+    expect(dataTransfer.values.has("text/json")).toBe(true);
+    expect(dragOver.defaultPrevented).toBe(true);
+    expect(target.classList.contains("vuuDropTarget-north")).toBe(true);
+
+    dispatchDrag(target, "drop", dataTransfer, { clientX: 50, clientY: 10 });
+    dispatchDrag(source, "dragend", dataTransfer);
+
+    expect(
+      container.querySelector("[data-testid='template-content']"),
+    ).not.toBeNull();
+    expect(target.classList.contains("vuuDropTarget-north")).toBe(false);
+  });
+
+  it.each([
+    {
+      point: { clientX: 50, clientY: 50 },
+      selector: "#target .vuuGridLayoutItemContent",
+      zone: "centre",
+    },
+    {
+      point: { clientX: 50, clientY: 12 },
+      selector: "#target .vuuGridLayoutItemHeader",
+      zone: "header",
+    },
+  ])("renders and clears the $zone affordance", ({ point, selector, zone }) => {
+    act(() => root.render(<ExistingItemFixture />));
+    const source = container.querySelector(
+      "#source .vuuGridLayoutItemHeader-title",
+    );
+    const target = container.querySelector(selector);
+    if (!source || !target) {
+      throw Error(`${zone} affordance fixture did not render`);
+    }
+    setTargetRect(target);
+    const dataTransfer = new TestDataTransfer();
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    flushAnimationFrames();
+    dispatchDrag(target, "dragenter", dataTransfer, point);
+    const dragOver = dispatchDrag(target, "dragover", dataTransfer, point);
+
+    expect(dragOver.defaultPrevented).toBe(true);
+    expect(target.classList.contains(`vuuDropTarget-${zone}`)).toBe(true);
+
+    dispatchDrag(source, "dragend", dataTransfer);
+
+    expect(target.classList.contains(`vuuDropTarget-${zone}`)).toBe(false);
+  });
+
+  it("renders the centre affordance for an empty placeholder", () => {
+    act(() => root.render(<PlaceholderFixture />));
+    const source = container.querySelector("[data-testid='palette-item']");
+    const target = container.querySelector(".vuuGridPlaceholder");
+    if (!source || !target) {
+      throw Error("placeholder drag fixture did not render");
+    }
+    setTargetRect(source);
+    setTargetRect(target);
+    const dataTransfer = new TestDataTransfer();
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    flushAnimationFrames();
+    dispatchDrag(target, "dragenter", dataTransfer);
+    const dragOver = dispatchDrag(target, "dragover", dataTransfer);
+
+    expect(dragOver.defaultPrevented).toBe(true);
+    expect(target.classList.contains("vuuDropTarget-centre")).toBe(true);
+
+    dispatchDrag(source, "dragend", dataTransfer);
+
+    expect(target.classList.contains("vuuDropTarget-centre")).toBe(false);
+  });
+
+  it("does not enable drop or render an affordance for an invalid split", () => {
+    act(() => root.render(<InvalidTargetFixture />));
+    const source = container.querySelector(
+      "#source .vuuGridLayoutItemHeader-title",
+    );
+    const target = container.querySelector("#fixed .vuuGridLayoutItemContent");
+    if (!source || !target) {
+      throw Error("invalid-target drag fixture did not render");
+    }
+    setTargetRect(target);
+    const dataTransfer = new TestDataTransfer();
+    const point = { clientX: 90, clientY: 50 };
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    flushAnimationFrames();
+    dispatchDrag(target, "dragenter", dataTransfer, point);
+    const dragOver = dispatchDrag(target, "dragover", dataTransfer, point);
+
+    expect(dragOver.defaultPrevented).toBe(false);
+    expect(
+      [...target.classList].some((className) =>
+        className.startsWith("vuuDropTarget-"),
+      ),
+    ).toBe(false);
+
+    dispatchDrag(source, "dragend", dataTransfer);
+  });
+
+  it.each([
+    "Escape",
+    "pointercancel",
+  ] as const)("rolls back the preview and clears affordances on %s", (cancellation) => {
+    act(() => root.render(<ExistingItemFixture />));
+    const source = container.querySelector(
+      "#source .vuuGridLayoutItemHeader-title",
+    );
+    const target = container.querySelector("#target .vuuGridLayoutItemContent");
+    if (!source || !target) {
+      throw Error("cancelled drag fixture did not render");
+    }
+    setTargetRect(target);
+    const dataTransfer = new TestDataTransfer();
+    const point = { clientX: 90, clientY: 50 };
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    flushAnimationFrames();
+    dispatchDrag(target, "dragenter", dataTransfer, point);
+    dispatchDrag(target, "dragover", dataTransfer, point);
+    expect(target.classList.contains("vuuDropTarget-east")).toBe(true);
+
+    act(() => {
+      if (cancellation === "Escape") {
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      } else {
+        window.dispatchEvent(new Event("pointercancel"));
+      }
+    });
+
+    expect(target.classList.contains("vuuDropTarget-east")).toBe(false);
+    expect(
+      container
+        .querySelector("#source")
+        ?.classList.contains("vuuGridLayoutItem-dragging"),
+    ).toBe(false);
+    expect(container.querySelector("#source")?.getAttribute("style")).toContain(
+      "grid-area: 1/1/2/2",
+    );
+  });
+
+  it("does not restore drag styling when cancelled before the next frame", () => {
+    act(() => root.render(<ExistingItemFixture />));
+    const source = container.querySelector(
+      "#source .vuuGridLayoutItemHeader-title",
+    );
+    if (!source) {
+      throw Error("early-cancel drag fixture did not render");
+    }
+    const dataTransfer = new TestDataTransfer();
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    flushAnimationFrames();
+
+    expect(
+      container
+        .querySelector("#source")
+        ?.classList.contains("vuuGridLayoutItem-dragging"),
+    ).toBe(false);
+    expect(
+      container.querySelector("#drag-grid")?.classList.contains("vuuDragging"),
+    ).toBe(false);
+  });
+
+  it("routes a palette drop to the deepest nested grid", () => {
+    act(() => root.render(<NestedPaletteFixture />));
+    const source = container.querySelector("[data-testid='palette-item']");
+    const target = container.querySelector(
+      "#nested-target .vuuGridLayoutItemContent",
+    );
+    if (!source || !target) {
+      throw Error("nested palette drag fixture did not render");
+    }
+    setTargetRect(source);
+    setTargetRect(target);
+    const dataTransfer = new TestDataTransfer();
+    const point = { clientX: 90, clientY: 50 };
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    flushAnimationFrames();
+    dispatchDrag(target, "dragenter", dataTransfer, point);
+    const dragOver = dispatchDrag(target, "dragover", dataTransfer, point);
+
+    expect(dragOver.defaultPrevented).toBe(true);
+    expect(target.classList.contains("vuuDropTarget-east")).toBe(true);
+
+    dispatchDrag(target, "drop", dataTransfer, point);
+    dispatchDrag(source, "dragend", dataTransfer);
+
+    const template = container.querySelector(
+      "#nested-grid [data-testid='template-content']",
+    );
+    expect(template).not.toBeNull();
+    expect(
+      container.querySelector("#parent-grid > #nested-owner"),
+    ).not.toBeNull();
+  });
+
+  it("clears a nested palette affordance when the drag is cancelled", () => {
+    act(() => root.render(<NestedPaletteFixture />));
+    const source = container.querySelector("[data-testid='palette-item']");
+    const target = container.querySelector(
+      "#nested-target .vuuGridLayoutItemContent",
+    );
+    if (!source || !target) {
+      throw Error("nested cancellation fixture did not render");
+    }
+    setTargetRect(source);
+    setTargetRect(target);
+    const dataTransfer = new TestDataTransfer();
+    const point = { clientX: 90, clientY: 50 };
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    flushAnimationFrames();
+    dispatchDrag(target, "dragenter", dataTransfer, point);
+    dispatchDrag(target, "dragover", dataTransfer, point);
+    expect(target.classList.contains("vuuDropTarget-east")).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(target.classList.contains("vuuDropTarget-east")).toBe(false);
+    expect(
+      container.querySelector("#nested-grid [data-testid='template-content']"),
+    ).toBeNull();
+  });
+});

--- a/vuu-ui/playwright/gallery/main-grid-layout.tsx
+++ b/vuu-ui/playwright/gallery/main-grid-layout.tsx
@@ -1,0 +1,38 @@
+import { createElement } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { GridLayoutTestFixture } from "../../packages/grid-layout/src/__tests__/__component__/GridLayoutTestFixture";
+
+type MountParams = {
+  props?: Parameters<typeof GridLayoutTestFixture>[0];
+};
+
+declare global {
+  interface Window {
+    mount: (params: MountParams) => Promise<void>;
+    unmount: () => Promise<void>;
+  }
+}
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("The GridLayout component gallery requires a #root element");
+}
+
+let root: Root | undefined;
+
+window.mount = async ({ props }: MountParams) => {
+  if (!props) {
+    throw new Error("GridLayout fixture props are required");
+  }
+  root ??= createRoot(rootElement);
+  flushSync(() => {
+    root?.render(createElement(GridLayoutTestFixture, props));
+  });
+};
+
+window.unmount = async () => {
+  root?.unmount();
+  root = undefined;
+};

--- a/vuu-ui/playwright/gallery/rsbuild.config.ts
+++ b/vuu-ui/playwright/gallery/rsbuild.config.ts
@@ -30,7 +30,10 @@ export default defineConfig({
   ],
   source: {
     entry: {
-      index: "./main.tsx",
+      index:
+        process.env.PLAYWRIGHT_GRID_LAYOUT_ONLY === "1"
+          ? "./main-grid-layout.tsx"
+          : "./main.tsx",
     },
   },
   html: {


### PR DESCRIPTION
## Regression and root cause

Phase-6 increment 7 (#2382) moved drag ownership into `GridDragCoordinator`, but the React integration cancelled the active `DragContext` whenever a preview snapshot changed callback identities. The provider effect cleanup then cleared the source during `dragover`, so subsequent drag events could not render a stable affordance or reach drop/commit. `useAsDropTarget` also initialized every hook from one mutable state object, coupling standalone, placeholder, and nested targets. Header stack creation additionally left the original target selected instead of the dropped item.

## Repair

- Keep provider subscriptions/listeners stable and forward current callbacks through refs; lifecycle cleanup now runs only for real unmount/cancel and reaches nested template contexts.
- Give each drop target independent ephemeral hover state, render classes only after a typed preview validates, and call `preventDefault` only for eligible targets.
- Restore ephemeral source-drag styling without mutating durable models, including cancellation of pending animation frames.
- Continue all durable split/replace/stack outcomes through `GridDragCoordinator` and `GridController`; typed `create-stack` atomically selects the dropped member.
- Clear affordances, provisional template state, transactions, and source styling on drop, dragend, Escape, pointercancel, provider unmount, and nested cancellation.
- Add a GridLayout-only gallery entry so Chromium component tests do not eagerly import unrelated Showcase modules.

## Why increment-7 tests missed it

The new tests in #2382 exercised coordinator methods and captured hook callbacks directly, so they did not fire the source/target React drag lifecycle that triggers provider effect cleanup after preview publication. The existing component suite was also blocked before mount by unrelated eager Showcase imports. On the merged #2382 head, the new DOM regression failed with a missing palette result and stale affordance after drop; after this repair all real-event regressions pass.

## Interaction coverage

The new React DOM suite fires `dragstart`, `dragenter`, `dragover`, `drop`, and `dragend` with `DataTransfer`, and covers existing-item and palette commits, cardinal/centre/header/placeholder affordances, invalid non-resizable targets, deepest nested routing, Escape/pointercancel, early-frame cancellation, and nested cleanup. The Chromium driver now verifies valid dragovers are default-prevented, invalid dragovers are not, and selects separators correctly for post-drop resizing.

## Validation

- GridLayout Vitest: 13 files, 270 passed, 2 existing todos.
- Focused React drag lifecycle: 11 passed.
- Focused Chromium drag matrix: 14 passed, 1 existing fixme skipped; includes palette split/header, existing cardinal/centre/header, invalid target, nested grid/tabstrip routing, and successful drop followed by resize.
- Targeted Biome: 13 changed files clean.
- GridLayout package build: passed (52 outputs).
- Workspace typecheck: zero GridLayout errors; remains red on unrelated existing vuu-data-react, vuu-utils, portal example, sample app, and Showcase errors.

## Remaining blockers

The default component gallery still cannot build because of unrelated Showcase `UserSettingsPanel`/`feature-filter-table` imports, so validation uses the new package-focused gallery. A complete serial 37-test GridLayout CT run also stops at the unrelated tab CRUD `Gamma Settings` assertion; the focused drag matrix runs independently and passes.