### PR TITLE
feat(grid-layout): add versioned persistence codecs

### DIFF
--- a/vuu-ui/packages/grid-layout/README.md
+++ b/vuu-ui/packages/grid-layout/README.md
@@ -41,3 +41,36 @@ When GridLayoutModel applies an operation that creates a
 grid track, it computes updates to child items then asks
 GridModel to apply each update. Move this logic up into GridModel
 GridLayoutModel should not need the addTrack method
+
+## Versioned persistence
+
+GridLayout owns an opaque, plain-JSON document with the discriminator
+`kind: "grid-layout"` and current `version: 2`. The envelope contains a
+revision-free canonical layout (`id`, track strings, sorted items, explicit
+placeholder IDs, sorted stacks with ordered members and selection) and sorted
+component records (`id`, `type`, settings `version`, JSON `settings`). The
+outer shell and `vuu-layout` persistence envelopes treat this document as
+component settings and do not merge their reducer schemas into it.
+
+`GridComponentSettingsRegistry` associates component type keys with typed
+encode/decode functions and one-step migration chains.
+`GridComponentRendererRegistry` is deliberately separate: decoded settings
+become React content only at the UI boundary. Unknown types, unsupported
+versions, malformed canonical references, and non-JSON settings return
+path-aware errors. JSON validation rejects functions, symbols, `undefined`,
+cycles, non-finite numbers, class instances, and React elements rather than
+silently dropping values.
+
+Version 1 canonical documents migrate `layout.gridId` to `layout.id` and add
+explicit stacks/placeholders before full validation. The legacy
+`SerializedGridLayout`/`GridLayoutDescriptor` shape remains readable through
+its dedicated adapter; new document writes never call `componentToJson`.
+Document decoding and content resolution complete before registry replacement,
+so a failed migration or renderer cannot partially mutate a live layout.
+
+Providers subscribe to `GridController.subscribeCommitted`, so ordinary
+commands write once, an interactive transaction writes once on semantic
+commit, and previews, rollbacks, rejected/no-op commands, revisions, measured
+pixels, drag state, DOM state, listeners, and initial hydration never write.
+Broad consumer migration and removal of legacy persistence APIs are deferred
+to the next architecture increment.

--- a/vuu-ui/packages/grid-layout/src/GridComponentSettings.ts
+++ b/vuu-ui/packages/grid-layout/src/GridComponentSettings.ts
@@ -1,0 +1,353 @@
+import type { ReactElement } from "react";
+import type { JsonValue, JsonValueIssue } from "./json-value";
+import { toJsonValue } from "./json-value";
+
+export interface GridSettingsCodecIssue {
+  readonly code: string;
+  readonly message: string;
+  readonly path: string;
+}
+
+export type GridSettingsCodecResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly error: GridSettingsCodecIssue; readonly ok: false };
+
+export interface GridComponentSettingsCodec<T> {
+  readonly decode: (value: JsonValue) => GridSettingsCodecResult<T>;
+  readonly encode: (settings: T) => GridSettingsCodecResult<unknown>;
+  readonly isSettings: (value: unknown) => value is T;
+  readonly migrations?: Readonly<
+    Record<number, (value: JsonValue) => GridSettingsCodecResult<unknown>>
+  >;
+  readonly version: number;
+}
+
+export interface GridComponentSettingsInput {
+  readonly id: string;
+  readonly settings: unknown;
+  readonly type: string;
+}
+
+export interface EncodedGridComponentSettings {
+  readonly id: string;
+  readonly settings: JsonValue;
+  readonly type: string;
+  readonly version: number;
+}
+
+export interface DecodedGridComponentSettings {
+  readonly id: string;
+  readonly settings: unknown;
+  readonly type: string;
+  readonly version: number;
+}
+
+export type GridComponentSettingsErrorCode =
+  | "COMPONENT_DECODE_FAILED"
+  | "COMPONENT_ENCODE_FAILED"
+  | "COMPONENT_MIGRATION_FAILED"
+  | "INVALID_COMPONENT_SETTINGS"
+  | "UNKNOWN_COMPONENT_TYPE"
+  | "UNSUPPORTED_COMPONENT_VERSION";
+
+export interface GridComponentSettingsError {
+  readonly code: GridComponentSettingsErrorCode;
+  readonly componentId: string;
+  readonly componentType: string;
+  readonly message: string;
+  readonly path: string;
+  readonly version?: number;
+}
+
+export type GridComponentSettingsResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly error: GridComponentSettingsError; readonly ok: false };
+
+interface RegisteredCodec {
+  readonly decode: (value: JsonValue) => GridSettingsCodecResult<unknown>;
+  readonly encode: (settings: unknown) => GridSettingsCodecResult<unknown>;
+  readonly migrations: Readonly<
+    Record<number, (value: JsonValue) => GridSettingsCodecResult<unknown>>
+  >;
+  readonly version: number;
+}
+
+const jsonIssue = (
+  issue: JsonValueIssue,
+  component: Pick<GridComponentSettingsInput, "id" | "type">,
+  code:
+    | "COMPONENT_ENCODE_FAILED"
+    | "COMPONENT_MIGRATION_FAILED"
+    | "INVALID_COMPONENT_SETTINGS",
+  version?: number,
+): GridComponentSettingsError => ({
+  code,
+  componentId: component.id,
+  componentType: component.type,
+  message: issue.message,
+  path: issue.path,
+  version,
+});
+
+const codecError = (
+  issue: GridSettingsCodecIssue,
+  component: Pick<GridComponentSettingsInput, "id" | "type">,
+  code:
+    | "COMPONENT_DECODE_FAILED"
+    | "COMPONENT_ENCODE_FAILED"
+    | "COMPONENT_MIGRATION_FAILED",
+  version: number,
+): GridComponentSettingsError => ({
+  code,
+  componentId: component.id,
+  componentType: component.type,
+  message: issue.message,
+  path: issue.path,
+  version,
+});
+
+export class GridComponentSettingsRegistry {
+  readonly #codecs = new Map<string, RegisteredCodec>();
+
+  register<T>(type: string, codec: GridComponentSettingsCodec<T>): void {
+    if (!type) {
+      throw new Error("Grid component type must not be empty");
+    }
+    if (!Number.isInteger(codec.version) || codec.version < 1) {
+      throw new Error(`Grid component codec "${type}" has an invalid version`);
+    }
+    if (this.#codecs.has(type)) {
+      throw new Error(`Grid component codec "${type}" is already registered`);
+    }
+    this.#codecs.set(type, {
+      decode: codec.decode,
+      encode: (settings) =>
+        codec.isSettings(settings)
+          ? codec.encode(settings)
+          : {
+              error: {
+                code: "INVALID_SETTINGS_TYPE",
+                message: `settings do not match component type "${type}"`,
+                path: "$",
+              },
+              ok: false,
+            },
+      migrations: codec.migrations ?? {},
+      version: codec.version,
+    });
+  }
+
+  encode(
+    component: GridComponentSettingsInput,
+  ): GridComponentSettingsResult<EncodedGridComponentSettings> {
+    const codec = this.#codecs.get(component.type);
+    if (!codec) {
+      return {
+        error: {
+          code: "UNKNOWN_COMPONENT_TYPE",
+          componentId: component.id,
+          componentType: component.type,
+          message: `component type "${component.type}" is not registered`,
+          path: "$.type",
+        },
+        ok: false,
+      };
+    }
+    const encoded = codec.encode(component.settings);
+    if (!encoded.ok) {
+      return {
+        error: codecError(
+          encoded.error,
+          component,
+          "COMPONENT_ENCODE_FAILED",
+          codec.version,
+        ),
+        ok: false,
+      };
+    }
+    const json = toJsonValue(encoded.value, "$.settings");
+    if (!json.ok) {
+      return {
+        error: jsonIssue(
+          json.error,
+          component,
+          "COMPONENT_ENCODE_FAILED",
+          codec.version,
+        ),
+        ok: false,
+      };
+    }
+    return {
+      ok: true,
+      value: {
+        id: component.id,
+        settings: json.value,
+        type: component.type,
+        version: codec.version,
+      },
+    };
+  }
+
+  decode(
+    component: EncodedGridComponentSettings,
+  ): GridComponentSettingsResult<DecodedGridComponentSettings> {
+    const codec = this.#codecs.get(component.type);
+    if (!codec) {
+      return {
+        error: {
+          code: "UNKNOWN_COMPONENT_TYPE",
+          componentId: component.id,
+          componentType: component.type,
+          message: `component type "${component.type}" is not registered`,
+          path: "$.type",
+          version: component.version,
+        },
+        ok: false,
+      };
+    }
+    if (component.version > codec.version || component.version < 1) {
+      return {
+        error: {
+          code: "UNSUPPORTED_COMPONENT_VERSION",
+          componentId: component.id,
+          componentType: component.type,
+          message: `component settings version ${component.version} is not supported; current version is ${codec.version}`,
+          path: "$.version",
+          version: component.version,
+        },
+        ok: false,
+      };
+    }
+
+    let value = component.settings;
+    for (
+      let version = component.version;
+      version < codec.version;
+      version += 1
+    ) {
+      const migrate = codec.migrations[version];
+      if (!migrate) {
+        return {
+          error: {
+            code: "UNSUPPORTED_COMPONENT_VERSION",
+            componentId: component.id,
+            componentType: component.type,
+            message: `no migration from component settings version ${version}`,
+            path: "$.version",
+            version,
+          },
+          ok: false,
+        };
+      }
+      const migrated = migrate(value);
+      if (!migrated.ok) {
+        return {
+          error: codecError(
+            migrated.error,
+            component,
+            "COMPONENT_MIGRATION_FAILED",
+            version,
+          ),
+          ok: false,
+        };
+      }
+      const json = toJsonValue(migrated.value, "$.settings");
+      if (!json.ok) {
+        return {
+          error: jsonIssue(
+            json.error,
+            component,
+            "COMPONENT_MIGRATION_FAILED",
+            version,
+          ),
+          ok: false,
+        };
+      }
+      value = json.value;
+    }
+
+    const decoded = codec.decode(value);
+    return decoded.ok
+      ? {
+          ok: true,
+          value: {
+            ...component,
+            settings: decoded.value,
+            version: codec.version,
+          },
+        }
+      : {
+          error: codecError(
+            decoded.error,
+            component,
+            "COMPONENT_DECODE_FAILED",
+            component.version,
+          ),
+          ok: false,
+        };
+  }
+}
+
+export type GridComponentRenderer<T> = (
+  settings: T,
+  componentId: string,
+) => ReactElement;
+
+interface RegisteredRenderer {
+  readonly isSettings: (value: unknown) => boolean;
+  readonly render: (settings: unknown, componentId: string) => ReactElement;
+}
+
+export class GridComponentRendererRegistry {
+  readonly #renderers = new Map<string, RegisteredRenderer>();
+
+  register<T>(
+    type: string,
+    isSettings: (value: unknown) => value is T,
+    render: GridComponentRenderer<T>,
+  ): void {
+    if (this.#renderers.has(type)) {
+      throw new Error(
+        `Grid component renderer "${type}" is already registered`,
+      );
+    }
+    this.#renderers.set(type, {
+      isSettings,
+      render: (settings, componentId) => {
+        if (!isSettings(settings)) {
+          throw new Error(`Decoded settings do not match renderer "${type}"`);
+        }
+        return render(settings, componentId);
+      },
+    });
+  }
+
+  render(component: DecodedGridComponentSettings): ReactElement {
+    const renderer = this.#renderers.get(component.type);
+    if (!renderer) {
+      throw new Error(
+        `Grid component renderer "${component.type}" is not registered`,
+      );
+    }
+    return renderer.render(component.settings, component.id);
+  }
+}
+
+export class GridLayoutContentRegistry<T> {
+  #entries = new Map<string, T>();
+
+  entries(): ReadonlyMap<string, T> {
+    return new Map(this.#entries);
+  }
+
+  replace(
+    components: readonly DecodedGridComponentSettings[],
+    resolve: (component: DecodedGridComponentSettings) => T,
+  ): void {
+    const next = new Map<string, T>();
+    for (const component of components) {
+      next.set(component.id, resolve(component));
+    }
+    this.#entries = next;
+  }
+}

--- a/vuu-ui/packages/grid-layout/src/GridLayoutDocument.ts
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutDocument.ts
@@ -1,0 +1,611 @@
+import type {
+  DecodedGridComponentSettings,
+  EncodedGridComponentSettings,
+  GridComponentSettingsError,
+  GridComponentSettingsInput,
+  GridComponentSettingsRegistry,
+} from "./GridComponentSettings";
+import {
+  gridLayoutDescriptorToSnapshot,
+  normalizeGridSnapshot,
+} from "./grid-snapshot-adapters";
+import type { SerializedGridLayout } from "./GridLayoutProvider";
+import type {
+  GridItemSnapshot,
+  GridSnapshot,
+  GridStackSnapshot,
+} from "./GridSnapshot";
+import { toJsonValue } from "./json-value";
+
+export const GRID_LAYOUT_DOCUMENT_KIND = "grid-layout";
+export const GRID_LAYOUT_DOCUMENT_VERSION = 2;
+
+export interface PersistedGridLayout {
+  readonly columns: readonly string[];
+  readonly id: string;
+  readonly items: readonly GridItemSnapshot[];
+  readonly placeholderIds: readonly string[];
+  readonly rows: readonly string[];
+  readonly stacks: readonly GridStackSnapshot[];
+}
+
+export interface GridLayoutDocument {
+  readonly components: readonly EncodedGridComponentSettings[];
+  readonly kind: typeof GRID_LAYOUT_DOCUMENT_KIND;
+  readonly layout: PersistedGridLayout;
+  readonly version: typeof GRID_LAYOUT_DOCUMENT_VERSION;
+}
+
+export interface GridLayoutDocumentV1 {
+  readonly components: readonly EncodedGridComponentSettings[];
+  readonly kind: typeof GRID_LAYOUT_DOCUMENT_KIND;
+  readonly layout: {
+    readonly columns: readonly string[];
+    readonly gridId: string;
+    readonly items: readonly GridItemSnapshot[];
+    readonly rows: readonly string[];
+    readonly stacks?: readonly GridStackSnapshot[];
+  };
+  readonly version: 1;
+}
+
+export interface DecodedGridLayoutDocument {
+  readonly components: readonly DecodedGridComponentSettings[];
+  readonly document: GridLayoutDocument;
+  readonly snapshot: GridSnapshot;
+}
+
+export type GridLayoutDocumentErrorCode =
+  | "COMPONENT_SETTINGS_ERROR"
+  | "DOCUMENT_MIGRATION_FAILED"
+  | "DUPLICATE_COMPONENT_ID"
+  | "INVALID_DISCRIMINATOR"
+  | "INVALID_DOCUMENT"
+  | "MISSING_COMPONENT_SETTINGS"
+  | "UNEXPECTED_COMPONENT_SETTINGS"
+  | "UNSUPPORTED_DOCUMENT_VERSION";
+
+export interface GridLayoutDocumentError {
+  readonly code: GridLayoutDocumentErrorCode;
+  readonly componentError?: GridComponentSettingsError;
+  readonly message: string;
+  readonly path: string;
+  readonly version?: number;
+}
+
+export class GridLayoutDocumentCodecError extends Error {
+  constructor(readonly issue: GridLayoutDocumentError) {
+    super(`${issue.path}: ${issue.message}`);
+    this.name = "GridLayoutDocumentCodecError";
+  }
+}
+
+export type GridLayoutDocumentResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly error: GridLayoutDocumentError; readonly ok: false };
+
+export interface EncodeGridLayoutDocumentOptions {
+  readonly componentSettings: readonly GridComponentSettingsInput[];
+  readonly placeholderIds?: readonly string[];
+}
+
+export interface LegacyGridLayoutDocument {
+  readonly components: SerializedGridLayout["components"];
+  readonly snapshot: GridSnapshot;
+}
+
+const failure = (
+  code: GridLayoutDocumentErrorCode,
+  message: string,
+  path: string,
+  version?: number,
+): GridLayoutDocumentResult<never> => ({
+  error: { code, message, path, version },
+  ok: false,
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const compareIds = (left: string, right: string) =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+const durableItem = ({
+  column,
+  componentInstanceId,
+  contentVisible,
+  dropTarget,
+  header,
+  id,
+  minHeight,
+  minWidth,
+  resizeable,
+  row,
+  title,
+}: GridItemSnapshot): GridItemSnapshot => ({
+  column: { ...column },
+  ...(componentInstanceId === undefined ? {} : { componentInstanceId }),
+  ...(contentVisible === undefined ? {} : { contentVisible }),
+  ...(dropTarget === undefined ? {} : { dropTarget }),
+  ...(header === undefined ? {} : { header }),
+  id,
+  ...(minHeight === undefined ? {} : { minHeight }),
+  ...(minWidth === undefined ? {} : { minWidth }),
+  ...(resizeable === undefined ? {} : { resizeable }),
+  row: { ...row },
+  ...(title === undefined ? {} : { title }),
+});
+
+const persistedLayoutToSnapshot = (layout: PersistedGridLayout): GridSnapshot =>
+  normalizeGridSnapshot({
+    columns: layout.columns.map((size) => ({
+      size: size as `${number}fr` | `${number}px`,
+    })),
+    gridId: layout.id,
+    items: layout.items,
+    revision: 0,
+    rows: layout.rows.map((size) => ({
+      size: size as `${number}fr` | `${number}px`,
+    })),
+    stacks: layout.stacks,
+  });
+
+export const encodeGridLayoutDocument = (
+  snapshot: GridSnapshot,
+  registry: GridComponentSettingsRegistry,
+  { componentSettings, placeholderIds = [] }: EncodeGridLayoutDocumentOptions,
+): GridLayoutDocumentResult<GridLayoutDocument> => {
+  let normalized: GridSnapshot;
+  try {
+    normalized = normalizeGridSnapshot(snapshot);
+  } catch (cause) {
+    return failure(
+      "INVALID_DOCUMENT",
+      cause instanceof Error ? cause.message : "invalid grid snapshot",
+      "$.layout",
+    );
+  }
+
+  const placeholderIdSet = new Set(placeholderIds);
+  if (placeholderIdSet.size !== placeholderIds.length) {
+    return failure(
+      "INVALID_DOCUMENT",
+      "placeholder ids must be unique",
+      "$.layout.placeholderIds",
+    );
+  }
+  const layoutItemIds = new Set(normalized.items.map(({ id }) => id));
+  for (const placeholderId of placeholderIdSet) {
+    if (!layoutItemIds.has(placeholderId)) {
+      return failure(
+        "INVALID_DOCUMENT",
+        `placeholder "${placeholderId}" has no matching layout item`,
+        "$.layout.placeholderIds",
+      );
+    }
+  }
+  const componentReferenceIds = new Set(
+    normalized.items
+      .filter(({ id }) => !placeholderIdSet.has(id))
+      .map(({ componentInstanceId, id }) => componentInstanceId ?? id),
+  );
+  const referencedComponents = new Map<string, string>();
+  for (const { componentInstanceId, id } of normalized.items) {
+    if (placeholderIdSet.has(id)) {
+      continue;
+    }
+    const componentId = componentInstanceId ?? id;
+    const previousItemId = referencedComponents.get(componentId);
+    if (previousItemId) {
+      return failure(
+        "DUPLICATE_COMPONENT_ID",
+        `component "${componentId}" is referenced by items "${previousItemId}" and "${id}"`,
+        `$.layout.items.${id}.componentInstanceId`,
+      );
+    }
+    referencedComponents.set(componentId, id);
+  }
+  const componentIds = new Set<string>();
+  const components: EncodedGridComponentSettings[] = [];
+  for (const component of [...componentSettings].sort((a, b) =>
+    compareIds(a.id, b.id),
+  )) {
+    if (componentIds.has(component.id)) {
+      return failure(
+        "DUPLICATE_COMPONENT_ID",
+        `component id "${component.id}" is duplicated`,
+        "$.components",
+      );
+    }
+    componentIds.add(component.id);
+    if (!componentReferenceIds.has(component.id)) {
+      return failure(
+        "UNEXPECTED_COMPONENT_SETTINGS",
+        `component "${component.id}" has no matching layout item reference`,
+        "$.components",
+      );
+    }
+    const encoded = registry.encode(component);
+    if (!encoded.ok) {
+      return {
+        error: {
+          code: "COMPONENT_SETTINGS_ERROR",
+          componentError: encoded.error,
+          message: encoded.error.message,
+          path: `$.components.${component.id}${encoded.error.path.slice(1)}`,
+          version: encoded.error.version,
+        },
+        ok: false,
+      };
+    }
+    components.push(encoded.value);
+  }
+
+  for (const { componentInstanceId, id } of normalized.items) {
+    if (placeholderIdSet.has(id) && componentInstanceId !== undefined) {
+      return failure(
+        "INVALID_DOCUMENT",
+        `placeholder "${id}" must not reference a component`,
+        `$.layout.items.${id}.componentInstanceId`,
+      );
+    }
+    const componentId = componentInstanceId ?? id;
+    if (!componentIds.has(componentId) && !placeholderIdSet.has(id)) {
+      return failure(
+        "MISSING_COMPONENT_SETTINGS",
+        `layout item "${id}" references missing component "${componentId}"`,
+        `$.layout.items.${id}`,
+      );
+    }
+  }
+
+  const document: GridLayoutDocument = {
+    components,
+    kind: GRID_LAYOUT_DOCUMENT_KIND,
+    layout: {
+      columns: normalized.columns.map(({ size }) => size),
+      id: normalized.gridId,
+      items: normalized.items
+        .map(durableItem)
+        .sort((a, b) => compareIds(a.id, b.id)),
+      placeholderIds: [...placeholderIdSet].sort(),
+      rows: normalized.rows.map(({ size }) => size),
+      stacks: normalized.stacks
+        .map((stack) => ({
+          id: stack.id,
+          itemIds: [...stack.itemIds],
+          selectedItemId: stack.selectedItemId,
+        }))
+        .sort((a, b) => compareIds(a.id, b.id)),
+    },
+    version: GRID_LAYOUT_DOCUMENT_VERSION,
+  };
+  const json = toJsonValue(document);
+  return json.ok
+    ? { ok: true, value: document }
+    : failure("INVALID_DOCUMENT", json.error.message, json.error.path);
+};
+
+const migrateDocument = (
+  value: Record<string, unknown>,
+): GridLayoutDocumentResult<Record<string, unknown>> => {
+  if (typeof value.version !== "number" || !Number.isInteger(value.version)) {
+    return failure(
+      "INVALID_DOCUMENT",
+      "document version must be an integer",
+      "$.version",
+    );
+  }
+  if (value.version === GRID_LAYOUT_DOCUMENT_VERSION) {
+    return { ok: true, value };
+  }
+  if (value.version !== 1) {
+    return failure(
+      "UNSUPPORTED_DOCUMENT_VERSION",
+      `GridLayout document version ${String(value.version)} is not supported`,
+      "$.version",
+      typeof value.version === "number" ? value.version : undefined,
+    );
+  }
+  if (!isRecord(value.layout) || typeof value.layout.gridId !== "string") {
+    return failure(
+      "DOCUMENT_MIGRATION_FAILED",
+      "version 1 layout.gridId must be a string",
+      "$.layout.gridId",
+      1,
+    );
+  }
+  const { gridId, stacks = [], ...layout } = value.layout;
+  return {
+    ok: true,
+    value: {
+      ...value,
+      layout: { ...layout, id: gridId, placeholderIds: [], stacks },
+      version: GRID_LAYOUT_DOCUMENT_VERSION,
+    },
+  };
+};
+
+const parseComponent = (
+  value: unknown,
+  index: number,
+): GridLayoutDocumentResult<EncodedGridComponentSettings> => {
+  const path = `$.components[${index}]`;
+  if (!isRecord(value)) {
+    return failure("INVALID_DOCUMENT", "component must be an object", path);
+  }
+  const unexpectedField = Object.keys(value).find(
+    (field) => !["id", "settings", "type", "version"].includes(field),
+  );
+  if (unexpectedField) {
+    return failure(
+      "INVALID_DOCUMENT",
+      `unexpected component field "${unexpectedField}"`,
+      `${path}.${unexpectedField}`,
+    );
+  }
+  if (
+    typeof value.id !== "string" ||
+    !value.id ||
+    typeof value.type !== "string" ||
+    !value.type ||
+    !Number.isInteger(value.version) ||
+    typeof value.version !== "number"
+  ) {
+    return failure(
+      "INVALID_DOCUMENT",
+      "component id, type and integer version are required",
+      path,
+    );
+  }
+  const settings = toJsonValue(value.settings, `${path}.settings`);
+  if (!settings.ok) {
+    return failure(
+      "INVALID_DOCUMENT",
+      settings.error.message,
+      settings.error.path,
+    );
+  }
+  return {
+    ok: true,
+    value: {
+      id: value.id,
+      settings: settings.value,
+      type: value.type,
+      version: value.version,
+    },
+  };
+};
+
+export const decodeGridLayoutDocument = (
+  input: unknown,
+  registry: GridComponentSettingsRegistry,
+): GridLayoutDocumentResult<DecodedGridLayoutDocument> => {
+  const detached = toJsonValue(input);
+  if (!detached.ok || !isRecord(detached.value)) {
+    return failure(
+      "INVALID_DOCUMENT",
+      detached.ok ? "document must be an object" : detached.error.message,
+      detached.ok ? "$" : detached.error.path,
+    );
+  }
+  if (detached.value.kind !== GRID_LAYOUT_DOCUMENT_KIND) {
+    return failure(
+      "INVALID_DISCRIMINATOR",
+      `expected document kind "${GRID_LAYOUT_DOCUMENT_KIND}"`,
+      "$.kind",
+    );
+  }
+  const migrated = migrateDocument(detached.value);
+  if (!migrated.ok) {
+    return migrated;
+  }
+  const value = migrated.value;
+  const unexpectedDocumentField = Object.keys(value).find(
+    (field) => !["components", "kind", "layout", "version"].includes(field),
+  );
+  if (unexpectedDocumentField) {
+    return failure(
+      "INVALID_DOCUMENT",
+      `unexpected document field "${unexpectedDocumentField}"`,
+      `$.${unexpectedDocumentField}`,
+    );
+  }
+  if (!isRecord(value.layout) || !Array.isArray(value.components)) {
+    return failure(
+      "INVALID_DOCUMENT",
+      "document layout and components are required",
+      "$",
+    );
+  }
+  const unexpectedLayoutField = Object.keys(value.layout).find(
+    (field) =>
+      !["columns", "id", "items", "placeholderIds", "rows", "stacks"].includes(
+        field,
+      ),
+  );
+  if (unexpectedLayoutField) {
+    return failure(
+      "INVALID_DOCUMENT",
+      `unexpected layout field "${unexpectedLayoutField}"`,
+      `$.layout.${unexpectedLayoutField}`,
+    );
+  }
+  const { columns, id, items, placeholderIds, rows, stacks } = value.layout;
+  if (
+    typeof id !== "string" ||
+    !Array.isArray(columns) ||
+    !Array.isArray(rows) ||
+    !Array.isArray(items) ||
+    !Array.isArray(placeholderIds) ||
+    !Array.isArray(stacks)
+  ) {
+    return failure(
+      "INVALID_DOCUMENT",
+      "layout id, columns, rows, items, placeholderIds and stacks are required",
+      "$.layout",
+    );
+  }
+
+  let snapshot: GridSnapshot;
+  try {
+    snapshot = persistedLayoutToSnapshot({
+      columns: columns as string[],
+      id,
+      items: items as GridItemSnapshot[],
+      placeholderIds: placeholderIds as string[],
+      rows: rows as string[],
+      stacks: stacks as GridStackSnapshot[],
+    });
+  } catch (cause) {
+    return failure(
+      "INVALID_DOCUMENT",
+      cause instanceof Error ? cause.message : "invalid canonical layout",
+      "$.layout",
+    );
+  }
+
+  const itemIds = new Set(snapshot.items.map(({ id: itemId }) => itemId));
+  const parsedPlaceholderIds = new Set<string>();
+  for (let index = 0; index < placeholderIds.length; index += 1) {
+    const placeholderId = placeholderIds[index];
+    if (
+      typeof placeholderId !== "string" ||
+      !itemIds.has(placeholderId) ||
+      parsedPlaceholderIds.has(placeholderId)
+    ) {
+      return failure(
+        "INVALID_DOCUMENT",
+        "placeholder id must identify one unique layout item",
+        `$.layout.placeholderIds[${index}]`,
+      );
+    }
+    parsedPlaceholderIds.add(placeholderId);
+  }
+  const componentItemById = new Map<string, string>();
+  for (const { componentInstanceId, id: itemId } of snapshot.items) {
+    if (parsedPlaceholderIds.has(itemId)) {
+      if (componentInstanceId !== undefined) {
+        return failure(
+          "INVALID_DOCUMENT",
+          `placeholder "${itemId}" must not reference a component`,
+          `$.layout.items.${itemId}.componentInstanceId`,
+        );
+      }
+      continue;
+    }
+    const componentId = componentInstanceId ?? itemId;
+    const previousItemId = componentItemById.get(componentId);
+    if (previousItemId) {
+      return failure(
+        "DUPLICATE_COMPONENT_ID",
+        `component "${componentId}" is referenced by items "${previousItemId}" and "${itemId}"`,
+        `$.layout.items.${itemId}.componentInstanceId`,
+      );
+    }
+    componentItemById.set(componentId, itemId);
+  }
+  const seen = new Set<string>();
+  const components: DecodedGridComponentSettings[] = [];
+  const encodedComponents: EncodedGridComponentSettings[] = [];
+  for (let index = 0; index < value.components.length; index += 1) {
+    const parsed = parseComponent(value.components[index], index);
+    if (!parsed.ok) {
+      return parsed;
+    }
+    if (seen.has(parsed.value.id)) {
+      return failure(
+        "DUPLICATE_COMPONENT_ID",
+        `component id "${parsed.value.id}" is duplicated`,
+        `$.components[${index}].id`,
+      );
+    }
+    if (!componentItemById.has(parsed.value.id)) {
+      return failure(
+        "UNEXPECTED_COMPONENT_SETTINGS",
+        `component "${parsed.value.id}" has no matching layout item reference`,
+        `$.components[${index}].id`,
+      );
+    }
+    seen.add(parsed.value.id);
+    encodedComponents.push(parsed.value);
+    const decoded = registry.decode(parsed.value);
+    if (!decoded.ok) {
+      return {
+        error: {
+          code: "COMPONENT_SETTINGS_ERROR",
+          componentError: decoded.error,
+          message: decoded.error.message,
+          path: `$.components[${index}]${decoded.error.path.slice(1)}`,
+          version: decoded.error.version,
+        },
+        ok: false,
+      };
+    }
+    components.push(decoded.value);
+  }
+  for (const [componentId, itemId] of componentItemById) {
+    if (!seen.has(componentId)) {
+      return failure(
+        "MISSING_COMPONENT_SETTINGS",
+        `layout item "${itemId}" references missing component "${componentId}"`,
+        `$.layout.items.${itemId}`,
+      );
+    }
+  }
+  for (const placeholderId of parsedPlaceholderIds) {
+    if (seen.has(placeholderId)) {
+      return failure(
+        "INVALID_DOCUMENT",
+        `placeholder "${placeholderId}" also has component settings`,
+        "$.layout.placeholderIds",
+      );
+    }
+  }
+
+  const document: GridLayoutDocument = {
+    components: encodedComponents.sort((a, b) => compareIds(a.id, b.id)),
+    kind: GRID_LAYOUT_DOCUMENT_KIND,
+    layout: {
+      columns: snapshot.columns.map(({ size }) => size),
+      id: snapshot.gridId,
+      items: snapshot.items
+        .map(durableItem)
+        .sort((a, b) => compareIds(a.id, b.id)),
+      placeholderIds: [...parsedPlaceholderIds].sort(),
+      rows: snapshot.rows.map(({ size }) => size),
+      stacks: snapshot.stacks
+        .map((stack) => ({ ...stack, itemIds: [...stack.itemIds] }))
+        .sort((a, b) => compareIds(a.id, b.id)),
+    },
+    version: GRID_LAYOUT_DOCUMENT_VERSION,
+  };
+  return { ok: true, value: { components, document, snapshot } };
+};
+
+export const decodeLegacySerializedGridLayout = (
+  value: SerializedGridLayout,
+): GridLayoutDocumentResult<LegacyGridLayoutDocument> => {
+  const json = toJsonValue(value);
+  if (!json.ok) {
+    return failure("INVALID_DOCUMENT", json.error.message, json.error.path);
+  }
+  try {
+    return {
+      ok: true,
+      value: {
+        components: value.components,
+        snapshot: gridLayoutDescriptorToSnapshot(value.layout, {
+          gridId: value.id,
+        }),
+      },
+    };
+  } catch (cause) {
+    return failure(
+      "INVALID_DOCUMENT",
+      cause instanceof Error ? cause.message : "invalid legacy GridLayout",
+      "$.layout",
+      1,
+    );
+  }
+};

--- a/vuu-ui/packages/grid-layout/src/GridLayoutProvider.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutProvider.tsx
@@ -1,17 +1,34 @@
 import {
   createContext,
-  DragEvent,
-  ReactElement,
-  ReactNode,
+  type DragEvent,
+  type ReactElement,
+  type ReactNode,
   useCallback,
   useContext,
   useMemo,
 } from "react";
-import { GridLayoutChangeHandler, GridLayoutDescriptor } from "./GridModel";
-import { GridLayoutItem, GridLayoutItemProps } from "./GridLayoutItem";
+import type {
+  GridComponentRendererRegistry,
+  GridComponentSettingsInput,
+  GridComponentSettingsRegistry,
+} from "./GridComponentSettings";
+import {
+  decodeGridLayoutDocument,
+  encodeGridLayoutDocument,
+  type GridLayoutDocument,
+  GridLayoutDocumentCodecError,
+  type GridLayoutDocumentError,
+} from "./GridLayoutDocument";
+import type {
+  GridLayoutChangeHandler,
+  GridLayoutDescriptor,
+} from "./GridModel";
+import type { GridSnapshot } from "./GridSnapshot";
+import { gridSnapshotToGridLayoutDescriptor } from "./grid-snapshot-adapters";
+import { GridLayoutItem, type GridLayoutItemProps } from "./GridLayoutItem";
 import { layoutToJSON } from "./layoutToJson";
 import { layoutFromJson } from "./layoutFromJson";
-import { LayoutJSON } from "./componentToJson";
+import type { LayoutJSON } from "./componentToJson";
 import {
   TemplateDragSession,
   TemplateDragSessionContext,
@@ -29,8 +46,7 @@ type GridLayoutOptions = {
 };
 
 export type ReactElementList = ReactElement[];
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ReactElementMap<P = any> = Record<string, ReactElement<P>>;
+export type ReactElementMap<P = unknown> = Record<string, ReactElement<P>>;
 export type SerializedComponentMap = Record<string, LayoutJSON>;
 
 export type SerializedGridLayout = {
@@ -43,6 +59,7 @@ export type DeserializedGridLayout = {
   components: ReactElementMap<GridLayoutItemProps>;
   id: string;
   layout: GridLayoutDescriptor;
+  placeholderIds?: readonly string[];
 };
 
 interface GridLayoutProviderContext {
@@ -60,6 +77,10 @@ interface GridLayoutProviderContext {
   options?: GridLayoutOptions;
   onChangeChildElements?: GridChildElementsChangeHandler;
   onChangeLayout?: GridLayoutChangeHandler;
+  onCommittedSnapshot?: (
+    snapshot: GridSnapshot,
+    placeholderIds: readonly string[],
+  ) => void;
 }
 
 const GridLayoutProviderContext = createContext<GridLayoutProviderContext>({});
@@ -71,15 +92,62 @@ export type GridLayoutDragEndHandler = (
 
 export interface GridLayoutProviderProps {
   children: ReactNode;
+  componentRenderers?: GridComponentRendererRegistry;
+  componentSettings?: readonly GridComponentSettingsInput[];
+  document?: unknown;
+  onDocumentChange?: (document: GridLayoutDocument) => void;
+  onDocumentError?: (error: GridLayoutDocumentError) => void;
   options?: GridLayoutOptions;
+  settingsCodecs?: GridComponentSettingsRegistry;
+  /** @deprecated Use document with settingsCodecs and componentRenderers. */
   serializedLayout?: SerializedGridLayout;
 }
 
 export const GridLayoutProvider = (
   props: GridLayoutProviderProps,
 ): ReactElement => {
-  const { children, serializedLayout, options } = props;
+  const {
+    children,
+    componentRenderers,
+    componentSettings,
+    document,
+    onDocumentChange,
+    onDocumentError,
+    serializedLayout,
+    settingsCodecs,
+    options,
+  } = props;
   const templateDragSession = useMemo(() => new TemplateDragSession(), []);
+  const decodedDocument = useMemo(() => {
+    if (document === undefined) {
+      return undefined;
+    }
+    if (!settingsCodecs || !componentRenderers) {
+      throw new Error(
+        "GridLayoutProvider document requires settingsCodecs and componentRenderers",
+      );
+    }
+    const decoded = decodeGridLayoutDocument(document, settingsCodecs);
+    if (!decoded.ok) {
+      throw new GridLayoutDocumentCodecError(decoded.error);
+    }
+    const componentById = new Map(
+      decoded.value.components.map(
+        (component) =>
+          [component.id, componentRenderers.render(component)] as const,
+      ),
+    );
+    const layout = gridSnapshotToGridLayoutDescriptor(decoded.value.snapshot);
+    return {
+      componentById,
+      decodedSettings: decoded.value.components.map(
+        ({ id, settings, type }) => ({ id, settings, type }),
+      ),
+      layout,
+      placeholderIds: [...decoded.value.document.layout.placeholderIds],
+      snapshot: decoded.value.snapshot,
+    };
+  }, [componentRenderers, document, settingsCodecs]);
   const [gridLayoutMap, gridChildItemsMap] = useMemo<
     [Map<string, GridLayoutDescriptor>, Map<string, SerializedComponentMap>]
   >(() => {
@@ -119,7 +187,7 @@ export const GridLayoutProvider = (
           const { id: gridLayoutItemId } = component.props;
           if (typeof gridLayoutItemId !== "string") {
             throw Error(
-              `[GridLayoutProvider] onChangeChildElements, child GridLayoutItem has no id`,
+              "[GridLayoutProvider] onChangeChildElements, child GridLayoutItem has no id",
             );
           }
           map[gridLayoutItemId] = layoutToJSON(component);
@@ -140,6 +208,46 @@ export const GridLayoutProvider = (
 
   const getSavedGrid = useCallback(
     (id: string): DeserializedGridLayout | undefined => {
+      if (decodedDocument?.snapshot.gridId === id) {
+        return {
+          components: Object.fromEntries(
+            decodedDocument.snapshot.items.flatMap((item) => {
+              const {
+                column,
+                componentInstanceId,
+                dropTarget,
+                id: itemId,
+                row,
+                ...metadata
+              } = item;
+              const component = decodedDocument.componentById.get(
+                componentInstanceId ?? itemId,
+              );
+              return component
+                ? [
+                    [
+                      itemId,
+                      <GridLayoutItem
+                        {...metadata}
+                        data-drop-target={dropTarget}
+                        id={itemId}
+                        key={itemId}
+                        style={{
+                          gridArea: `${row.start}/${column.start}/${row.start + row.span}/${column.start + column.span}`,
+                        }}
+                      >
+                        {component}
+                      </GridLayoutItem>,
+                    ] as const,
+                  ]
+                : [];
+            }),
+          ),
+          id,
+          layout: decodedDocument.layout,
+          placeholderIds: decodedDocument.placeholderIds,
+        };
+      }
       const layoutJSON = gridChildItemsMap.get(id);
       const layout = gridLayoutMap.get(id);
       if (layoutJSON && layout) {
@@ -166,7 +274,55 @@ export const GridLayoutProvider = (
         };
       }
     },
-    [gridChildItemsMap, gridLayoutMap],
+    [decodedDocument, gridChildItemsMap, gridLayoutMap],
+  );
+
+  const onCommittedSnapshot = useCallback(
+    (snapshot: GridSnapshot, placeholderIds: readonly string[]) => {
+      if (!onDocumentChange) {
+        return;
+      }
+      if (!settingsCodecs) {
+        const error: GridLayoutDocumentError = {
+          code: "INVALID_DOCUMENT",
+          message: "onDocumentChange requires a GridComponentSettingsRegistry",
+          path: "$.components",
+        };
+        if (onDocumentError) {
+          onDocumentError(error);
+          return;
+        }
+        throw new GridLayoutDocumentCodecError(error);
+      }
+      const availableSettings =
+        componentSettings ?? decodedDocument?.decodedSettings ?? [];
+      const referencedComponentIds = new Set(
+        snapshot.items.map(
+          ({ componentInstanceId, id }) => componentInstanceId ?? id,
+        ),
+      );
+      const settings = availableSettings.filter(({ id }) =>
+        referencedComponentIds.has(id),
+      );
+      const encoded = encodeGridLayoutDocument(snapshot, settingsCodecs, {
+        componentSettings: settings,
+        placeholderIds,
+      });
+      if (encoded.ok) {
+        onDocumentChange(encoded.value);
+      } else if (onDocumentError) {
+        onDocumentError(encoded.error);
+      } else {
+        throw new GridLayoutDocumentCodecError(encoded.error);
+      }
+    },
+    [
+      componentSettings,
+      decodedDocument,
+      onDocumentChange,
+      onDocumentError,
+      settingsCodecs,
+    ],
   );
 
   return (
@@ -179,6 +335,7 @@ export const GridLayoutProvider = (
           gridLayoutMap,
           onChangeChildElements,
           onChangeLayout,
+          onCommittedSnapshot,
           options,
         }}
       >
@@ -189,10 +346,9 @@ export const GridLayoutProvider = (
 };
 
 export const useGridChangeHandler = () => {
-  const { onChangeChildElements, onChangeLayout } = useContext(
-    GridLayoutProviderContext,
-  );
-  return { onChangeChildElements, onChangeLayout };
+  const { onChangeChildElements, onChangeLayout, onCommittedSnapshot } =
+    useContext(GridLayoutProviderContext);
+  return { onChangeChildElements, onChangeLayout, onCommittedSnapshot };
 };
 
 export const useSavedGrid = () => {

--- a/vuu-ui/packages/grid-layout/src/GridModel.ts
+++ b/vuu-ui/packages/grid-layout/src/GridModel.ts
@@ -102,6 +102,7 @@ export const toGridItemUpdates = (
 
 //TODO shouldn't id be here ?
 export interface GridLayoutChildItemDescriptor {
+  componentId?: string;
   contentVisible?: boolean;
   dropTarget?: boolean | string;
   gridArea: string;
@@ -251,6 +252,7 @@ export type GridModelItemType =
 export interface IGridModelChildItem extends GridModelCoordinates {
   childId?: string[];
   closeable?: boolean;
+  componentInstanceId?: string;
   contentVisible?: boolean;
   dropTarget?: boolean | string;
   fixed?: boolean;
@@ -342,6 +344,7 @@ class ObservableGridPosition {
 export class GridModelChildItem implements IGridModelChildItem {
   id: string;
   column: GridModelPosition;
+  componentInstanceId?: string;
   contentDetached?: boolean;
   contentVisible?: boolean;
   dropTarget?: boolean | string;
@@ -361,6 +364,7 @@ export class GridModelChildItem implements IGridModelChildItem {
   #dragging = false;
 
   constructor({
+    componentInstanceId,
     header,
     height,
     id,
@@ -376,6 +380,7 @@ export class GridModelChildItem implements IGridModelChildItem {
     width,
     contentVisible = stackId === undefined,
   }: OptionalProperty<IGridModelChildItem, "type">) {
+    this.componentInstanceId = componentInstanceId;
     this.contentVisible = contentVisible;
     this.dropTarget = dropTarget;
     this.header = header;
@@ -1833,6 +1838,7 @@ export class GridModel extends EventEmitter<GridModelEvents> {
           {
             id,
             column,
+            componentInstanceId,
             contentVisible,
             dropTarget,
             header,
@@ -1848,6 +1854,9 @@ export class GridModel extends EventEmitter<GridModelEvents> {
           // The stacked-content gridItems are a runtime construct, no need to serialize
           if (type !== "stacked-content") {
             result[id] = {
+              ...(componentInstanceId === undefined
+                ? {}
+                : { componentId: componentInstanceId }),
               contentVisible,
               dropTarget,
               gridArea: `${row.start}/${column.start}/${row.end}/${column.end}`,
@@ -2039,6 +2048,7 @@ export class GridModel extends EventEmitter<GridModelEvents> {
     for (const [
       id,
       {
+        componentId,
         contentVisible,
         dropTarget,
         header,
@@ -2054,6 +2064,7 @@ export class GridModel extends EventEmitter<GridModelEvents> {
       this.addChildItem(
         new GridModelChildItem({
           contentVisible,
+          componentInstanceId: componentId,
           id,
           column,
           dropTarget,

--- a/vuu-ui/packages/grid-layout/src/index.ts
+++ b/vuu-ui/packages/grid-layout/src/index.ts
@@ -54,8 +54,49 @@ export { useGridControllerSnapshot } from "./useGridControllerSnapshot";
 export { GridLayoutItem } from "./GridLayoutItem";
 export {
   GridLayoutProvider,
+  type GridLayoutProviderProps,
   type SerializedGridLayout,
 } from "./GridLayoutProvider";
+export {
+  GridComponentRendererRegistry,
+  GridComponentSettingsRegistry,
+  GridLayoutContentRegistry,
+  type DecodedGridComponentSettings,
+  type EncodedGridComponentSettings,
+  type GridComponentRenderer,
+  type GridComponentSettingsCodec,
+  type GridComponentSettingsError,
+  type GridComponentSettingsErrorCode,
+  type GridComponentSettingsInput,
+  type GridComponentSettingsResult,
+  type GridSettingsCodecIssue,
+  type GridSettingsCodecResult,
+} from "./GridComponentSettings";
+export {
+  GRID_LAYOUT_DOCUMENT_KIND,
+  GRID_LAYOUT_DOCUMENT_VERSION,
+  GridLayoutDocumentCodecError,
+  decodeGridLayoutDocument,
+  decodeLegacySerializedGridLayout,
+  encodeGridLayoutDocument,
+  type DecodedGridLayoutDocument,
+  type EncodeGridLayoutDocumentOptions,
+  type GridLayoutDocument,
+  type GridLayoutDocumentError,
+  type GridLayoutDocumentErrorCode,
+  type GridLayoutDocumentResult,
+  type GridLayoutDocumentV1,
+  type LegacyGridLayoutDocument,
+  type PersistedGridLayout,
+} from "./GridLayoutDocument";
+export {
+  toJsonValue,
+  type JsonPrimitive,
+  type JsonValue,
+  type JsonValueErrorCode,
+  type JsonValueIssue,
+  type JsonValueResult,
+} from "./json-value";
 export { GridLayoutStackedItem } from "./GridLayoutStackedtem";
 export {
   gridLayoutDescriptorToSnapshot,

--- a/vuu-ui/packages/grid-layout/src/json-value.ts
+++ b/vuu-ui/packages/grid-layout/src/json-value.ts
@@ -1,0 +1,127 @@
+export type JsonPrimitive = boolean | number | string | null;
+export type JsonValue =
+  | JsonPrimitive
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+export type JsonValueErrorCode =
+  | "CYCLE"
+  | "INVALID_NUMBER"
+  | "NON_PLAIN_OBJECT"
+  | "UNSUPPORTED_VALUE";
+
+export interface JsonValueIssue {
+  readonly code: JsonValueErrorCode;
+  readonly message: string;
+  readonly path: string;
+}
+
+export type JsonValueResult =
+  | { readonly ok: true; readonly value: JsonValue }
+  | { readonly error: JsonValueIssue; readonly ok: false };
+
+const error = (
+  code: JsonValueErrorCode,
+  message: string,
+  path: string,
+): JsonValueResult => ({ error: { code, message, path }, ok: false });
+
+/**
+ * Validate and detach data at the persistence boundary. JSON.stringify is not
+ * used because it silently drops unsupported values and coerces non-finite
+ * numbers.
+ */
+export const toJsonValue = (value: unknown, path = "$"): JsonValueResult => {
+  const ancestors = new Set<object>();
+
+  const visit = (
+    candidate: unknown,
+    candidatePath: string,
+  ): JsonValueResult => {
+    if (
+      candidate === null ||
+      typeof candidate === "string" ||
+      typeof candidate === "boolean"
+    ) {
+      return { ok: true, value: candidate };
+    }
+    if (typeof candidate === "number") {
+      return Number.isFinite(candidate)
+        ? { ok: true, value: candidate }
+        : error("INVALID_NUMBER", "numbers must be finite", candidatePath);
+    }
+    if (typeof candidate !== "object") {
+      return error(
+        "UNSUPPORTED_VALUE",
+        `${typeof candidate} values are not valid JSON`,
+        candidatePath,
+      );
+    }
+    if (ancestors.has(candidate)) {
+      return error("CYCLE", "cyclic values are not valid JSON", candidatePath);
+    }
+
+    const prototype = Object.getPrototypeOf(candidate);
+    if (
+      !Array.isArray(candidate) &&
+      prototype !== Object.prototype &&
+      prototype !== null
+    ) {
+      return error(
+        "NON_PLAIN_OBJECT",
+        "only arrays and plain objects are valid JSON",
+        candidatePath,
+      );
+    }
+    if (Object.getOwnPropertySymbols(candidate).length > 0) {
+      return error(
+        "UNSUPPORTED_VALUE",
+        "symbol-keyed properties are not valid JSON",
+        candidatePath,
+      );
+    }
+
+    ancestors.add(candidate);
+    if (Array.isArray(candidate)) {
+      const propertyNames = Object.getOwnPropertyNames(candidate);
+      const unexpectedProperty = propertyNames.find(
+        (key) =>
+          key !== "length" &&
+          (!/^(?:0|[1-9]\d*)$/.test(key) || Number(key) >= candidate.length),
+      );
+      if (unexpectedProperty) {
+        return error(
+          "UNSUPPORTED_VALUE",
+          `array property "${unexpectedProperty}" is not valid JSON`,
+          `${candidatePath}.${unexpectedProperty}`,
+        );
+      }
+      const result: JsonValue[] = [];
+      for (let index = 0; index < candidate.length; index += 1) {
+        const item = visit(candidate[index], `${candidatePath}[${index}]`);
+        if (!item.ok) {
+          return item;
+        }
+        result.push(item.value);
+      }
+      ancestors.delete(candidate);
+      return { ok: true, value: result };
+    }
+
+    const result: Record<string, JsonValue> = {};
+    for (const key of Object.getOwnPropertyNames(candidate).sort()) {
+      const item = visit(
+        (candidate as Record<string, unknown>)[key],
+        candidatePath === "$" ? `$.${key}` : `${candidatePath}.${key}`,
+      );
+      if (!item.ok) {
+        return item;
+      }
+      result[key] = item.value;
+    }
+    ancestors.delete(candidate);
+    return { ok: true, value: result };
+  };
+
+  return visit(value, path);
+};

--- a/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
@@ -160,7 +160,8 @@ export const useGridLayout = ({
   onChange,
 }: GridLayoutHookProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { onChangeChildElements, onChangeLayout } = useGridChangeHandler();
+  const { onChangeChildElements, onChangeLayout, onCommittedSnapshot } =
+    useGridChangeHandler();
   const layoutOptions = useGridLayoutOptions();
 
   const getSavedGrid = useSavedGrid();
@@ -170,29 +171,38 @@ export const useGridLayout = ({
    * which will be used to create the GridModel. We also save in state a copy
    * of the child elements as a map, keyed by id.
    */
-  const [[children, layout]] = useState<
-    [GridLayoutItemElements, GridLayoutDescriptor]
-  >(() => {
-    const savedGrid = getSavedGrid?.(id);
-    if (savedGrid) {
-      const { components: savedChildren, layout: savedLayout } = savedGrid;
-      return [Object.values(savedChildren), savedLayout];
-    } else if (colsAndRows) {
-      const reactElements = asReactElements(
-        childrenProp,
-      ) as GridLayoutItemElements;
-      const layoutDescriptor = layoutDescriptorFromChildren(
-        colsAndRows,
-        reactElements,
-      );
+  const [[children, layout, persistedPlaceholderIds], setInitialGrid] =
+    useState<
+      [
+        GridLayoutItemElements,
+        GridLayoutDescriptor,
+        readonly string[] | undefined,
+      ]
+    >(() => {
+      const savedGrid = getSavedGrid?.(id);
+      if (savedGrid) {
+        const { components: savedChildren, layout: savedLayout } = savedGrid;
+        return [
+          Object.values(savedChildren),
+          savedLayout,
+          savedGrid.placeholderIds,
+        ];
+      } else if (colsAndRows) {
+        const reactElements = asReactElements(
+          childrenProp,
+        ) as GridLayoutItemElements;
+        const layoutDescriptor = layoutDescriptorFromChildren(
+          colsAndRows,
+          reactElements,
+        );
 
-      return [reactElements, layoutDescriptor];
-    } else {
-      throw Error(
-        "[useGridLayout] no saved grid details available and no layout provided. Either pass layout props or provide a layout using GridLayoutProvider",
-      );
-    }
-  });
+        return [reactElements, layoutDescriptor, undefined];
+      } else {
+        throw Error(
+          "[useGridLayout] no saved grid details available and no layout provided. Either pass layout props or provide a layout using GridLayoutProvider",
+        );
+      }
+    });
 
   // Note we initialise this ref with the initial children from props. We subsequently
   // only update it in response to manipulation of the GridLayout NOT in case of the
@@ -203,6 +213,28 @@ export const useGridLayout = ({
   const contentRegistryRef = useRef(
     new Map(children.map((element) => [element.props.id, element])),
   );
+  const savedGridReaderRef = useRef(getSavedGrid);
+
+  useEffect(() => {
+    if (savedGridReaderRef.current === getSavedGrid) {
+      return;
+    }
+    savedGridReaderRef.current = getSavedGrid;
+    const savedGrid = getSavedGrid?.(id);
+    if (savedGrid) {
+      const nextChildren = Object.values(savedGrid.components);
+      childrenRef.current = nextChildren;
+      contentRegistryRef.current = new Map(
+        nextChildren.map((element) => [element.props.id, element]),
+      );
+      setChildElements(nextChildren);
+      setInitialGrid([
+        nextChildren,
+        savedGrid.layout,
+        savedGrid.placeholderIds,
+      ]);
+    }
+  }, [getSavedGrid, id]);
 
   const setChildren = useCallback(
     (
@@ -234,6 +266,9 @@ export const useGridLayout = ({
       //   "color: green",
       // );
       const gridModel = new GridModel(id, layout);
+      for (const placeholderId of persistedPlaceholderIds ?? []) {
+        gridModel.getChildItem(placeholderId, true).type = "placeholder";
+      }
       for (const [stackId, items] of gridModel.getStackedChildItems()) {
         if (gridModel.getChildItem(stackId) === undefined) {
           const { column, row } = getSharedGridPosition(items);
@@ -255,7 +290,9 @@ export const useGridLayout = ({
           );
         }
       }
-      gridModel.createPlaceholders();
+      if (persistedPlaceholderIds === undefined) {
+        gridModel.createPlaceholders();
+      }
       const gridLayoutModel = new GridLayoutModel(gridModel);
       const callbackRef: RefCallback<HTMLDivElement> = (el) => {
         if (el) {
@@ -265,7 +302,7 @@ export const useGridLayout = ({
 
       return [gridModel, gridLayoutModel, callbackRef];
     },
-    [children, id, layout],
+    [children, id, layout, persistedPlaceholderIds],
   );
   const gridController = useMemo(
     () =>
@@ -925,8 +962,14 @@ export const useGridLayout = ({
   useEffect(() => {
     return gridController.subscribeCommitted(({ snapshot }) => {
       saveGridLayout(id, gridSnapshotToGridLayoutDescriptor(snapshot));
+      onCommittedSnapshot?.(
+        snapshot,
+        gridModel
+          .getPlaceholders()
+          .map(({ id: placeholderId }) => placeholderId),
+      );
     });
-  }, [gridController, id, saveGridLayout]);
+  }, [gridController, gridModel, id, onCommittedSnapshot, saveGridLayout]);
 
   return {
     children: renderedChildren,

--- a/vuu-ui/packages/grid-layout/test/GridLayout.persistence.react.test.tsx
+++ b/vuu-ui/packages/grid-layout/test/GridLayout.persistence.react.test.tsx
@@ -1,0 +1,195 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type GridController,
+  GridComponentRendererRegistry,
+  GridComponentSettingsRegistry,
+  GridLayout,
+  type GridLayoutDocument,
+  GridLayoutItem,
+  GridLayoutProvider,
+  useGridController,
+} from "../src";
+
+const isLabelSettings = (value: unknown): value is { readonly label: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "label" in value &&
+  typeof value.label === "string";
+
+const codecs = new GridComponentSettingsRegistry();
+codecs.register("label", {
+  decode: (value) =>
+    isLabelSettings(value)
+      ? { ok: true, value }
+      : {
+          error: {
+            code: "INVALID_LABEL",
+            message: "label must be a string",
+            path: "$.label",
+          },
+          ok: false,
+        },
+  encode: (value) => ({ ok: true, value }),
+  isSettings: isLabelSettings,
+  version: 1,
+});
+const renderers = new GridComponentRendererRegistry();
+renderers.register("label", isLabelSettings, ({ label }, id) => (
+  <span id={id}>{label}</span>
+));
+
+const documentWithLabel = (
+  gridId: string,
+  componentId: string,
+  label: string,
+): GridLayoutDocument => ({
+  components: [
+    {
+      id: componentId,
+      settings: { label },
+      type: "label",
+      version: 1,
+    },
+  ],
+  kind: "grid-layout",
+  layout: {
+    columns: ["1fr"],
+    id: gridId,
+    items: [
+      {
+        column: { span: 1, start: 1 },
+        id: componentId,
+        row: { span: 1, start: 1 },
+      },
+    ],
+    placeholderIds: [],
+    rows: ["1fr"],
+    stacks: [],
+  },
+  version: 2,
+});
+
+const Capture = ({
+  capture,
+}: {
+  capture: (controller: GridController) => void;
+}) => {
+  capture(useGridController());
+  return null;
+};
+
+describe("GridLayout provider persistence", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("writes only committed semantic transitions", () => {
+    const onDocumentChange = vi.fn<(document: GridLayoutDocument) => void>();
+    let controller: GridController | undefined;
+    act(() =>
+      root.render(
+        <GridLayoutProvider
+          componentSettings={[
+            { id: "left", settings: { label: "Left" }, type: "label" },
+            { id: "right", settings: { label: "Right" }, type: "label" },
+          ]}
+          onDocumentChange={onDocumentChange}
+          settingsCodecs={codecs}
+        >
+          <GridLayout
+            colsAndRows={{ cols: ["100px", "100px"], rows: ["1fr"] }}
+            id="persisted-grid"
+          >
+            <GridLayoutItem id="left" style={{ gridArea: "1/1/2/2" }}>
+              <Capture capture={(value) => (controller = value)} />
+            </GridLayoutItem>
+            <GridLayoutItem id="right" style={{ gridArea: "1/2/2/3" }}>
+              Right
+            </GridLayoutItem>
+          </GridLayout>
+        </GridLayoutProvider>,
+      ),
+    );
+    expect(onDocumentChange).not.toHaveBeenCalled();
+    if (!controller) {
+      throw new Error("controller was not captured");
+    }
+
+    act(() => {
+      controller?.dispatch({
+        itemId: "left",
+        title: "Renamed",
+        type: "rename-item",
+      });
+    });
+    expect(onDocumentChange).toHaveBeenCalledTimes(1);
+
+    const transaction = controller.beginTransaction("resize");
+    if (!transaction.ok) {
+      throw new Error(transaction.error.message);
+    }
+    act(() => {
+      transaction.transaction.dispatch({
+        index: 0,
+        size: "120px",
+        track: "column",
+        type: "resize-track",
+      });
+    });
+    expect(onDocumentChange).toHaveBeenCalledTimes(1);
+    act(() => {
+      transaction.transaction.rollback();
+    });
+    expect(onDocumentChange).toHaveBeenCalledTimes(1);
+
+    const committed = controller.beginTransaction("resize");
+    if (!committed.ok) {
+      throw new Error(committed.error.message);
+    }
+    act(() => {
+      committed.transaction.dispatch({
+        index: 0,
+        size: "125px",
+        track: "column",
+        type: "resize-track",
+      });
+      committed.transaction.commit();
+    });
+    expect(onDocumentChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("loads and replaces typed content without an initial write", () => {
+    const onDocumentChange = vi.fn<(document: GridLayoutDocument) => void>();
+    const render = (document: GridLayoutDocument) => (
+      <GridLayoutProvider
+        componentRenderers={renderers}
+        document={document}
+        onDocumentChange={onDocumentChange}
+        settingsCodecs={codecs}
+      >
+        <GridLayout id="loaded-grid" />
+      </GridLayoutProvider>
+    );
+
+    act(() => root.render(render(documentWithLabel("loaded-grid", "a", "A"))));
+    expect(container.querySelector("#a")?.textContent).toBe("A");
+    expect(onDocumentChange).not.toHaveBeenCalled();
+
+    act(() => root.render(render(documentWithLabel("loaded-grid", "b", "B"))));
+    expect(container.querySelector("#a")).toBeNull();
+    expect(container.querySelector("#b")?.textContent).toBe("B");
+    expect(onDocumentChange).not.toHaveBeenCalled();
+  });
+});

--- a/vuu-ui/packages/grid-layout/test/GridLayoutDocument.test.ts
+++ b/vuu-ui/packages/grid-layout/test/GridLayoutDocument.test.ts
@@ -1,0 +1,492 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import {
+  type GridComponentSettingsCodec,
+  GridComponentRendererRegistry,
+  GridComponentSettingsRegistry,
+  GridLayoutContentRegistry,
+  type GridSettingsCodecResult,
+} from "../src/GridComponentSettings";
+import {
+  decodeGridLayoutDocument,
+  decodeLegacySerializedGridLayout,
+  encodeGridLayoutDocument,
+  type GridLayoutDocumentV1,
+} from "../src/GridLayoutDocument";
+import { GridModel } from "../src/GridModel";
+import type { GridSnapshot } from "../src/GridSnapshot";
+import {
+  gridLayoutDescriptorToSnapshot,
+  gridSnapshotToGridLayoutDescriptor,
+  normalizeGridSnapshot,
+} from "../src/grid-snapshot-adapters";
+import { toJsonValue } from "../src/json-value";
+
+interface LabelSettings {
+  readonly label: string;
+}
+
+interface NestedSettings {
+  readonly document: unknown;
+}
+
+const isLabelSettings = (value: unknown): value is LabelSettings =>
+  typeof value === "object" &&
+  value !== null &&
+  "label" in value &&
+  typeof value.label === "string";
+
+const labelCodec: GridComponentSettingsCodec<LabelSettings> = {
+  decode: (value): GridSettingsCodecResult<LabelSettings> =>
+    isLabelSettings(value)
+      ? { ok: true, value }
+      : {
+          error: {
+            code: "INVALID_LABEL",
+            message: "label must be a string",
+            path: "$.label",
+          },
+          ok: false,
+        },
+  encode: (settings) => ({ ok: true, value: settings }),
+  isSettings: isLabelSettings,
+  migrations: {
+    1: (value) =>
+      typeof value === "object" &&
+      value !== null &&
+      "text" in value &&
+      typeof value.text === "string"
+        ? { ok: true, value: { label: value.text } }
+        : {
+            error: {
+              code: "INVALID_TEXT",
+              message: "text must be a string",
+              path: "$.text",
+            },
+            ok: false,
+          },
+  },
+  version: 2,
+};
+
+const snapshot: GridSnapshot = {
+  columns: [{ size: "0.5fr" }, { size: "120px" }],
+  gridId: "grid",
+  items: [
+    {
+      column: { span: 2, start: 1 },
+      header: true,
+      id: "b",
+      resizeable: "hv",
+      row: { span: 1, start: 1 },
+      title: "Duplicate title",
+    },
+    {
+      column: { span: 2, start: 1 },
+      componentInstanceId: "component-a",
+      id: "a",
+      resizeable: false,
+      row: { span: 1, start: 1 },
+      title: "Duplicate title",
+    },
+    {
+      column: { span: 1, start: 2 },
+      id: "placeholder",
+      row: { span: 1, start: 2 },
+    },
+  ],
+  revision: 19,
+  rows: [{ size: "1fr" }, { size: "80px" }],
+  stacks: [
+    {
+      id: "tabs",
+      itemIds: ["b", "a"],
+      selectedItemId: "a",
+    },
+  ],
+};
+
+const settings = [
+  { id: "b", settings: { label: "Beta" }, type: "label" },
+  {
+    id: "component-a",
+    settings: { label: "Alpha" },
+    type: "label",
+  },
+] as const;
+
+const registry = () => {
+  const result = new GridComponentSettingsRegistry();
+  result.register("label", labelCodec);
+  return result;
+};
+
+describe("GridLayout document codec", () => {
+  it("round trips canonical state deterministically without revisions", () => {
+    const codecs = registry();
+    const encoded = encodeGridLayoutDocument(snapshot, codecs, {
+      componentSettings: settings,
+      placeholderIds: ["placeholder"],
+    });
+    expect(encoded.ok).toBe(true);
+    if (!encoded.ok) {
+      return;
+    }
+    expect(encoded.value).toMatchObject({
+      components: [{ id: "b" }, { id: "component-a" }],
+      kind: "grid-layout",
+      layout: {
+        id: "grid",
+        placeholderIds: ["placeholder"],
+        stacks: [{ itemIds: ["b", "a"], selectedItemId: "a" }],
+      },
+      version: 2,
+    });
+    expect(JSON.stringify(encoded.value)).not.toContain("revision");
+
+    const decoded = decodeGridLayoutDocument(encoded.value, codecs);
+    expect(decoded.ok).toBe(true);
+    if (!decoded.ok) {
+      return;
+    }
+    const normalized = normalizeGridSnapshot(snapshot);
+    expect(decoded.value.snapshot).toEqual({
+      ...normalized,
+      items: [...normalized.items].sort((a, b) => a.id.localeCompare(b.id)),
+      revision: 0,
+    });
+
+    const reencoded = encodeGridLayoutDocument(decoded.value.snapshot, codecs, {
+      componentSettings: decoded.value.components,
+      placeholderIds: decoded.value.document.layout.placeholderIds,
+    });
+    expect(reencoded).toEqual(encoded);
+    expect(decoded.value.snapshot.items).not.toBe(snapshot.items);
+  });
+
+  it("migrates document and component settings versions", () => {
+    const v1: GridLayoutDocumentV1 = {
+      components: [
+        {
+          id: "only",
+          settings: { text: "Migrated" },
+          type: "label",
+          version: 1,
+        },
+      ],
+      kind: "grid-layout",
+      layout: {
+        columns: ["1fr"],
+        gridId: "old-grid",
+        items: [
+          {
+            column: { span: 1, start: 1 },
+            id: "only",
+            row: { span: 1, start: 1 },
+          },
+        ],
+        rows: ["1fr"],
+      },
+      version: 1,
+    };
+
+    const decoded = decodeGridLayoutDocument(v1, registry());
+    expect(decoded).toMatchObject({
+      ok: true,
+      value: {
+        components: [{ settings: { label: "Migrated" }, version: 2 }],
+        document: { layout: { id: "old-grid" }, version: 2 },
+      },
+    });
+  });
+
+  it.each([
+    [
+      "future document",
+      { kind: "grid-layout", version: 99 },
+      "UNSUPPORTED_DOCUMENT_VERSION",
+      "$.version",
+    ],
+    [
+      "wrong discriminator",
+      { kind: "other", version: 2 },
+      "INVALID_DISCRIMINATOR",
+      "$.kind",
+    ],
+    [
+      "future component",
+      {
+        components: [{ id: "x", settings: {}, type: "label", version: 99 }],
+        kind: "grid-layout",
+        layout: {
+          columns: ["1fr"],
+          id: "grid",
+          items: [
+            {
+              column: { span: 1, start: 1 },
+              id: "x",
+              row: { span: 1, start: 1 },
+            },
+          ],
+          placeholderIds: [],
+          rows: ["1fr"],
+          stacks: [],
+        },
+        version: 2,
+      },
+      "COMPONENT_SETTINGS_ERROR",
+      "$.components[0].version",
+    ],
+  ])("rejects %s with a path-aware error", (_name, value, code, path) => {
+    expect(decodeGridLayoutDocument(value, registry())).toMatchObject({
+      error: { code, path },
+      ok: false,
+    });
+  });
+
+  it("rejects malformed references and missing component settings", () => {
+    const encoded = encodeGridLayoutDocument(snapshot, registry(), {
+      componentSettings: settings,
+      placeholderIds: ["placeholder"],
+    });
+    if (!encoded.ok) {
+      throw new Error(encoded.error.message);
+    }
+    const malformed = {
+      ...encoded.value,
+      layout: {
+        ...encoded.value.layout,
+        placeholderIds: [],
+      },
+    };
+    expect(decodeGridLayoutDocument(malformed, registry())).toMatchObject({
+      error: {
+        code: "MISSING_COMPONENT_SETTINGS",
+        path: "$.layout.items.placeholder",
+      },
+      ok: false,
+    });
+  });
+
+  it("rejects unsupported runtime values rather than coercing them", () => {
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+
+    for (const [value, code] of [
+      [() => undefined, "UNSUPPORTED_VALUE"],
+      [Symbol("x"), "UNSUPPORTED_VALUE"],
+      [undefined, "UNSUPPORTED_VALUE"],
+      [Number.NaN, "INVALID_NUMBER"],
+      [Number.POSITIVE_INFINITY, "INVALID_NUMBER"],
+      [new Date(), "NON_PLAIN_OBJECT"],
+      [
+        React.createElement("div", { key: "react-element" }),
+        "UNSUPPORTED_VALUE",
+      ],
+      [{ [Symbol("key")]: "value" }, "UNSUPPORTED_VALUE"],
+      [cyclic, "CYCLE"],
+    ] as const) {
+      expect(toJsonValue(value)).toMatchObject({
+        error: { code },
+        ok: false,
+      });
+    }
+    const arrayWithProperty: unknown[] & { extra?: unknown } = [];
+    arrayWithProperty.extra = () => undefined;
+    expect(toJsonValue(arrayWithProperty)).toMatchObject({
+      error: { code: "UNSUPPORTED_VALUE", path: "$.extra" },
+      ok: false,
+    });
+  });
+
+  it("keeps content registry replacement atomic", () => {
+    const content = new GridLayoutContentRegistry<string>();
+    content.replace(
+      [{ id: "old", settings: { label: "Old" }, type: "label", version: 2 }],
+      ({ id }) => id,
+    );
+
+    expect(() =>
+      content.replace(
+        [
+          { id: "new", settings: { label: "New" }, type: "label", version: 2 },
+          { id: "broken", settings: {}, type: "label", version: 2 },
+        ],
+        ({ id }) => {
+          if (id === "broken") {
+            throw new Error("cannot render");
+          }
+          return id;
+        },
+      ),
+    ).toThrow("cannot render");
+    expect([...content.entries()]).toEqual([["old", "old"]]);
+  });
+
+  it("resolves decoded settings through a separate renderer registry", () => {
+    const renderers = new GridComponentRendererRegistry();
+    renderers.register("label", isLabelSettings, ({ label }, id) =>
+      React.createElement("span", { id }, label),
+    );
+    const element = renderers.render({
+      id: "alpha",
+      settings: { label: "Alpha" },
+      type: "label",
+      version: 2,
+    });
+    expect(element.type).toBe("span");
+    expect(element.props.children).toBe("Alpha");
+  });
+
+  it("round trips a nested GridLayout document as independent settings", () => {
+    const codecs = registry();
+    codecs.register<NestedSettings>("nested-grid", {
+      decode: (value) =>
+        typeof value === "object" && value !== null && "document" in value
+          ? { ok: true, value: { document: value.document } }
+          : {
+              error: {
+                code: "INVALID_NESTED_GRID",
+                message: "nested document is required",
+                path: "$.document",
+              },
+              ok: false,
+            },
+      encode: (value) => ({ ok: true, value }),
+      isSettings: (value): value is NestedSettings =>
+        typeof value === "object" && value !== null && "document" in value,
+      version: 1,
+    });
+    const nested = encodeGridLayoutDocument(
+      {
+        columns: [{ size: "1fr" }],
+        gridId: "nested",
+        items: [
+          {
+            column: { span: 1, start: 1 },
+            id: "nested-item",
+            row: { span: 1, start: 1 },
+          },
+        ],
+        revision: 0,
+        rows: [{ size: "1fr" }],
+        stacks: [],
+      },
+      codecs,
+      {
+        componentSettings: [
+          {
+            id: "nested-item",
+            settings: { label: "Nested" },
+            type: "label",
+          },
+        ],
+      },
+    );
+    if (!nested.ok) {
+      throw new Error(nested.error.message);
+    }
+    const outer = encodeGridLayoutDocument(
+      {
+        columns: [{ size: "1fr" }],
+        gridId: "outer",
+        items: [
+          {
+            column: { span: 1, start: 1 },
+            id: "nested-grid-item",
+            row: { span: 1, start: 1 },
+          },
+        ],
+        revision: 0,
+        rows: [{ size: "1fr" }],
+        stacks: [],
+      },
+      codecs,
+      {
+        componentSettings: [
+          {
+            id: "nested-grid-item",
+            settings: { document: nested.value },
+            type: "nested-grid",
+          },
+        ],
+      },
+    );
+
+    expect(outer).toMatchObject({
+      ok: true,
+      value: {
+        components: [
+          {
+            settings: {
+              document: { kind: "grid-layout", layout: { id: "nested" } },
+            },
+          },
+        ],
+        layout: { id: "outer" },
+      },
+    });
+    if (outer.ok) {
+      expect(decodeGridLayoutDocument(outer.value, codecs)).toMatchObject({
+        ok: true,
+        value: {
+          components: [
+            {
+              settings: {
+                document: { kind: "grid-layout", layout: { id: "nested" } },
+              },
+            },
+          ],
+        },
+      });
+    }
+  });
+
+  it("adapts legacy SerializedGridLayout without changing its v1 wire shape", () => {
+    const decoded = decodeLegacySerializedGridLayout({
+      components: {
+        green: {
+          props: { style: { background: "green" } },
+          type: "div",
+        },
+      },
+      id: "legacy",
+      layout: {
+        cols: ["1fr"],
+        gridLayoutItems: {
+          green: {
+            gridArea: "1/1/2/2",
+            resizeable: "hv",
+            title: "Green",
+          },
+        },
+        rows: ["1fr"],
+      },
+    });
+    expect(decoded).toMatchObject({
+      ok: true,
+      value: {
+        snapshot: {
+          gridId: "legacy",
+          items: [{ id: "green", resizeable: "hv", title: "Green" }],
+        },
+      },
+    });
+  });
+
+  it("preserves distinct item/component IDs through the legacy model bridge", () => {
+    const descriptor = gridSnapshotToGridLayoutDescriptor(snapshot);
+    if (!descriptor.gridLayoutItems) {
+      throw new Error("descriptor has no items");
+    }
+    const model = new GridModel("grid", descriptor);
+    const restored = gridLayoutDescriptorToSnapshot(
+      model.toGridLayoutDescriptor(),
+      { gridId: "grid" },
+    );
+
+    expect(
+      restored.items.find(({ id }) => id === "a")?.componentInstanceId,
+    ).toBe("component-a");
+  });
+});


### PR DESCRIPTION
## Summary

- add the plain-JSON GridLayout document contract (`kind: "grid-layout"`, schema `version: 2`) with deterministic, revision-free canonical layout state: durable grid ID, tracks, placements/spans, explicit placeholder IDs, stack order/selection, `resizeable` metadata, and versioned component settings records
- add typed component settings and renderer registries with encode/decode validation, per-type version migrations, path-aware component errors, unknown/future-version rejection, and nested GridLayout document support
- enforce a strict JSON boundary that rejects functions, React elements, symbols/symbol keys, undefined, cycles, non-finite numbers, class instances, and non-JSON array properties instead of coercing or dropping them
- migrate canonical document v1 (`layout.gridId`) to v2 and retain legacy `SerializedGridLayout` / `GridLayoutDescriptor` reads behind explicit compatibility paths; new writes do not use `componentToJson`
- persist through `GridController.subscribeCommitted` only, preserving zero writes for initial hydration, previews, rollback, rejected commands, and semantic no-ops, with one write for ordinary commits and transaction commits
- decode and resolve all typed settings/renderers before atomically replacing canonical initialization and the ID-keyed React content bridge; preserve distinct layout-item/component IDs and persisted placeholder identity

## Durable and transient boundary

The document persists domain layout state and versioned component settings. It excludes controller revisions, measurements, drag/hover/drop-zone state, active transactions/splitters, detached presentation, DOM state, React elements/keys/listeners, and other runtime objects. Outer `vuu-layout` and shell envelopes remain separate and treat this document as opaque component settings.

## Validation and compatibility

- validates discriminator/version, tracks, spans, IDs, stacks, selection, references, placeholder/component coverage, duplicate IDs, and component versions after migration
- deterministic code-unit ordering for components, items, and stacks; stack member order remains semantic
- typed migration/encode/decode failures identify component ID, type, version, and path
- failed decode/render resolution does not partially replace live content or mutate an existing controller
- legacy `resizeable` spelling and v1 descriptor/serialized-layout behavior remain intact

## Tests and validation

- complete GridLayout Vitest suite: **284 passed, 2 existing todos** across 15 files
- focused persistence/provider suites: **14 passed**
- isolated trusted native Playwright drag matrix from #2385: **9 passed, 1 intentionally skipped** (existing item, GridPalette cardinal/centre/header paths, affordance/cancel/outside-drop coverage)
- full isolated GridLayout Playwright run reached **14 passed** before an unrelated existing tab-settings test timed out waiting for `Gamma Settings`; serial mode then stopped the remainder
- GridLayout package build passed
- targeted Biome check passed with only 3 pre-existing `GridModel.ts` warnings
- the default Showcase-backed Playwright gallery still fails on existing `UserSettingsPanel` and `feature-filter-table` imports; the #2385 isolated gallery was used for the trusted native matrix

## Deferred to increment 9

Broad consumer migration, removal of legacy APIs, shell/reducer schema changes, and migration of palette/runtime component metadata producers are intentionally deferred. This increment does not add catalogs, thumbnails, undo/redo, collaborative history, cloud sync, responsive breakpoints, or arbitrary cross-grid instance drag.

## Stack

Dependent base: `heswell-copilot-finish-grid-layout-tests` at `4a1d3989011bf1ae2413eb4c8b55dfd709013325` (includes PR #2385 native drag repair).

Head: `2a10a408d3f40cd62e87a901ba74fbf83bce6349` — exactly one increment-8 persistence commit. The rebase applied without conflicts; no obsolete-base merge commit is present.