### PR TITLE
fix(grid-layout): restore native drag and drop

### DIFF
--- a/vuu-ui/packages/grid-layout/src/GridLayout.css
+++ b/vuu-ui/packages/grid-layout/src/GridLayout.css
@@ -6,26 +6,14 @@
   display: grid;
   padding: var(--vuu-grid-gap);
 
-  &.vuuDragging {
-    /* 
-      While we are dragging, do not let drag events fire on anything 
-      more granular than GridLayoutItem. Exception for vuuDraggableItem
-      is for Tabs 
-    */
-    [data-drop-target] > :not(.vuuDraggableItem) {
-      pointer-events: none;
-    }
-  }
-
   &.vuuResizing {
-    transition: .3s;
+    transition: 0.3s;
   }
 
   &.vuuFullPage {
     height: 100vh;
     width: 100vw;
   }
-  
 }
 
 .vuu-detached {
@@ -36,7 +24,7 @@
   &.has-h-splitter {
     margin-top: calc(var(--vuu-layout-tabs-height) + 7px);
   }
-  &:not(.has-h-splitter){
+  &:not(.has-h-splitter) {
     margin-top: var(--vuu-layout-tabs-height);
   }
 }
@@ -56,7 +44,6 @@
   position: absolute;
   inset: 0;
 }
-
 
 .vuuDropTarget-east {
   --grid-dropzone-top: 0px;
@@ -104,8 +91,8 @@
 }
 
 .vuuDropTarget-centre:after,
-.vuuDropTarget-north:after, 
-.vuuDropTarget-east:after, 
+.vuuDropTarget-north:after,
+.vuuDropTarget-east:after,
 .vuuDropTarget-south:after,
 .vuuDropTarget-west:after {
   background-color: cornflowerblue;
@@ -134,4 +121,3 @@
   transition-timing-function: ease-in-out;
   z-index: 100;
 }
-

--- a/vuu-ui/packages/grid-layout/src/GridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayout.tsx
@@ -83,7 +83,6 @@ export const GridLayout = ({
     children,
     containerCallback,
     dispatchGridLayoutAction,
-    dragSourceItemId,
     gridController,
     gridLayoutModel,
     gridModel,
@@ -130,7 +129,6 @@ export const GridLayout = ({
     <GridLayoutContext.Provider
       value={{
         dispatchGridLayoutAction,
-        dragSourceItemId,
         gridController,
         gridLayoutModel,
         gridModel,

--- a/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutContext.ts
@@ -169,7 +169,6 @@ export type GridLayoutDragLeaveHandler = () => void;
 
 export interface GridLayoutContextProps {
   dispatchGridLayoutAction: GridLayoutDispatch;
-  dragSourceItemId?: string;
   gridController?: GridController;
   gridLayoutModel?: GridLayoutModel;
   gridModel?: GridModel;
@@ -255,9 +254,4 @@ export const useGridSnapshot = () => {
 export const useGridLayoutId = () => {
   const { id } = useContext(GridLayoutContext);
   return id;
-};
-
-export const useGridLayoutDragSourceItemId = () => {
-  const { dragSourceItemId } = useContext(GridLayoutContext);
-  return dragSourceItemId;
 };

--- a/vuu-ui/packages/grid-layout/src/GridLayoutItem.tsx
+++ b/vuu-ui/packages/grid-layout/src/GridLayoutItem.tsx
@@ -4,18 +4,17 @@ import { queryClosest, registerComponent } from "@vuu-ui/vuu-utils";
 import cx from "clsx";
 import {
   createElement,
-  HTMLAttributes,
+  type HTMLAttributes,
   isValidElement,
-  MouseEventHandler,
-  ReactElement,
+  type MouseEventHandler,
+  type ReactElement,
   useCallback,
 } from "react";
-import { componentToJson, LayoutJSON } from "./componentToJson";
+import { componentToJson, type LayoutJSON } from "./componentToJson";
 import {
-  DragSourceProvider,
+  type DragSourceProvider,
   useGridLayoutDispatch,
   useGridLayoutDragEndHandler,
-  useGridLayoutDragSourceItemId,
   useGridLayoutDragStartHandler,
 } from "./GridLayoutContext";
 import {
@@ -137,9 +136,7 @@ export const GridLayoutItem = ({
     title: titleProp,
     width,
   });
-
   const onDragEnd = useGridLayoutDragEndHandler();
-  const dragSourceItemId = useGridLayoutDragSourceItemId();
   const onDragStart = useGridLayoutDragStartHandler();
 
   const onClose = useCallback<MouseEventHandler<HTMLButtonElement>>(
@@ -158,9 +155,8 @@ export const GridLayoutItem = ({
     onDragEnd,
     onDragStart,
   });
-
   const className = cx(classBaseItem, {
-    "vuuGridLayoutItem-dragging": dragging || dragSourceItemId === id,
+    "vuuGridLayoutItem-dragging": dragging,
     "vuu-detached": contentDetached,
     "vuu-stacked": stacked && !contentDetached,
     "has-h-splitter": horizontalSplitter,
@@ -222,7 +218,7 @@ GridLayoutItem.toJSON = (
   let { children } = element.props;
   if (Array.isArray(children)) {
     if (children.length > 1) {
-      throw Error(`[GridLayoutItem] cannot have more than one child element`);
+      throw Error("[GridLayoutItem] cannot have more than one child element");
     }
     // Only happens when reconstitured from JSON
     [children] = children;

--- a/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayout.playwright.test.tsx
+++ b/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayout.playwright.test.tsx
@@ -1,7 +1,52 @@
 import { expect, test } from "../../../../../playwright/fixtures";
+import type { Locator } from "@playwright/test";
 import { GridLayoutDriver } from "./GridLayoutDriver";
 
 const fixture = "GridLayout/GridLayoutTestFixture/GridLayoutTestFixture";
+const observeTrustedNativeDrag = async (
+  component: Locator,
+  target: Locator,
+  affordance: string,
+) => {
+  await target.evaluate((element, affordanceClass) => {
+    element.setAttribute("data-native-drop-observer", affordanceClass);
+  }, affordance);
+  await component.evaluate(
+    (root, { affordanceClass }) => {
+      root.addEventListener(
+        "dragstart",
+        (event) => {
+          root.setAttribute("data-native-dragstart", String(event.isTrusted));
+        },
+        true,
+      );
+      root.addEventListener(
+        "pointercancel",
+        (event) => {
+          root.setAttribute(
+            "data-native-pointercancel",
+            String(event.isTrusted),
+          );
+        },
+        true,
+      );
+      const targetElement = root.querySelector(
+        `[data-native-drop-observer="${affordanceClass}"]`,
+      );
+      if (!targetElement) {
+        throw Error("Native drop observer target not found");
+      }
+      const observer = new MutationObserver(() => {
+        if (targetElement.classList.contains(affordanceClass)) {
+          root.setAttribute("data-native-affordance", affordanceClass);
+          observer.disconnect();
+        }
+      });
+      observer.observe(targetElement, { attributeFilter: ["class"] });
+    },
+    { affordanceClass: affordance },
+  );
+};
 
 test.describe("GridLayout browser interactions", () => {
   test.describe.configure({ mode: "serial" });
@@ -50,6 +95,146 @@ test.describe("GridLayout browser interactions", () => {
       }
     });
   }
+
+  test("native existing-item drag shows an affordance and moves the item", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount("GridLayout/Showcase/MoveExistingItems");
+    await page.waitForTimeout(250);
+    const grid = new GridLayoutDriver(component, page);
+    const target = grid.content("move-target");
+    await observeTrustedNativeDrag(component, target, "vuuDropTarget-south");
+
+    await grid.nativeDrag(grid.header("move-source"), target, "south");
+
+    await expect(component).toHaveAttribute("data-native-dragstart", "true");
+    await expect(component).toHaveAttribute(
+      "data-native-pointercancel",
+      "true",
+    );
+    await expect(component).toHaveAttribute(
+      "data-native-affordance",
+      "vuuDropTarget-south",
+    );
+    const targetBox = await grid.item("move-target").boundingBox();
+    const sourceBox = await grid.item("move-source").boundingBox();
+    expect(sourceBox?.y).toBeGreaterThan(targetBox?.y ?? 0);
+    await expect(component.locator('[class*="vuuDropTarget-"]')).toHaveCount(0);
+    await expect(grid.item("move-source")).not.toHaveClass(
+      /vuuGridLayoutItem-dragging/,
+    );
+  });
+
+  test("native GridPalette swatch drag creates a south split", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount("GridLayout/Showcase/PaletteSplitAndReplace");
+    await page.waitForTimeout(250);
+    const grid = new GridLayoutDriver(component, page);
+    const source = component.locator('[data-item-id="coral"]');
+    const target = grid.content("palette-target");
+    await observeTrustedNativeDrag(component, target, "vuuDropTarget-south");
+
+    await grid.nativeDrag(source, target, "south");
+
+    await expect(component).toHaveAttribute("data-native-dragstart", "true");
+    await expect(component).toHaveAttribute(
+      "data-native-affordance",
+      "vuuDropTarget-south",
+    );
+    const templateItem = component
+      .getByText("Coral template")
+      .locator("xpath=ancestor::*[contains(@class, 'vuuGridLayoutItem')][1]");
+    await expect(templateItem).toBeVisible();
+    const targetBox = await grid.item("palette-target").boundingBox();
+    const templateBox = await templateItem.boundingBox();
+    expect(templateBox?.y).toBeGreaterThan(targetBox?.y ?? 0);
+    await expect(target).not.toHaveClass(/vuuDropTarget-/);
+    await expect(grid.layout("palette-replace")).not.toHaveClass(/vuuDragging/);
+  });
+
+  for (const direction of ["north", "east", "west"] as const) {
+    test(`native GridPalette swatch drag creates a ${direction} split`, async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(
+        "GridLayout/Showcase/PaletteSplitAndReplace",
+      );
+      await page.waitForTimeout(250);
+      const grid = new GridLayoutDriver(component, page);
+      const source = component.locator('[data-item-id="coral"]');
+      const target = grid.content("palette-target");
+
+      await grid.nativeDrag(source, target, direction);
+
+      const templateItem = component
+        .getByText("Coral template")
+        .locator("xpath=ancestor::*[contains(@class, 'vuuGridLayoutItem')][1]");
+      await expect(templateItem).toBeVisible();
+      const targetBox = await grid.item("palette-target").boundingBox();
+      const templateBox = await templateItem.boundingBox();
+      if (direction === "north") {
+        expect(templateBox?.y).toBeLessThan(targetBox?.y ?? 0);
+      } else if (direction === "east") {
+        expect(templateBox?.x).toBeGreaterThan(targetBox?.x ?? 0);
+      } else {
+        expect(templateBox?.x).toBeLessThan(targetBox?.x ?? 0);
+      }
+      await expect(component.locator('[class*="vuuDropTarget-"]')).toHaveCount(
+        0,
+      );
+    });
+  }
+
+  test("native GridPalette centre drop replaces existing content", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount("GridLayout/Showcase/PaletteSplitAndReplace");
+    await page.waitForTimeout(250);
+    const grid = new GridLayoutDriver(component, page);
+
+    await grid.nativeDrag(
+      component.locator('[data-item-id="coral"]'),
+      grid.content("palette-target"),
+      "centre",
+    );
+
+    await expect(grid.item("palette-target")).toHaveCount(0);
+    await expect(component.getByText("Coral template")).toBeVisible();
+    await expect(component.locator('[class*="vuuDropTarget-"]')).toHaveCount(0);
+  });
+
+  test("native GridPalette swatch drag onto a header creates a stack", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount("GridLayout/Showcase/PaletteSplitAndReplace");
+    await page.waitForTimeout(250);
+    const grid = new GridLayoutDriver(component, page);
+    const source = component.locator('[data-item-id="teal"]');
+    const target = grid
+      .item("palette-target")
+      .locator(".vuuGridLayoutItemHeader");
+    await observeTrustedNativeDrag(component, target, "vuuDropTarget-header");
+
+    await grid.nativeDrag(source, target, "header");
+
+    await expect(component).toHaveAttribute("data-native-dragstart", "true");
+    await expect(component).toHaveAttribute(
+      "data-native-affordance",
+      "vuuDropTarget-header",
+    );
+    await expect(
+      component.getByRole("tab", { name: "Drop target" }),
+    ).toBeVisible();
+    await expect(component.getByRole("tab", { name: "Teal" })).toBeVisible();
+    await expect(component.locator('[class*="vuuDropTarget-"]')).toHaveCount(0);
+    await expect(grid.layout("palette-replace")).not.toHaveClass(/vuuDragging/);
+  });
 
   test("centre drop replaces the target component", async ({ mount, page }) => {
     const component = await mount(fixture, { variant: "basic" });
@@ -137,6 +322,7 @@ test.describe("GridLayout browser interactions", () => {
     await draggableTab.dispatchEvent("dragstart", {
       dataTransfer: committedDataTransfer,
     });
+
     await page.clock.fastForward(100);
     await expect(draggableTab).toHaveClass(/vuuDraggableItem-hidden/);
 
@@ -150,6 +336,106 @@ test.describe("GridLayout browser interactions", () => {
 
     await component.getByRole("tab", { name: "Beta" }).click();
     await expect(component.getByTestId("content-beta")).toBeVisible();
+  });
+
+  test("native target transitions replace the affordance and Escape cancels", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(fixture, { variant: "basic" });
+    const grid = new GridLayoutDriver(component, page);
+    const sourceBox = await grid.header("beta").boundingBox();
+    const targetBox = await grid.content("alpha").boundingBox();
+    if (!sourceBox || !targetBox) {
+      throw Error("Native transition test requires visible source and target");
+    }
+    const sourceX = sourceBox.x + sourceBox.width / 2;
+    const sourceY = sourceBox.y + sourceBox.height / 2;
+
+    await page.mouse.move(sourceX, sourceY);
+    await page.mouse.down();
+    await page.mouse.move(sourceX + 10, sourceY, { steps: 5 });
+    await page.mouse.move(
+      targetBox.x + targetBox.width / 2,
+      targetBox.y + targetBox.height * 0.05,
+      { steps: 20 },
+    );
+    await expect(grid.content("alpha")).toHaveClass(/vuuDropTarget-north/);
+    await page.mouse.move(
+      targetBox.x + targetBox.width * 0.95,
+      targetBox.y + targetBox.height / 2,
+      { steps: 10 },
+    );
+    await expect(grid.content("alpha")).toHaveClass(/vuuDropTarget-east/);
+    await expect(grid.content("alpha")).not.toHaveClass(/vuuDropTarget-north/);
+
+    await page.keyboard.press("Escape");
+    await page.mouse.up();
+
+    expect(await grid.gridArea("alpha")).toBe("1/1/2/2");
+    expect(await grid.gridArea("beta")).toBe("1/2/2/3");
+    await expect(component.locator('[class*="vuuDropTarget-"]')).toHaveCount(0);
+  });
+
+  test("native outside drop ends without changing the layout", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(fixture, { variant: "basic" });
+    const grid = new GridLayoutDriver(component, page);
+    await component.evaluate((root) => {
+      root.addEventListener(
+        "dragend",
+        (event) => {
+          root.setAttribute("data-native-dragend", String(event.isTrusted));
+        },
+        true,
+      );
+      const outsideTarget = document.createElement("div");
+      outsideTarget.dataset.testid = "outside-drop-target";
+      outsideTarget.style.cssText =
+        "position:fixed;right:0;bottom:0;width:24px;height:24px;z-index:10000";
+      document.body.append(outsideTarget);
+    });
+
+    await grid.header("beta").dragTo(page.getByTestId("outside-drop-target"), {
+      targetPosition: { x: 12, y: 12 },
+    });
+
+    await expect(component).toHaveAttribute("data-native-dragend", "true");
+    expect(await grid.gridArea("alpha")).toBe("1/1/2/2");
+    expect(await grid.gridArea("beta")).toBe("1/2/2/3");
+    await expect(component.locator('[class*="vuuDropTarget-"]')).toHaveCount(0);
+    await expect(grid.item("beta")).not.toHaveClass(
+      /vuuGridLayoutItem-dragging/,
+    );
+    await page.getByTestId("outside-drop-target").evaluate((element) => {
+      element.remove();
+    });
+  });
+
+  test.fixme("native stack member drag creates a standalone cardinal split", async ({
+    mount,
+    page,
+  }) => {
+    // Tab detachment requires the delayed spacer gesture; dragTo intentionally
+    // starts immediately and does not keep the tab detached long enough.
+    const component = await mount(fixture, { variant: "stacked-target" });
+    const grid = new GridLayoutDriver(component, page);
+    const source = component
+      .getByRole("tab", { name: "Alpha" })
+      .locator(
+        "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' vuuDraggableItem ')][1]",
+      );
+
+    await grid.nativeDrag(source, grid.content("target"), "north");
+
+    await expect(component.getByRole("tab", { name: "Alpha" })).toHaveCount(0);
+    await expect(component.getByTestId("content-alpha")).toBeVisible();
+    const alpha = await grid.item("alpha").boundingBox();
+    const target = await grid.item("target").boundingBox();
+    expect(alpha?.y).toBeLessThan(target?.y ?? 0);
+    await expect(component.locator('[class*="vuuDropTarget-"]')).toHaveCount(0);
   });
 
   test("quick tab selection movements do not start or reorder a drag", async ({
@@ -293,7 +579,13 @@ test.describe("GridLayout browser interactions", () => {
     const component = await mount(fixture, { variant: "change-rerender" });
     const grid = new GridLayoutDriver(component, page);
 
-    await grid.dragItem("rerender-alpha", "rerender-beta", "north");
+    // This lower-level rerender check deliberately keeps synthetic delivery;
+    // native split/stack/resize coverage is exercised below.
+    await grid.syntheticDrag(
+      grid.header("rerender-alpha"),
+      grid.content("rerender-beta"),
+      "north",
+    );
     expect(await grid.gridArea("rerender-alpha")).toBe("1/1/2/2");
     expect(await grid.gridArea("rerender-beta")).toBe("2/1/3/2");
 
@@ -778,17 +1070,17 @@ test.describe("GridLayout browser interactions", () => {
   });
 
   test.fixme("palette template drop onto an empty placeholder", async () => {
-    // Native template drag currently depends on unstable placeholder drag-enter
-    // sequencing in Playwright CT.
-  });
-
-  test.fixme("palette template centre drop replaces existing content", async () => {
-    // The template path works in the showcase, but native DataTransfer delivery
-    // from the compact palette fixture is not deterministic in CT.
+    // Trusted dragTo reaches the placeholder affordance, but Chromium does not
+    // dispatch a stable drop for an all-placeholder target.
   });
 
   test.fixme("reorders tabs by dragging within a tabstrip", async () => {
     // Tab reordering uses delayed spacer animation that Playwright's dragTo
     // cannot currently drive deterministically.
+  });
+
+  test.fixme("dragging duplicate-title tabs preserves item identity", async () => {
+    // Duplicate labels are supported by item id, but native tab dragging still
+    // depends on the delayed spacer gesture described above.
   });
 });

--- a/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayoutDriver.ts
+++ b/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayoutDriver.ts
@@ -27,6 +27,10 @@ export class GridLayoutDriver {
     return this.root.locator(`[id=${JSON.stringify(id)}]`);
   }
 
+  layout(id: string) {
+    return this.root.locator(`.vuuGridLayout[id=${JSON.stringify(id)}]`);
+  }
+
   header(id: string) {
     return this.item(id).locator(".vuuGridLayoutItemHeader-title");
   }
@@ -62,126 +66,60 @@ export class GridLayoutDriver {
     await this.drag(this.header(id), this.content(targetId), zone);
   }
 
-  async drag(source: Locator, target: Locator, zone: DropZone) {
-    const dataTransfer = await this.page.evaluateHandle(
-      () => new DataTransfer(),
-    );
-    await source.dispatchEvent("dragstart", { dataTransfer });
-    await this.waitForClass(
-      source.locator(
-        "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' vuuGridLayoutItem ')][1]",
-      ),
-      "vuuGridLayoutItem-dragging",
-    );
-
-    const box = await target.boundingBox();
-    if (!box) {
-      throw Error("GridLayoutDriver target has no bounding box");
+  async nativeDrag(source: Locator, target: Locator, zone: DropZone) {
+    const targetBox = await target.boundingBox();
+    if (!targetBox) {
+      throw Error("GridLayoutDriver native drag requires visible elements");
     }
+    const expectedClassName = `vuuDropTarget-${zone}`;
+    await target.evaluate((element, className) => {
+      document.documentElement.removeAttribute("data-grid-affordance-seen");
+      const observer = new MutationObserver(() => {
+        if (element.classList.contains(className)) {
+          document.documentElement.setAttribute(
+            "data-grid-affordance-seen",
+            className,
+          );
+          observer.disconnect();
+        }
+      });
+      observer.observe(element, { attributeFilter: ["class"] });
+    }, expectedClassName);
     const position = targetPosition[zone];
-    const clientX = box.x + box.width * position.x;
-    const clientY = box.y + box.height * position.y;
-    const eventInit = { clientX, clientY, dataTransfer };
-
-    await target.dispatchEvent("dragenter", eventInit);
-    await this.observeDragOverDefault(target);
-    await target.dispatchEvent("dragover", eventInit);
-    await this.requirePreventedDragOver(target);
-    await this.waitForClass(target, `vuuDropTarget-${zone}`);
-    await target.dispatchEvent("drop", eventInit);
-    if ((await source.count()) > 0) {
-      await source.dispatchEvent("dragend", { dataTransfer });
+    const nestedDragHandle = source.locator('[draggable="true"]');
+    const dragHandle =
+      (await nestedDragHandle.count()) > 0 ? nestedDragHandle.first() : source;
+    await dragHandle.dragTo(target, {
+      targetPosition: {
+        x: targetBox.width * position.x,
+        y: targetBox.height * position.y,
+      },
+    });
+    const observedClassName = await this.page
+      .locator("html")
+      .getAttribute("data-grid-affordance-seen");
+    if (observedClassName !== expectedClassName) {
+      throw Error(
+        `GridLayoutDriver expected native ${expectedClassName} affordance, received ${observedClassName}`,
+      );
     }
-    await dataTransfer.dispose();
+  }
+
+  async drag(source: Locator, target: Locator, zone: DropZone) {
+    await this.nativeDrag(source, target, zone);
   }
 
   async dragTemplate(source: Locator, target: Locator, zone: DropZone) {
-    const sourceGrid = source.locator(
-      "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' vuuGridLayout ')][1]",
-    );
-    const dataTransfer = await this.page.evaluateHandle(
-      () => new DataTransfer(),
-    );
-    await source.dispatchEvent("dragstart", { dataTransfer });
-    await this.waitForClass(sourceGrid, "vuuDragging");
-
-    const position = targetPosition[zone];
-    const { clientX, clientY } = await target.evaluate((element, { x, y }) => {
-      const box = element.getBoundingClientRect();
-      return {
-        clientX: box.x + box.width * x,
-        clientY: box.y + box.height * y,
-      };
-    }, position);
-    const eventInit = { clientX, clientY, dataTransfer };
-    await target.dispatchEvent("dragenter", eventInit);
-    await this.observeDragOverDefault(target);
-    await target.dispatchEvent("dragover", eventInit);
-    await this.requirePreventedDragOver(target);
-    await target.dispatchEvent("dragover", eventInit);
-    const dropTargetClass = await target.evaluate((element) =>
-      [...element.classList].find((className) =>
-        className.startsWith("vuuDropTarget-"),
-      ),
-    );
-    if (dropTargetClass !== `vuuDropTarget-${zone}`) {
-      const rect = await target.evaluate((element) => {
-        const { bottom, left, right, top } = element.getBoundingClientRect();
-        return { bottom, left, right, top };
-      });
-      throw Error(
-        `GridLayoutDriver expected vuuDropTarget-${zone}, received ${dropTargetClass}; pointer ${clientX},${clientY}; rect ${JSON.stringify(rect)}`,
-      );
-    }
-    await target.dispatchEvent("drop", eventInit);
-    await source.dispatchEvent("dragend", { dataTransfer });
-    await this.waitForClassRemoval(sourceGrid, "vuuDragging");
-    if ((await target.count()) > 0) {
-      await this.waitForClassPrefixRemoval(target, "vuuDropTarget-");
-    }
-    await dataTransfer.dispose();
+    await this.nativeDrag(source, target, zone);
   }
 
-  async dragTemplateToTabs(source: Locator, tabList: Locator) {
-    const sourceGrid = source.locator(
-      "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' vuuGridLayout ')][1]",
-    );
+  async syntheticDrag(source: Locator, target: Locator, zone: DropZone) {
     const dataTransfer = await this.page.evaluateHandle(
       () => new DataTransfer(),
     );
-    await source.dispatchEvent("dragstart", { dataTransfer });
-    await this.waitForClass(sourceGrid, "vuuDragging");
-    const { clientX, clientY } = await tabList.evaluate((element) => {
-      const box = element.getBoundingClientRect();
-      return {
-        clientX: box.right - 2,
-        clientY: box.y + box.height / 2,
-      };
-    });
-    const eventInit = { clientX, clientY, dataTransfer };
-    await tabList.dispatchEvent("dragenter", eventInit);
-    await tabList.dispatchEvent("dragover", eventInit);
-    await tabList.dispatchEvent("drop", eventInit);
-    await source.dispatchEvent("dragend", { dataTransfer });
-    await this.waitForClassRemoval(sourceGrid, "vuuDragging");
-    await dataTransfer.dispose();
-  }
-
-  async attemptRejectedDrag(source: Locator, target: Locator, zone: DropZone) {
-    const dataTransfer = await this.page.evaluateHandle(
-      () => new DataTransfer(),
-    );
-    await source.dispatchEvent("dragstart", { dataTransfer });
-    await this.waitForClass(
-      source.locator(
-        "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' vuuGridLayoutItem ')][1]",
-      ),
-      "vuuGridLayoutItem-dragging",
-    );
-
     const box = await target.boundingBox();
     if (!box) {
-      throw Error("GridLayoutDriver target has no bounding box");
+      throw Error("GridLayoutDriver synthetic target has no bounding box");
     }
     const position = targetPosition[zone];
     const eventInit = {
@@ -189,118 +127,60 @@ export class GridLayoutDriver {
       clientY: box.y + box.height * position.y,
       dataTransfer,
     };
+    await source.dispatchEvent("dragstart", { dataTransfer });
     await target.dispatchEvent("dragenter", eventInit);
-    await this.observeDragOverDefault(target);
     await target.dispatchEvent("dragover", eventInit);
-    const defaultPrevented = await this.readPreventedDragOver(target);
-    const accepted = await target.evaluate((element) =>
-      [...element.classList].some((className) =>
-        className.startsWith("vuuDropTarget-"),
-      ),
-    );
     await target.dispatchEvent("drop", eventInit);
-    await source.dispatchEvent("dragend", { dataTransfer });
+    if ((await source.count()) > 0) {
+      await source.dispatchEvent("dragend", { dataTransfer });
+    }
     await dataTransfer.dispose();
-    if (defaultPrevented) {
-      throw Error("GridLayoutDriver invalid dragover enabled drop");
-    }
-    return accepted;
   }
 
-  private async observeDragOverDefault(target: Locator) {
+  async dragTemplateToTabs(source: Locator, tabList: Locator) {
+    const box = await tabList.boundingBox();
+    if (!box) {
+      throw Error("GridLayoutDriver tab list has no bounding box");
+    }
+    await source.dragTo(tabList, {
+      targetPosition: { x: box.width - 2, y: box.height / 2 },
+    });
+  }
+
+  async attemptRejectedDrag(source: Locator, target: Locator, zone: DropZone) {
+    const box = await target.boundingBox();
+    if (!box) {
+      throw Error("GridLayoutDriver target has no bounding box");
+    }
+    const position = targetPosition[zone];
     await target.evaluate((element) => {
-      window.addEventListener(
-        "dragover",
-        (event) => {
-          if (event.target === element) {
-            element.setAttribute(
-              "data-dragover-default-prevented",
-              String(event.defaultPrevented),
-            );
-          }
-        },
-        { once: true },
-      );
+      document.documentElement.removeAttribute("data-grid-affordance-seen");
+      const observer = new MutationObserver(() => {
+        if (
+          [...element.classList].some((className) =>
+            className.startsWith("vuuDropTarget-"),
+          )
+        ) {
+          document.documentElement.setAttribute(
+            "data-grid-affordance-seen",
+            "true",
+          );
+          observer.disconnect();
+        }
+      });
+      observer.observe(element, { attributeFilter: ["class"] });
     });
-  }
-
-  private async readPreventedDragOver(target: Locator) {
-    return target.evaluate((element) => {
-      const prevented =
-        element.getAttribute("data-dragover-default-prevented") === "true";
-      element.removeAttribute("data-dragover-default-prevented");
-      return prevented;
+    await source.dragTo(target, {
+      targetPosition: {
+        x: box.width * position.x,
+        y: box.height * position.y,
+      },
     });
-  }
-
-  private async requirePreventedDragOver(target: Locator) {
-    if (!(await this.readPreventedDragOver(target))) {
-      throw Error("GridLayoutDriver valid dragover did not enable drop");
-    }
-  }
-
-  private async waitForClass(locator: Locator, className: string) {
-    await locator.evaluate((element, expectedClassName) => {
-      if (element.classList.contains(expectedClassName)) {
-        return;
-      }
-      return new Promise<void>((resolve) => {
-        const observer = new MutationObserver(() => {
-          if (element.classList.contains(expectedClassName)) {
-            observer.disconnect();
-            resolve();
-          }
-        });
-        observer.observe(element, {
-          attributeFilter: ["class"],
-          attributes: true,
-        });
-      });
-    }, className);
-  }
-
-  private async waitForClassRemoval(locator: Locator, className: string) {
-    await locator.evaluate((element, removedClassName) => {
-      if (!element.classList.contains(removedClassName)) {
-        return;
-      }
-      return new Promise<void>((resolve) => {
-        const observer = new MutationObserver(() => {
-          if (!element.classList.contains(removedClassName)) {
-            observer.disconnect();
-            resolve();
-          }
-        });
-        observer.observe(element, {
-          attributeFilter: ["class"],
-          attributes: true,
-        });
-      });
-    }, className);
-  }
-
-  private async waitForClassPrefixRemoval(locator: Locator, prefix: string) {
-    await locator.evaluate((element, removedPrefix) => {
-      const hasClass = () =>
-        [...element.classList].some((className) =>
-          className.startsWith(removedPrefix),
-        );
-      if (!hasClass()) {
-        return;
-      }
-      return new Promise<void>((resolve) => {
-        const observer = new MutationObserver(() => {
-          if (!hasClass()) {
-            observer.disconnect();
-            resolve();
-          }
-        });
-        observer.observe(element, {
-          attributeFilter: ["class"],
-          attributes: true,
-        });
-      });
-    }, prefix);
+    return (
+      (await this.page
+        .locator("html")
+        .getAttribute("data-grid-affordance-seen")) === "true"
+    );
   }
 
   async resize(separator: Locator, deltaX: number, deltaY = 0) {

--- a/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayoutTestFixture.tsx
+++ b/vuu-ui/packages/grid-layout/src/__tests__/__component__/GridLayoutTestFixture.tsx
@@ -75,20 +75,19 @@ const TemplatePalette = () => {
   const draggable = useDraggable({ getDragSource, onDragStart });
 
   return (
-    <>
+    <div data-testid="template-palette" {...draggable}>
       {["Template A", "Template B"].map((label, index) => (
-        <button
+        <div
           data-label={label}
           data-testid={`palette-item-${index + 1}`}
-          draggable
           key={label}
-          type="button"
-          {...draggable}
         >
-          {label}
-        </button>
+          <button draggable type="button">
+            {label}
+          </button>
+        </div>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/vuu-ui/packages/grid-layout/src/drag-drop-next/DragDropProviderNext.tsx
+++ b/vuu-ui/packages/grid-layout/src/drag-drop-next/DragDropProviderNext.tsx
@@ -98,6 +98,11 @@ export const DragDropProviderNext = ({
         cancelActiveDrag();
       }
     };
+    const handlePointerCancel = () => {
+      if (!dragContext.ownsDrag) {
+        cancelActiveDrag();
+      }
+    };
     const handleCancelTabDrag: DragContextCancelTabDragHandler = (event) =>
       handlersRef.current.onCancelTabDrag(event);
     const handleDetachTab: DragContextDetachTabHandler = (event) =>
@@ -109,7 +114,7 @@ export const DragDropProviderNext = ({
     dragContext.on("drop", handleDrop);
     targetWindow.addEventListener("keydown", handleKeyDown);
     targetWindow.addEventListener("dragend", cancelActiveDrag);
-    targetWindow.addEventListener("pointercancel", cancelActiveDrag);
+    targetWindow.addEventListener("pointercancel", handlePointerCancel);
 
     const cleanupCallbacks: Array<() => void> = [];
     // console.log(
@@ -134,7 +139,7 @@ export const DragDropProviderNext = ({
       dragContext.removeListener("drop", handleDrop);
       targetWindow.removeEventListener("keydown", handleKeyDown);
       targetWindow.removeEventListener("dragend", cancelActiveDrag);
-      targetWindow.removeEventListener("pointercancel", cancelActiveDrag);
+      targetWindow.removeEventListener("pointercancel", handlePointerCancel);
       cancelActiveDrag();
       cleanupCallbacks.forEach((cleanup) => {
         cleanup();

--- a/vuu-ui/packages/grid-layout/src/useAsDropTarget.ts
+++ b/vuu-ui/packages/grid-layout/src/useAsDropTarget.ts
@@ -147,6 +147,20 @@ const createDropTargetState = (): DropTargetState => ({
   dropTarget: undefined,
 });
 
+const createActiveDropTargetState = (
+  dropTarget: DropTarget,
+): DropTargetState => {
+  const { bottom, left, right, top } =
+    dropTarget.target.getBoundingClientRect();
+  return {
+    accepted: false,
+    dropTarget,
+    mousePos: { clientX: -1, clientY: -1 },
+    position: undefined,
+    rect: { bottom, left, right, top },
+  };
+};
+
 export const useAsDropTarget = () => {
   const dropTargetStateRef = useRef<DropTargetState>(createDropTargetState());
 
@@ -182,30 +196,26 @@ export const useAsDropTarget = () => {
 
       if (dropTarget !== currentDropTarget) {
         if (dropTarget) {
+          if (currentDropTarget) {
+            removeDropTargetPositionClassName(currentDropTarget.target);
+            leave();
+          }
           // console.log(
           //   `%c[useAsDropTarget] onDragEnter set current dropTarget = ${dropTarget.gridLayoutItemId}`,
           //   "color:green;font-weight:bold;",
           // );
 
-          dropTargetStateRef.current.dropTarget = dropTarget;
-          dropTargetStateRef.current.accepted = false;
-          const { rect } = dropTargetStateRef.current;
-          const { bottom, left, right, top } =
-            dropTarget.target.getBoundingClientRect();
-          rect.bottom = bottom;
-          rect.left = left;
-          rect.right = right;
-          rect.top = top;
+          dropTargetStateRef.current = createActiveDropTargetState(dropTarget);
         } else if (currentDropTarget) {
           dropTargetStateRef.current.dropTarget = undefined;
           dropTargetStateRef.current.accepted = false;
           dropTargetStateRef.current.position = undefined;
+          removeDropTargetPositionClassName(currentDropTarget.target);
           leave();
           // console.log(
           //   `%c[useAsDropTarget] clear droptarget ${currentDropTarget?.gridLayoutItemId}`,
           //   "color:brown;font-weight: bold;",
           // );
-          removeDropTargetPositionClassName(currentDropTarget?.target);
         }
       }
     },
@@ -218,14 +228,25 @@ export const useAsDropTarget = () => {
       if (dragContext.dragSource === undefined) {
         return;
       }
-      const { dropTarget: currentDropTarget } = dropTargetStateRef.current;
+      let { dropTarget: currentDropTarget } = dropTargetStateRef.current;
       const dropTarget = getDropTarget(evt.target, currentDropTarget, layoutId);
       if (dropTarget) {
+        if (dropTarget !== currentDropTarget) {
+          if (currentDropTarget) {
+            removeDropTargetPositionClassName(currentDropTarget.target);
+            leave();
+          }
+          dropTargetStateRef.current = createActiveDropTargetState(dropTarget);
+          currentDropTarget = dropTarget;
+        }
         // TODO store dropTarget and rect and tabRect in same ref
         if (dropTarget === currentDropTarget) {
           const { position: lastPosition } = dropTargetStateRef.current;
           if (dropTarget.type === "header") {
-            if (lastPosition !== "header") {
+            if (
+              lastPosition !== "header" ||
+              !dropTarget.target.classList.contains("vuuDropTarget-header")
+            ) {
               const accepted = preview(
                 dropTarget.gridLayoutItemId,
                 dragContext.dragSource,
@@ -259,7 +280,12 @@ export const useAsDropTarget = () => {
               // console.log(
               //   `[useAsDropTarget] onDragOver ${dropTarget.gridLayoutItemId} position ${position}`,
               // );
-              if (position !== lastPosition) {
+              if (
+                position !== lastPosition ||
+                !dropTarget.target.classList.contains(
+                  `${DROPTARGET_CLASSNAME}-${position}`,
+                )
+              ) {
                 const accepted = preview(
                   dropTarget.gridLayoutItemId,
                   dragContext.dragSource,
@@ -277,12 +303,13 @@ export const useAsDropTarget = () => {
           }
           if (dropTargetStateRef.current.accepted) {
             // A dragover must be cancelled for the browser to dispatch drop.
+            evt.dataTransfer.dropEffect = "move";
             evt.preventDefault();
           }
         }
       }
     },
-    [dragContext, layoutId, preview],
+    [dragContext, layoutId, leave, preview],
   );
 
   const onDragLeave = useCallback<DragEventHandler>(

--- a/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
+++ b/vuu-ui/packages/grid-layout/src/useGridLayout.tsx
@@ -289,15 +289,8 @@ export const useGridLayout = ({
       }
     | undefined
   >(undefined);
-  const [dragSourceItemId, setDragSourceItemId] = useState<string>();
-  const dragAppearanceFrameRef = useRef<number | undefined>(undefined);
   const clearDragAppearance = useCallback(() => {
-    if (dragAppearanceFrameRef.current !== undefined) {
-      cancelAnimationFrame(dragAppearanceFrameRef.current);
-      dragAppearanceFrameRef.current = undefined;
-    }
     containerRef.current?.classList.remove("vuuDragging");
-    setDragSourceItemId(undefined);
   }, []);
   useEffect(
     () => () => {
@@ -347,25 +340,15 @@ export const useGridLayout = ({
 
   const handleDragStart = useCallback<GridLayoutDragStartHandler>(
     (_evt, options) => {
-      const { current: grid } = containerRef;
-      if (grid) {
-        if (options.type === "text/plain") {
-          const result = dragCoordinator.begin({
-            itemId: options.id,
-            kind: "existing-item",
-            sourceGridId: id,
-          });
-          if (!result.ok) {
-            throw Error(result.error.message);
-          }
-        }
-        dragAppearanceFrameRef.current = requestAnimationFrame(() => {
-          dragAppearanceFrameRef.current = undefined;
-          grid.classList.add("vuuDragging");
-          if (options.type === "text/plain") {
-            setDragSourceItemId(options.id);
-          }
+      if (options.type === "text/plain") {
+        const result = dragCoordinator.begin({
+          itemId: options.id,
+          kind: "existing-item",
+          sourceGridId: id,
         });
+        if (!result.ok) {
+          throw Error(result.error.message);
+        }
       }
     },
     [dragCoordinator, id],
@@ -950,7 +933,6 @@ export const useGridLayout = ({
     containerCallback,
     containerRef,
     dispatchGridLayoutAction,
-    dragSourceItemId,
     gridController,
     gridLayoutModel,
     gridModel,

--- a/vuu-ui/packages/grid-layout/test/GridLayout.drag-drop.react.test.tsx
+++ b/vuu-ui/packages/grid-layout/test/GridLayout.drag-drop.react.test.tsx
@@ -276,7 +276,7 @@ describe("GridLayout React drag/drop lifecycle", () => {
       container
         .querySelector("#source")
         ?.classList.contains("vuuGridLayoutItem-dragging"),
-    ).toBe(true);
+    ).toBe(false);
     dispatchDrag(target, "dragenter", dataTransfer, {
       clientX: 90,
       clientY: 50,
@@ -428,10 +428,7 @@ describe("GridLayout React drag/drop lifecycle", () => {
     dispatchDrag(source, "dragend", dataTransfer);
   });
 
-  it.each([
-    "Escape",
-    "pointercancel",
-  ] as const)("rolls back the preview and clears affordances on %s", (cancellation) => {
+  it("rolls back the preview and clears affordances on Escape", () => {
     act(() => root.render(<ExistingItemFixture />));
     const source = container.querySelector(
       "#source .vuuGridLayoutItemHeader-title",
@@ -451,11 +448,7 @@ describe("GridLayout React drag/drop lifecycle", () => {
     expect(target.classList.contains("vuuDropTarget-east")).toBe(true);
 
     act(() => {
-      if (cancellation === "Escape") {
-        window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-      } else {
-        window.dispatchEvent(new Event("pointercancel"));
-      }
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     });
 
     expect(target.classList.contains("vuuDropTarget-east")).toBe(false);
@@ -467,6 +460,31 @@ describe("GridLayout React drag/drop lifecycle", () => {
     expect(container.querySelector("#source")?.getAttribute("style")).toContain(
       "grid-area: 1/1/2/2",
     );
+  });
+
+  it("keeps an owned HTML drag active through pointercancel", () => {
+    act(() => root.render(<ExistingItemFixture />));
+    const source = container.querySelector(
+      "#source .vuuGridLayoutItemHeader-title",
+    );
+    const target = container.querySelector("#target .vuuGridLayoutItemContent");
+    if (!source || !target) {
+      throw Error("pointercancel drag fixture did not render");
+    }
+    setTargetRect(target);
+    const dataTransfer = new TestDataTransfer();
+    const point = { clientX: 90, clientY: 50 };
+
+    dispatchDrag(source, "dragstart", dataTransfer);
+    dispatchDrag(target, "dragenter", dataTransfer, point);
+    dispatchDrag(target, "dragover", dataTransfer, point);
+    act(() => {
+      window.dispatchEvent(new Event("pointercancel"));
+    });
+
+    expect(target.classList.contains("vuuDropTarget-east")).toBe(true);
+    dispatchDrag(source, "dragend", dataTransfer);
+    expect(target.classList.contains("vuuDropTarget-east")).toBe(false);
   });
 
   it("does not restore drag styling when cancelled before the next frame", () => {

--- a/vuu-ui/playwright/gallery/main-grid-layout.tsx
+++ b/vuu-ui/playwright/gallery/main-grid-layout.tsx
@@ -2,9 +2,16 @@ import { createElement } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import { GridLayoutTestFixture } from "../../packages/grid-layout/src/__tests__/__component__/GridLayoutTestFixture";
+import {
+  MoveExistingItems,
+  PaletteSplitAndReplace,
+} from "../../showcase/src/examples/GridLayout/GridLayoutScenarios.examples";
+import gridLayoutScenariosCss from "../../showcase/src/examples/GridLayout/GridLayoutScenarios.examples.css";
+import gridPaletteCss from "../../showcase/src/examples/html/components/GridPalette.css";
 
 type MountParams = {
   props?: Parameters<typeof GridLayoutTestFixture>[0];
+  story: string;
 };
 
 declare global {
@@ -20,15 +27,25 @@ if (!rootElement) {
   throw new Error("The GridLayout component gallery requires a #root element");
 }
 
+const showcaseStyle = document.createElement("style");
+showcaseStyle.textContent = `${gridLayoutScenariosCss}\n${gridPaletteCss}`;
+document.head.append(showcaseStyle);
+
 let root: Root | undefined;
 
-window.mount = async ({ props }: MountParams) => {
-  if (!props) {
+window.mount = async ({ props, story }: MountParams) => {
+  const Component =
+    story === "GridLayout/Showcase/MoveExistingItems"
+      ? MoveExistingItems
+      : story === "GridLayout/Showcase/PaletteSplitAndReplace"
+        ? PaletteSplitAndReplace
+        : GridLayoutTestFixture;
+  if (Component === GridLayoutTestFixture && !props) {
     throw new Error("GridLayout fixture props are required");
   }
   root ??= createRoot(rootElement);
   flushSync(() => {
-    root?.render(createElement(GridLayoutTestFixture, props));
+    root?.render(createElement(Component, props));
   });
 };
 


### PR DESCRIPTION
## Summary

Restores native Chromium drag/drop for GridLayout existing items and palette templates while preserving the typed `GridDragCoordinator`/controller transaction path.

## Root cause

PR #2383's synthetic tests passed because `dispatchEvent` never reproduces Chromium's native pointer handoff. A trusted HTML5 drag emits `pointercancel` immediately after `dragstart`; #2383 treated that event as an unconditional cancellation and cleared `DragContext` before the first real `dragover`. Its source-state styling also applied `display: none` to the native source, which is unsafe during browser-owned DnD. Finally, target handling assumed an ideal `dragenter` sequence and could retain stale target position state across real descendant transitions.

On the merged #2383 base, the new trusted test observed `dragstart.isTrusted === true` and native `pointercancel`, then failed because no `vuuDropTarget-*` affordance appeared and no drop was committed. The old synthetic tests still passed.

## Fix

- Preserve an owned native HTML drag through Chromium's expected startup `pointercancel`; cancellation still occurs for an unowned pointer cancellation, Escape, outside dragend, and provider cleanup.
- Remove React-driven `display: none` source hiding and obsolete blanket hit-test styling.
- Make `dragover` authoritative: recover or switch the current target, reset stale position/mouse state, clear the previous preview, recompute bounds, and only call `preventDefault`/set `dropEffect` after the typed coordinator accepts the plan.
- Mount the real Showcase `MoveExistingItems` and `PaletteSplitAndReplace` compositions in the focused browser gallery, including their actual CSS and GridPalette wrapper/nested-swatch DOM contract.
- Convert primary GridLayout browser drag helpers to trusted `Locator.dragTo` interactions. Plain `page.mouse` reliably generated trusted startup/affordance events but did not consistently produce Chromium `drop`; `dragTo` produces trusted native events and stable drops without `dispatchEvent`.

## Native interaction matrix

Covered with visible-affordance, canonical/rendered result, and cleanup assertions:

- existing item: north/south/east/west, centre replacement, header stack creation
- real GridPalette: north/south/east/west, centre replacement, header stack creation
- palette template: nested content, existing/nested tabstrip insertion, deepest visible nested layout routing
- nested grids: cross-scope existing-item rejection and within-child movement
- invalid non-resizable target rejection
- target-zone transitions and Escape rollback
- outside drop/dragend cleanup
- split, then stack, then splitter resize

Explicit native `fixme`s remain:

- empty placeholder: Chromium exposes the affordance but `dragTo` does not generate a stable drop on the all-placeholder target
- tab reorder: the delayed spacer gesture is not deterministic with `dragTo`
- stack member to standalone/cardinal: requires the same delayed tab-detachment gesture
- duplicate-title tab drag identity: blocked by delayed native tab dragging, while identity remains item-id based

## Verification

- Trusted native matrix: **69/69 passed** (`23 cases × 3 repeats`), no flakes
- Complete GridLayout Vitest: **270 passed, 2 todo**
- GridLayout package build: passed
- Biome on all changed files: passed
- Actual Showcase gallery exercise:
  1. `MoveExistingItems`: dragged the existing source header onto the target south zone; the south affordance appeared before release, the source moved below the target, and styling cleared.
  2. `PaletteSplitAndReplace`: dragged the nested Coral swatch to the target south zone, then exercised the Teal swatch on the target header; the split and tab stack rendered and affordances cleared.

The complete browser file still contains an unrelated existing tab-UI failure waiting for `Gamma Settings`; the native drag matrix is isolated from it. Repository-wide type declaration generation also has pre-existing errors in `vuu-data-react`/`vuu-utils`; the changed GridLayout package builds cleanly.

## Persistence follow-up

PR #2384 is based on the old #2383 head and will need to rebase onto this corrective commit. This PR does not modify persistence work.
