### PR TITLE
feat(vuu-table-extras): options-based CSV export API, useCsvExport hook, upload guards

### DIFF
--- a/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
+++ b/vuu-ui/packages/vuu-data-remote/src/VuuDataSource.ts
@@ -110,6 +110,7 @@ export class VuuDataSource extends BaseDataSource implements DataSourceBase {
   #status: DataSourceStatus = "initialising";
   #tableSchema: TableSchema | undefined;
 
+  public readonly isRemote = true;
   public table: VuuTable;
 
   constructor({

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -703,6 +703,7 @@ export interface DataSourceBase<
   freezeTimestamp?: number | undefined;
   select?: (selectRequest: Omit<SelectRequest, "vpId">) => void;
 
+  isRemote?: boolean;
   status: DataSourceStatus;
   /**
    *

--- a/vuu-ui/packages/vuu-table-extras/README.md
+++ b/vuu-ui/packages/vuu-table-extras/README.md
@@ -1,0 +1,32 @@
+# @vuu-ui/vuu-table-extras
+
+Extended components and utilities for Vuu tables, including CSV export, CSV upload and validation, column settings, column pickers, custom cell renderers, and table footer controls.
+
+---
+
+## Features
+
+### [CSV Export](./src/csv-export/README.md)
+Standalone utilities and a React hook for exporting table data and template schemas to CSV:
+- `exportToCsv(dataSource, options)`: Subscribes to a session table, collects rows in memory in index order, formats values, and triggers browser downloads.
+- `exportCsvTemplate(dataSource, options)`: Generates a header-only CSV template for import workflows.
+- `useCsvExport(dataSource)`: React hook with built-in `isExporting` state, error handling, and helper methods.
+
+### [CSV Upload](./src/csv-upload/README.md)
+Dialog and hook workflow for importing CSV data into Vuu tables via server-side session tables:
+- `CsvUpload`: Complete dialog component with file drag-and-drop, client-side validation, error summaries, and staging controls.
+- `useCsvUpload`: Headless hook managing file parsing, schema validation, session table staging, and RPC row batching.
+- `DataUploadPreview`: Inline editable table preview for inspecting and correcting invalid staged rows before commit.
+
+### Column Management
+- `ColumnMenu` & `useColumnActions`: Context menus for sorting, grouping, filtering, and column configuration.
+- `ColumnPicker` & `useTableColumnPicker`: Dialog and drawer controls for selecting and reordering visible columns.
+- `CalculatedColumnPanel`: UI panel for defining custom expression-based columns.
+
+### Cell Renderers & Formatters
+- Pre-built cell renderers including `BackgroundCell`, `DropdownCell`, `IconButtonCell`, and undo support.
+- Cell edit validators for ensuring valid data entry.
+
+### Table Footer & Status Controls
+- `TableFooter` & `TableFooterTray`: Status bar and pagination trays.
+- `DataSourceStats`: Live indicators for row count, connection state, freeze status, and filter metrics.

--- a/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-export/CsvExport.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/__tests__/__component__/csv-export/CsvExport.playwright.test.tsx
@@ -242,3 +242,48 @@ test.describe("exportCsvTemplate and exportToCsv with overrides", () => {
   });
 });
 
+test.describe("useCsvExport hook", () => {
+  test("WHEN export is triggered via useCsvExport THEN file downloads and status updates", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithHook");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Export All (useCsvExport)" }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("instruments-hook-export.csv");
+    await expect(
+      page.locator("span", { hasText: "Download started" }),
+    ).toBeVisible({ timeout: 5000 });
+
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+    expect(lines.length).toBeGreaterThan(1);
+  });
+
+  test("WHEN template export is triggered via useCsvExport THEN template downloads", async ({
+    mount,
+    page,
+  }) => {
+    await mount("TableExtras/CsvExport/CsvExportWithHook");
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator("button", { hasText: "Download Template" }).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toBe("instruments-hook-template.csv");
+    const filePath = await download.path();
+    if (!filePath) throw new Error("download path not available");
+    const content = fs.readFileSync(filePath, "utf-8");
+    const lines = content.split("\r\n").filter(Boolean);
+    expect(lines).toHaveLength(1);
+  });
+});
+
+

--- a/vuu-ui/packages/vuu-table-extras/src/csv-export/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-export/README.md
@@ -1,25 +1,53 @@
 # CSV Export
 
-CSV export is a set of standalone utility functions — `exportToCsv`, `exportCsvTemplate`, and `exportSessionTableToCsv` — implemented in [export-utils.ts](./export-utils.ts) and exported from `@vuu-ui/vuu-table-extras`. There is no React component: call them directly from a button handler or menu action.
+CSV export provides standalone utility functions — `exportToCsv`, `exportCsvTemplate`, and `exportSessionTableToCsv` — as well as a React hook `useCsvExport` exported from `@vuu-ui/vuu-table-extras`.
 
 See [CsvUpload](../csv-upload/README.md) for the counterpart component that imports a CSV into a Vuu table.
 
 ---
 
-## Usage
+## Usage with React Hook (`useCsvExport`)
+
+```tsx
+import { useCsvExport } from "@vuu-ui/vuu-table-extras";
+import { Button } from "@salt-ds/core";
+
+const MyTable = () => {
+  const { isExporting, exportCsv, exportTemplate } = useCsvExport(dataSource);
+
+  return (
+    <div>
+      <Button
+        disabled={isExporting}
+        onClick={() => exportCsv({ filename: "instruments.csv" })}
+      >
+        {isExporting ? "Exporting..." : "Export to CSV"}
+      </Button>
+      <Button
+        disabled={isExporting}
+        onClick={() => exportTemplate({ filename: "template.csv" })}
+      >
+        Download Template
+      </Button>
+    </div>
+  );
+};
+```
+
+---
+
+## Usage with Standalone Functions
 
 ```tsx
 import { exportToCsv } from "@vuu-ui/vuu-table-extras";
 
 const handleExport = useCallback(async () => {
-  await exportToCsv(
-    dataSource,
-    "All",
-    "instruments.csv",
-    [],
-    (err) => setStatus(`Export failed: ${err.message}`),
-    () => setStatus("Download started"),
-  );
+  await exportToCsv(dataSource, {
+    filename: "instruments.csv",
+    copyOption: "All",
+    onSuccess: () => setStatus("Download started"),
+    onError: (err) => setStatus(`Export failed: ${err.message}`),
+  });
 }, [dataSource]);
 ```
 
@@ -28,7 +56,10 @@ const handleExport = useCallback(async () => {
 ```tsx
 import { exportCsvTemplate } from "@vuu-ui/vuu-table-extras";
 
-exportCsvTemplate(dataSource, "instruments-template.csv");
+await exportCsvTemplate(dataSource, {
+  filename: "instruments-template.csv",
+  columns: ["ric", "currency", "isin"],
+});
 ```
 
 ---
@@ -38,31 +69,23 @@ exportCsvTemplate(dataSource, "instruments-template.csv");
 ```ts
 exportToCsv<TName extends string = string>(
   dataSource: DataSource,
-  copyOption?: CopyOption,             // default "All"
-  filename?: string,                   // default "export.csv"
-  excludeColumns?: string[],
-  onError?: (error: Error) => void,
-  onSuccess?: () => void,
-  maxRows?: number,                    // default 10_000
-  columnDescriptors?: ExportColumnDescriptor<TName>[],
-  overrides?: SessionDataSourceOverrides,
+  options?: ExportToCsvOptions<TName>,
 ): Promise<void>
 ```
 
-Creates a session table via `dataSource.createSessionDataSource(copyOption, "export", overrides)`, subscribes to it, drains every row, then triggers a browser download. The session data source is unsubscribed automatically once the download completes or the export fails.
+Options (`ExportToCsvOptions`):
 
-| Param | Description |
-|---|---|
-| `dataSource` | The target `DataSource`. Must support `createSessionDataSource`, unless it is already a session table (see [Exporting an existing session table](#exporting-an-existing-session-table)). |
-| `copyOption` | `"All"` exports every row, `"Selected"` only the currently selected rows. |
-| `excludeColumns` | Additional columns to omit, on top of the always-excluded `vuuMsg`, `vuuAction`, `vuuRowNum`. |
-| `onError` | Called once with the failure reason. Never called and rejected simultaneously — the returned promise always resolves. |
-| `onSuccess` | Called once the download has been triggered (or once, with no download, if the table has zero rows). |
-| `maxRows` | Row limit for the whole table. If the server reports more rows than this, the export fails via `onError` before any data is requested. |
-| `columnDescriptors` | See [Column labels and formatters](#column-labels-and-formatters). Every `name` not present in the session table's columns (excluding the always-excluded set) fails the export via `onError`. |
-| `overrides` | See [Exporting a divergent export table](#exporting-a-divergent-export-table). |
-
-Rows are requested from the session data source in chunks of 1,000 rather than one bulk range request, so this behaves predictably across both local and remote data sources.
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `filename` | `string` | `"export.csv"` | Downloaded filename. |
+| `copyOption` | `CopyOption` | `"All"` | `"All"` exports every row, `"Selected"` only the currently selected rows. |
+| `excludeColumns` | `string[]` | `[]` | Additional columns to omit, on top of the always-excluded `vuuMsg`, `vuuAction`, `vuuRowNum`. |
+| `maxRows` | `number` | `10_000` | Row limit for the export. Fails if the server reports more rows than this before requesting data. |
+| `columnDescriptors` | `ExportColumnDescriptor<TName>[]` | `undefined` | Custom labels and cell formatters per column (see [Column labels and formatters](#column-labels-and-formatters)). |
+| `overrides` | `SessionDataSourceOverrides` | `undefined` | Divergent export table or column overrides. |
+| `timeout` | `number` | `30_000` | Milliseconds before the export times out (0 to disable). |
+| `onError` | `(error: Error) => void` | `undefined` | Callback invoked on error. |
+| `onSuccess` | `() => void` | `undefined` | Callback invoked once the download is triggered (including when table has 0 data rows, downloading a header-only file). |
 
 ---
 
@@ -71,16 +94,21 @@ Rows are requested from the session data source in chunks of 1,000 rather than o
 ```ts
 exportCsvTemplate(
   dataSource: DataSource,
-  filename?: string,                   // default "template.csv"
-  excludeColumns?: string[],
-  columns?: string[],
-  overrides?: SessionDataSourceOverrides,
+  options?: ExportCsvTemplateOptions,
 ): Promise<void>
 ```
 
-Downloads a single-row CSV containing only the column headers — no data rows, no server round trip for rows (it creates an `"Empty"` session table purely to discover columns). Pass `columns` to restrict the header to a specific subset and order; omit it to include every schema column except the always-excluded set.
+Options (`ExportCsvTemplateOptions`):
 
-If `dataSource.createSessionDataSource` fails or is unavailable, this falls back to `dataSource.tableSchema` to build the header. In that fallback path, `columns` (or `overrides.columns`) not present in the schema produce a console warning rather than a thrown error.
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `filename` | `string` | `"template.csv"` | Downloaded filename. |
+| `excludeColumns` | `string[]` | `[]` | Columns to omit from the template. |
+| `columns` | `string[]` | `undefined` | Specific subset and order of columns to include. |
+| `overrides` | `SessionDataSourceOverrides` | `undefined` | Divergent table schema overrides. |
+| `timeout` | `number` | `10_000` | Milliseconds before template creation times out (0 to disable). |
+| `onError` | `(error: Error) => void` | `undefined` | Callback invoked on error. |
+| `onSuccess` | `() => void` | `undefined` | Callback invoked once the template download is triggered. |
 
 ---
 
@@ -89,18 +117,11 @@ If `dataSource.createSessionDataSource` fails or is unavailable, this falls back
 ```ts
 exportSessionTableToCsv<TName extends string = string>(
   dataSource: DataSource,
-  filename?: string,
-  excludeColumns?: string[],
-  onError?: (error: Error) => void,
-  onSuccess?: () => void,
-  maxRows?: number,
-  columnDescriptors?: ExportColumnDescriptor<TName>[],
-  copyOption?: CopyOption,
-  overrides?: SessionDataSourceOverrides,
+  options?: ExportToCsvOptions<TName>,
 ): Promise<void>
 ```
 
-The lower-level function `exportToCsv` delegates to. Accepts either a view `DataSource` (in which case it creates the session table itself, exactly like `exportToCsv`) or an already-created session `DataSource` — see below.
+The lower-level function `exportToCsv` delegates to. Accepts either a view `DataSource` (in which case it creates the session table itself) or an already-created session `DataSource`.
 
 ### Exporting an existing session table
 
@@ -125,7 +146,10 @@ const descriptors: ExportColumnDescriptor[] = [
   { name: "lotSize", label: "Lot Size", exportFormatter: (v) => `${v} units` },
 ];
 
-await exportToCsv(dataSource, "All", "instruments.csv", [], onError, onSuccess, 10_000, descriptors);
+await exportToCsv(dataSource, {
+  filename: "instruments.csv",
+  columnDescriptors: descriptors,
+});
 ```
 
 `exportFormatter` is applied per-cell before CSV escaping. `label` overrides only the header row — the underlying column selection and order are unaffected. Omitting `columnDescriptors` exports every subscribed column (excluding the always-excluded set) using its raw column name as both header and value.

--- a/vuu-ui/packages/vuu-table-extras/src/csv-export/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-export/README.md
@@ -161,17 +161,10 @@ await exportToCsv(dataSource, {
 By default the session table is built from the target data source's config, so it carries the target table's columns. When exports should target a separate table with its own schema, pass `overrides`:
 
 ```ts
-await exportToCsv(
-  dataSource,
-  "All",
-  "instruments-overrides.csv",
-  [],
-  onError,
-  onSuccess,
-  10_000,
-  undefined,
-  { columns: ["ric", "currency", "lotSize"], table: EXPORT_TABLE },
-);
+await exportToCsv(dataSource, {
+  filename: "instruments-overrides.csv",
+  overrides: { columns: ["ric", "currency", "lotSize"], table: EXPORT_TABLE },
+});
 ```
 
 ```ts

--- a/vuu-ui/packages/vuu-table-extras/src/csv-export/export-utils.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-export/export-utils.ts
@@ -15,14 +15,40 @@ export type ExportColumnDescriptor<TName extends string = string> = {
   exportFormatter?: (value: unknown) => string;
 };
 
+export interface ExportToCsvOptions<TName extends string = string> {
+  filename?: string;
+  copyOption?: CopyOption;
+  excludeColumns?: string[];
+  maxRows?: number;
+  columnDescriptors?: ExportColumnDescriptor<TName>[];
+  overrides?: SessionDataSourceOverrides;
+  /** Timeout in milliseconds before the export times out. Default: 30_000ms (0 to disable). */
+  timeout?: number;
+  onError?: (error: Error) => void;
+  onSuccess?: () => void;
+}
+
+export interface ExportCsvTemplateOptions {
+  filename?: string;
+  excludeColumns?: string[];
+  columns?: string[];
+  overrides?: SessionDataSourceOverrides;
+  /** Timeout in milliseconds before template generation times out. Default: 10_000ms (0 to disable). */
+  timeout?: number;
+  onError?: (error: Error) => void;
+  onSuccess?: () => void;
+}
+
 const EXPORT_EXCLUDED_COLUMNS = new Set(["vuuMsg", "vuuAction", "vuuRowNum"]);
 const MAX_EXPORT_ROWS = 10_000;
 const CHUNK_SIZE = 1_000;
+const DEFAULT_EXPORT_TIMEOUT = 30_000;
+const DEFAULT_TEMPLATE_TIMEOUT = 10_000;
 
 const csvCell = (value: unknown): string => {
   const s = value == null ? "" : String(value);
-  return s.includes(",") || s.includes('"') || s.includes("\n")
-    ? `"${s.replace(/"/g, '""')}`
+  return s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")
+    ? `"${s.replace(/"/g, '""')}"`
     : s;
 };
 
@@ -43,15 +69,27 @@ const triggerCsvDownload = (csv: string, filename: string): void => {
 /** Downloads a single-row CSV containing only the column headers, for use as an import template. */
 export const exportCsvTemplate = async (
   dataSource: DataSource,
-  filename = "template.csv",
-  excludeColumns: string[] = [],
-  columns?: string[],
-  overrides?: SessionDataSourceOverrides,
+  options: ExportCsvTemplateOptions = {},
 ): Promise<void> => {
+  const {
+    filename = "template.csv",
+    excludeColumns = [],
+    columns,
+    overrides,
+    timeout = DEFAULT_TEMPLATE_TIMEOUT,
+    onError,
+    onSuccess,
+  } = options;
+
   const sessionOverrides: SessionDataSourceOverrides | undefined =
     overrides ?? (columns ? { columns } : undefined);
 
-  if (!isSessionTable(dataSource.table) && dataSource.createSessionDataSource) {
+  if (
+    !isSessionTable(dataSource.table) &&
+    dataSource.createSessionDataSource &&
+    dataSource.status !== "initialising" &&
+    dataSource.status !== "unsubscribed"
+  ) {
     try {
       const sessionDataSource = await dataSource.createSessionDataSource(
         "Empty",
@@ -59,11 +97,33 @@ export const exportCsvTemplate = async (
         sessionOverrides,
       );
       if (sessionDataSource) {
-        return new Promise<void>((resolve) => {
+        return new Promise<void>((resolve, reject) => {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          const cleanup = () => {
+            if (timer) clearTimeout(timer);
+            sessionDataSource.unsubscribe();
+          };
+
+          if (timeout > 0) {
+            timer = setTimeout(() => {
+              cleanup();
+              const err = new Error(
+                `exportCsvTemplate: timed out after ${timeout}ms waiting for subscription`,
+              );
+              if (onError) {
+                onError(err);
+                resolve();
+              } else {
+                reject(err);
+              }
+            }, timeout);
+          }
+
           const excluded = new Set([
             ...EXPORT_EXCLUDED_COLUMNS,
             ...excludeColumns,
           ]);
+
           sessionDataSource.subscribe(
             { range: Range(0, 0), columns: sessionOverrides?.columns },
             (message: DataSourceCallbackMessage) => {
@@ -75,7 +135,8 @@ export const exportCsvTemplate = async (
                 );
                 const header = exportCols.map(csvCell).join(",");
                 triggerCsvDownload(`${header}\r\n`, filename);
-                sessionDataSource.unsubscribe();
+                cleanup();
+                onSuccess?.();
                 resolve();
               }
             },
@@ -103,7 +164,14 @@ export const exportCsvTemplate = async (
       }
     }
   } else if (!schema) {
-    throw Error("exportCsvTemplate: tableSchema not available on dataSource");
+    const error = new Error(
+      "exportCsvTemplate: tableSchema not available on dataSource",
+    );
+    if (onError) {
+      onError(error);
+      return;
+    }
+    throw error;
   }
 
   const excluded = new Set([...EXPORT_EXCLUDED_COLUMNS, ...excludeColumns]);
@@ -114,30 +182,58 @@ export const exportCsvTemplate = async (
         .map((col) => col.name) ?? [];
 
   if (exportCols.length === 0) {
-    throw Error("exportCsvTemplate: no columns available for export");
+    const error = new Error(
+      "exportCsvTemplate: no columns available for export",
+    );
+    if (onError) {
+      onError(error);
+      return;
+    }
+    throw error;
   }
 
   const header = exportCols.map(csvCell).join(",");
   triggerCsvDownload(`${header}\r\n`, filename);
+  onSuccess?.();
 };
 
 /**
- * Subscribes to `dataSource` (creating an export session data source if a view data source is passed)
- * with a full-range request to drain all rows, serialises them to CSV (excluding internal session columns),
+ * Subscribes to `dataSource` (creating an export session data source if a view data source is passed),
+ * collects all rows in memory in index order, serialises them to CSV (excluding internal session columns),
  * then triggers a browser download. The session data source is unsubscribed automatically once the download
  * is initiated.
  */
 export const exportSessionTableToCsv = async <TName extends string = string>(
   dataSource: DataSource,
-  filename = "export.csv",
-  excludeColumns: string[] = [],
-  onError?: (error: Error) => void,
-  onSuccess?: () => void,
-  maxRows = MAX_EXPORT_ROWS,
-  columnDescriptors?: ExportColumnDescriptor<TName>[],
-  copyOption: CopyOption = "All",
-  overrides?: SessionDataSourceOverrides,
+  options: ExportToCsvOptions<TName> = {},
 ): Promise<void> => {
+  const {
+    filename = "export.csv",
+    copyOption = "All",
+    excludeColumns = [],
+    maxRows = MAX_EXPORT_ROWS,
+    columnDescriptors,
+    overrides,
+    timeout = DEFAULT_EXPORT_TIMEOUT,
+    onError,
+    onSuccess,
+  } = options;
+
+  if (
+    !isSessionTable(dataSource.table) &&
+    (dataSource.status === "initialising" ||
+      dataSource.status === "unsubscribed")
+  ) {
+    const error = new Error(
+      `exportSessionTableToCsv: dataSource must be subscribed before exporting (current status: "${dataSource.status}")`,
+    );
+    if (onError) {
+      onError(error);
+      return;
+    }
+    throw error;
+  }
+
   let sessionDataSource: DataSource | undefined;
   if (!isSessionTable(dataSource.table) && dataSource.createSessionDataSource) {
     try {
@@ -147,18 +243,26 @@ export const exportSessionTableToCsv = async <TName extends string = string>(
         overrides,
       );
     } catch (err) {
-      onError?.(err instanceof Error ? err : new Error(String(err)));
-      return;
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (onError) {
+        onError(error);
+        return;
+      }
+      throw error;
     }
   } else {
     sessionDataSource = dataSource;
   }
 
   if (!sessionDataSource) {
-    onError?.(
-      new Error("exportSessionTableToCsv: unable to obtain sessionDataSource"),
+    const error = new Error(
+      "exportSessionTableToCsv: unable to obtain sessionDataSource",
     );
-    return;
+    if (onError) {
+      onError(error);
+      return;
+    }
+    throw error;
   }
 
   const activeSessionDataSource = sessionDataSource;
@@ -167,9 +271,37 @@ export const exportSessionTableToCsv = async <TName extends string = string>(
   let colNameToRowIdx: Record<string, number> = {};
   let descriptorMap: Record<string, ExportColumnDescriptor> = {};
   let totalSize = 0;
-  const collectedRows: DataSourceRow[] = [];
+  let nextRequestedFrom = 0;
+  const collectedRows = new Map<number, DataSourceRow>();
 
-  return new Promise<void>((resolve) => {
+  return new Promise<void>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      activeSessionDataSource.unsubscribe();
+    };
+
+    const fail = (err: Error) => {
+      cleanup();
+      if (onError) {
+        onError(err);
+        resolve();
+      } else {
+        reject(err);
+      }
+    };
+
+    if (timeout > 0) {
+      timer = setTimeout(() => {
+        fail(
+          new Error(
+            `exportToCsv: export timed out after ${timeout}ms waiting for data`,
+          ),
+        );
+      }, timeout);
+    }
+
     const handleMessage = (message: DataSourceCallbackMessage): void => {
       if (message.type === "subscribed") {
         const { columns } = message as DataSourceSubscribedMessage;
@@ -179,13 +311,11 @@ export const exportSessionTableToCsv = async <TName extends string = string>(
             .filter((d) => !excluded.has(d.name) && !subscribedSet.has(d.name))
             .map((d) => d.name);
           if (unknown.length > 0) {
-            activeSessionDataSource.unsubscribe();
-            onError?.(
+            fail(
               new Error(
                 `exportToCsv: unknown column(s) in columnDescriptors: ${unknown.join(", ")}`,
               ),
             );
-            resolve();
             return;
           }
           descriptorMap = Object.fromEntries(
@@ -201,59 +331,70 @@ export const exportSessionTableToCsv = async <TName extends string = string>(
         if (message.mode === "size-only") {
           totalSize = message.size ?? 0;
           if (totalSize === 0) {
-            activeSessionDataSource.unsubscribe();
+            cleanup();
+            const header = exportCols
+              .map((name) => csvCell(descriptorMap[name]?.label ?? name))
+              .join(",");
+            triggerCsvDownload(`${header}\r\n`, filename);
             onSuccess?.();
             resolve();
             return;
           }
           if (totalSize > maxRows) {
-            activeSessionDataSource.unsubscribe();
-            onError?.(
+            fail(
               new Error(
                 `exportToCsv: row count ${totalSize} exceeds the ${maxRows} row limit`,
               ),
             );
-            resolve();
             return;
           }
           // request rows in chunks for predictable behaviour across local and remote DataSources
-          activeSessionDataSource.range = Range(
-            0,
-            Math.min(CHUNK_SIZE, totalSize),
-          );
+          nextRequestedFrom = Math.min(CHUNK_SIZE, totalSize);
+          activeSessionDataSource.range = Range(0, nextRequestedFrom);
         } else if (message.mode === "batch" && message.rows) {
-          collectedRows.push(...message.rows);
+          // Note: rows may be received from server in multiple batches and with no guaranteed ordering
+          for (const row of message.rows) {
+            const rowIndex = row[metadataKeys.IDX] as number;
+            if (typeof rowIndex === "number") {
+              collectedRows.set(rowIndex, row);
+            }
+          }
           // update totalSize in case it changed between size-only and batch
           if (message.size !== undefined) {
             totalSize = message.size;
           }
-          if (collectedRows.length >= totalSize) {
-            activeSessionDataSource.unsubscribe();
+          if (collectedRows.size >= totalSize) {
+            cleanup();
             const lines: string[] = [
               exportCols
                 .map((name) => csvCell(descriptorMap[name]?.label ?? name))
                 .join(","),
             ];
-            for (const row of collectedRows) {
-              lines.push(
-                exportCols
-                  .map((c) => {
-                    const raw = row[colNameToRowIdx[c]];
-                    const formatter = descriptorMap[c]?.exportFormatter;
-                    return csvCell(formatter ? formatter(raw) : raw);
-                  })
-                  .join(","),
-              );
+            // Assemble rows in strict index order (0 .. totalSize - 1)
+            for (let i = 0; i < totalSize; i++) {
+              const row = collectedRows.get(i);
+              if (row) {
+                lines.push(
+                  exportCols
+                    .map((c) => {
+                      const raw = row[colNameToRowIdx[c]];
+                      const formatter = descriptorMap[c]?.exportFormatter;
+                      return csvCell(formatter ? formatter(raw) : raw);
+                    })
+                    .join(","),
+                );
+              }
             }
             triggerCsvDownload(lines.join("\r\n"), filename);
             onSuccess?.();
             resolve();
-          } else {
-            const nextFrom = collectedRows.length;
-            activeSessionDataSource.range = Range(
-              nextFrom,
-              Math.min(nextFrom + CHUNK_SIZE, totalSize),
-            );
+          } else if (
+            collectedRows.size >= nextRequestedFrom &&
+            nextRequestedFrom < totalSize
+          ) {
+            const nextTo = Math.min(nextRequestedFrom + CHUNK_SIZE, totalSize);
+            activeSessionDataSource.range = Range(nextRequestedFrom, nextTo);
+            nextRequestedFrom = nextTo;
           }
         }
       }
@@ -267,28 +408,11 @@ export const exportSessionTableToCsv = async <TName extends string = string>(
 };
 
 /**
- * Creates an export session table from `dataSource` then streams all rows to a CSV download.
+ * Creates an export session table from `dataSource`, collects all rows in memory, then triggers a CSV download.
  */
 export const exportToCsv = async <TName extends string = string>(
   dataSource: DataSource,
-  copyOption: CopyOption = "All",
-  filename = "export.csv",
-  excludeColumns: string[] = [],
-  onError?: (error: Error) => void,
-  onSuccess?: () => void,
-  maxRows = MAX_EXPORT_ROWS,
-  columnDescriptors?: ExportColumnDescriptor<TName>[],
-  overrides?: SessionDataSourceOverrides,
+  options?: ExportToCsvOptions<TName>,
 ): Promise<void> => {
-  return exportSessionTableToCsv(
-    dataSource,
-    filename,
-    excludeColumns,
-    onError,
-    onSuccess,
-    maxRows,
-    columnDescriptors,
-    copyOption,
-    overrides,
-  );
+  return exportSessionTableToCsv(dataSource, options);
 };

--- a/vuu-ui/packages/vuu-table-extras/src/csv-export/export-utils.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-export/export-utils.ts
@@ -219,7 +219,10 @@ export const exportSessionTableToCsv = async <TName extends string = string>(
     onSuccess,
   } = options;
 
+  const isRemote = !!dataSource.isRemote;
+
   if (
+    isRemote &&
     !isSessionTable(dataSource.table) &&
     (dataSource.status === "initialising" ||
       dataSource.status === "unsubscribed")
@@ -393,8 +396,12 @@ export const exportSessionTableToCsv = async <TName extends string = string>(
             nextRequestedFrom < totalSize
           ) {
             const nextTo = Math.min(nextRequestedFrom + CHUNK_SIZE, totalSize);
-            activeSessionDataSource.range = Range(nextRequestedFrom, nextTo);
+            const requestedFrom = nextRequestedFrom;
             nextRequestedFrom = nextTo;
+            // Defer Range query to prevent synchronous deep stack recursion on local mocks
+            setTimeout(() => {
+              activeSessionDataSource.range = Range(requestedFrom, nextTo);
+            }, 0);
           }
         }
       }

--- a/vuu-ui/packages/vuu-table-extras/src/csv-export/index.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-export/index.ts
@@ -3,4 +3,12 @@ export {
   exportSessionTableToCsv,
   exportToCsv,
   type ExportColumnDescriptor,
+  type ExportCsvTemplateOptions,
+  type ExportToCsvOptions,
 } from "./export-utils";
+export {
+  useCsvExport,
+  type UseCsvExportProps,
+  type UseCsvExportResult,
+} from "./useCsvExport";
+

--- a/vuu-ui/packages/vuu-table-extras/src/csv-export/useCsvExport.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-export/useCsvExport.ts
@@ -1,0 +1,138 @@
+import { useCallback, useState } from "react";
+import type { DataSource } from "@vuu-ui/vuu-data-types";
+import {
+  exportCsvTemplate,
+  exportToCsv,
+  type ExportCsvTemplateOptions,
+  type ExportToCsvOptions,
+} from "./export-utils";
+
+export interface UseCsvExportProps {
+  dataSource?: DataSource;
+  onError?: (error: Error) => void;
+  onSuccess?: () => void;
+}
+
+export interface UseCsvExportResult {
+  isExporting: boolean;
+  error: Error | null;
+  exportCsv: <TName extends string = string>(
+    options?: ExportToCsvOptions<TName>,
+    overrideDataSource?: DataSource,
+  ) => Promise<void>;
+  exportTemplate: (
+    options?: ExportCsvTemplateOptions,
+    overrideDataSource?: DataSource,
+  ) => Promise<void>;
+}
+
+export function useCsvExport(
+  propsOrDataSource?: DataSource | UseCsvExportProps,
+): UseCsvExportResult {
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const config =
+    propsOrDataSource && "table" in propsOrDataSource
+      ? { dataSource: propsOrDataSource }
+      : (propsOrDataSource as UseCsvExportProps) ?? {};
+
+  const { dataSource: defaultDataSource, onError, onSuccess } = config;
+
+  const exportCsv = useCallback(
+    async <TName extends string = string>(
+      options?: ExportToCsvOptions<TName>,
+      overrideDataSource?: DataSource,
+    ) => {
+      const activeDataSource = overrideDataSource ?? defaultDataSource;
+      if (!activeDataSource) {
+        const err = new Error(
+          "useCsvExport: dataSource is required to export to CSV",
+        );
+        setError(err);
+        onError?.(err);
+        options?.onError?.(err);
+        throw err;
+      }
+
+      setIsExporting(true);
+      setError(null);
+      try {
+        await exportToCsv(activeDataSource, {
+          ...options,
+          onError: (err) => {
+            setError(err);
+            onError?.(err);
+            options?.onError?.(err);
+          },
+          onSuccess: () => {
+            onSuccess?.();
+            options?.onSuccess?.();
+          },
+        });
+      } catch (err) {
+        const catchedError =
+          err instanceof Error ? err : new Error(String(err));
+        setError(catchedError);
+        onError?.(catchedError);
+        options?.onError?.(catchedError);
+        throw catchedError;
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [defaultDataSource, onError, onSuccess],
+  );
+
+  const exportTemplate = useCallback(
+    async (
+      options?: ExportCsvTemplateOptions,
+      overrideDataSource?: DataSource,
+    ) => {
+      const activeDataSource = overrideDataSource ?? defaultDataSource;
+      if (!activeDataSource) {
+        const err = new Error(
+          "useCsvExport: dataSource is required to export CSV template",
+        );
+        setError(err);
+        onError?.(err);
+        options?.onError?.(err);
+        throw err;
+      }
+
+      setIsExporting(true);
+      setError(null);
+      try {
+        await exportCsvTemplate(activeDataSource, {
+          ...options,
+          onError: (err) => {
+            setError(err);
+            onError?.(err);
+            options?.onError?.(err);
+          },
+          onSuccess: () => {
+            onSuccess?.();
+            options?.onSuccess?.();
+          },
+        });
+      } catch (err) {
+        const catchedError =
+          err instanceof Error ? err : new Error(String(err));
+        setError(catchedError);
+        onError?.(catchedError);
+        options?.onError?.(catchedError);
+        throw catchedError;
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [defaultDataSource, onError, onSuccess],
+  );
+
+  return {
+    isExporting,
+    error,
+    exportCsv,
+    exportTemplate,
+  };
+}

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
@@ -31,7 +31,7 @@ import { CsvUpload } from "@vuu-ui/vuu-table-extras";
 
 | Prop | Type | Description |
 |---|---|---|
-| `dataSource` | `DataSource` | **Required.** The Vuu data source for the target table. Must support `createSessionDataSource` (used internally with `sessionType: "import"`), `addRow`, and `endEditSession`. |
+| `dataSource` | `DataSource` | **Required.** The Vuu data source for the target table. Must be subscribed (`status: "subscribed"`) and support `createSessionDataSource` (used internally with `sessionType: "import"`), `addRow`, and `endEditSession`. |
 | `importSchema` | `TableSchema` | Schema of the import table, where it differs from the target table. Used to validate the CSV and to determine the session datasource columns. If omitted and `importTable` is provided, the schema is fetched via `getTableSchema`. Pass a stable reference. See [Importing into a separate table](#importing-into-a-separate-table). |
 | `importTable` | `VuuTable` | The import table, where it differs from the target table. Used to resolve `importSchema` when that is not supplied, and to validate the module of the session table returned by the server. |
 | `embedded` | `boolean` | Renders the upload content and actions without its own `Dialog`, for use inside an existing modal. Defaults to `false`. |
@@ -162,7 +162,7 @@ type CsvErrorMap<TError extends string> = {
 
 | Code | Meaning |
 |---|---|
-| `MISSING_KEY_COLUMN` | The CSV does not contain the table's key column. Reported as a `fileError`. |
+| `MISSING_KEY_COLUMN` | The CSV does not contain the table's key column (internal/staging key columns such as `vuuRowNum` are exempt and generated automatically). Reported as a `fileError`. |
 | `UNKNOWN_COLUMN` | A CSV column has no matching column in the table schema. Reported as a `fileError`. |
 | `MAX_ROWS_EXCEEDED` | The CSV contains more rows than the `maxRows` limit. Reported as a `fileError`. |
 | `EMPTY_NON_STRING_VALUE` | A non-string column cell is empty. Reported as a `rowError`. |
@@ -210,7 +210,7 @@ By default the CSV is validated against `dataSource.tableSchema` and the session
 />
 ```
 
-`importSchema` does double duty: its column names become the session datasource columns, and it replaces `dataSource.tableSchema` as the schema the CSV is validated against. That second role is not optional — `processFile` validates the CSV *before* the session begins, and the session datasource is never subscribed (rows are added via `addRow` RPC), so its schema is never populated. The import schema has to be known up front.
+`importSchema` does double duty: its column names become the session datasource columns, and it replaces `dataSource.tableSchema` as the schema the CSV is validated against. That second role is not optional — `processFile` validates the CSV *before* the session begins, and `useCsvUpload` does not subscribe to the session datasource itself (rows are added via `addRow` RPCs directly). When `onImportSessionStarted` fires, subscribing to the session datasource is left to the consumer (e.g. `<Table />` or `DataUploadPreview`) to manage viewport rendering. The import schema has to be known up front.
 
 | Props | Behaviour |
 |---|---|

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/parse/csv-schema-validation.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/parse/csv-schema-validation.ts
@@ -37,6 +37,8 @@ export type CsvValidationOptions = {
   maxRows?: number;
 };
 
+const INTERNAL_KEY_COLUMNS = new Set(["vuuRowNum"]);
+
 export const validateCsvAgainstSchema = (
   parsed: CsvParseResult,
   tableSchema: TableSchema,
@@ -48,7 +50,11 @@ export const validateCsvAgainstSchema = (
   const maxRows = options?.maxRows ?? MAX_ROWS_IN_CSV;
   const errorState = createCsvErrorState<CsvValidationErrorEnum>();
 
-  if (!parsed.header.includes(tableSchema.key)) {
+  if (
+    tableSchema.key &&
+    !INTERNAL_KEY_COLUMNS.has(tableSchema.key) &&
+    !parsed.header.includes(tableSchema.key)
+  ) {
     addCsvFileError(
       errorState,
       tableSchema.key,

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
@@ -315,6 +315,7 @@ export const useCsvUpload = ({
     if (!sessionDataSource.columns.includes("vuuMsg")) {
       sessionDataSource.columns = sessionDataSource.columns.concat("vuuMsg");
     }
+
     setActiveSessionDataSource(sessionDataSource);
     onImportSessionStarted?.(sessionDataSource);
     return sessionDataSource;
@@ -347,6 +348,20 @@ export const useCsvUpload = ({
 
       await closePendingEditSession(false);
       if (operationId !== operationIdRef.current) {
+        return;
+      }
+
+      if (
+        !isSessionTable(dataSource.table) &&
+        (dataSource.status === "initialising" ||
+          dataSource.status === "unsubscribed")
+      ) {
+        const errorMessage = `CsvUpload requires dataSource to be subscribed before uploading (current status: "${dataSource.status}").`;
+        onError?.({
+          errors: {
+            validationError: createUploadError("validation", errorMessage),
+          },
+        });
         return;
       }
 
@@ -439,6 +454,8 @@ export const useCsvUpload = ({
       parseOptions,
       beginEditSession,
       closePendingEditSession,
+      dataSource.status,
+      dataSource.table,
       table,
       endEditSessionAndNotify,
       schema,

--- a/vuu-ui/packages/vuu-table-extras/test/csv-export/export-utils.test.ts
+++ b/vuu-ui/packages/vuu-table-extras/test/csv-export/export-utils.test.ts
@@ -1,0 +1,482 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  DataSource,
+  DataSourceRow,
+} from "@vuu-ui/vuu-data-types";
+import {
+  exportCsvTemplate,
+  exportSessionTableToCsv,
+  exportToCsv,
+} from "../../src/csv-export/export-utils";
+
+describe("export-utils", () => {
+  let mockSessionDataSource: {
+    table: { module: string; table: string };
+    status: string;
+    subscribe: ReturnType<typeof vi.fn>;
+    unsubscribe: ReturnType<typeof vi.fn>;
+  };
+
+  let mockDataSource: {
+    table: { module: string; table: string };
+    status: string;
+    tableSchema: { columns: { name: string; serverDataType: string }[] };
+    createSessionDataSource: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    // 10 metadata elements followed by columns: ric, currency, description, vuuRowNum
+    const metadata: DataSourceRow = [
+      0,
+      1,
+      false,
+      false,
+      0,
+      0,
+      "key1",
+      false,
+      0,
+      false,
+    ];
+    const metadata2: DataSourceRow = [
+      1,
+      2,
+      false,
+      false,
+      0,
+      0,
+      "key2",
+      false,
+      0,
+      false,
+    ];
+
+    mockSessionDataSource = {
+      table: { module: "SIMUL", table: "session-123" },
+      status: "subscribed",
+      subscribe: vi.fn((_props: unknown, callback: (msg: unknown) => void) => {
+        callback({
+          type: "subscribed",
+          columns: ["ric", "currency", "description", "vuuRowNum"],
+        });
+        callback({
+          type: "viewport-update",
+          mode: "size-only",
+          size: 2,
+        });
+        callback({
+          type: "viewport-update",
+          mode: "batch",
+          rows: [
+            [...metadata, "VOD.L", "GBP", "Vodafone", 1],
+            [...metadata2, "BP.L", "GBP", "BP", 2],
+          ],
+        });
+      }),
+      unsubscribe: vi.fn(),
+    };
+
+    mockDataSource = {
+      table: { module: "SIMUL", table: "instruments" },
+      status: "subscribed",
+      tableSchema: {
+        columns: [
+          { name: "ric", serverDataType: "string" },
+          { name: "currency", serverDataType: "string" },
+          { name: "description", serverDataType: "string" },
+        ],
+      },
+      createSessionDataSource: vi.fn().mockResolvedValue(mockSessionDataSource),
+    };
+
+    // mock DOM elements for triggerCsvDownload
+    vi.stubGlobal(
+      "Blob",
+      vi.fn(function (
+        this: { content: BlobPart[] },
+        content: BlobPart[],
+      ) {
+        this.content = content;
+      }),
+    );
+    URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    URL.revokeObjectURL = vi.fn();
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    vi.spyOn(document.body, "appendChild").mockImplementation((node) => node);
+    vi.spyOn(document.body, "removeChild").mockImplementation((node) => node);
+  });
+
+  describe("exportToCsv with options object", () => {
+    it("supports exporting via options object", async () => {
+      const onSuccess = vi.fn();
+      await exportToCsv(mockDataSource as unknown as DataSource, {
+        filename: "test.csv",
+        copyOption: "Selected",
+        onSuccess,
+      });
+
+      expect(mockDataSource.createSessionDataSource).toHaveBeenCalledWith(
+        "Selected",
+        "export",
+        undefined,
+      );
+      expect(mockSessionDataSource.subscribe).toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it("supports column descriptors with custom formatters and properly escapes quotes and special chars", async () => {
+      let csvContent = "";
+      vi.stubGlobal(
+        "Blob",
+        vi.fn(function (
+          this: { content: BlobPart[] },
+          content: BlobPart[],
+        ) {
+          csvContent = content[0] as string;
+        }),
+      );
+
+      mockSessionDataSource.subscribe.mockImplementation(
+        (_props: unknown, callback: (msg: unknown) => void) => {
+          callback({
+            type: "subscribed",
+            columns: ["ric", "currency", "description", "vuuRowNum"],
+          });
+          callback({
+            type: "viewport-update",
+            mode: "size-only",
+            size: 1,
+          });
+          callback({
+            type: "viewport-update",
+            mode: "batch",
+            rows: [
+              [
+                0,
+                0,
+                false,
+                false,
+                0,
+                0,
+                "key0",
+                false,
+                0,
+                false,
+                'VOD, "UK"',
+                "GBP",
+                "Vodafone\nGroup",
+                1,
+              ],
+            ],
+          });
+        },
+      );
+
+      await exportToCsv(mockDataSource as unknown as DataSource, {
+        filename: "formatted.csv",
+        columnDescriptors: [
+          { name: "ric", label: "RIC, Code" },
+          { name: "currency", exportFormatter: (v) => `${v}-CURR` },
+          { name: "description" },
+        ],
+      });
+
+      expect(csvContent).toContain('"RIC, Code",currency,description');
+      expect(csvContent).toContain('"VOD, ""UK""",GBP-CURR,"Vodafone\nGroup"');
+    });
+
+    it("downloads a header-only CSV when there are 0 records", async () => {
+      let csvContent = "";
+      vi.stubGlobal(
+        "Blob",
+        vi.fn(function (
+          this: { content: BlobPart[] },
+          content: BlobPart[],
+        ) {
+          csvContent = content[0] as string;
+        }),
+      );
+
+      mockSessionDataSource.subscribe.mockImplementation(
+        (_props: unknown, callback: (msg: unknown) => void) => {
+          callback({
+            type: "subscribed",
+            columns: ["ric", "currency", "description", "vuuRowNum"],
+          });
+          callback({
+            type: "viewport-update",
+            mode: "size-only",
+            size: 0,
+          });
+        },
+      );
+
+      const onSuccess = vi.fn();
+      await exportToCsv(mockDataSource as unknown as DataSource, {
+        filename: "empty.csv",
+        onSuccess,
+      });
+
+      expect(csvContent).toBe("ric,currency,description\r\n");
+      expect(onSuccess).toHaveBeenCalled();
+      expect(mockSessionDataSource.unsubscribe).toHaveBeenCalled();
+    });
+
+    it("assembles rows in correct order even when batches arrive out of order", async () => {
+      let csvContent = "";
+      vi.stubGlobal(
+        "Blob",
+        vi.fn(function (
+          this: { content: BlobPart[] },
+          content: BlobPart[],
+        ) {
+          csvContent = content[0] as string;
+        }),
+      );
+
+      const metadataRow0: DataSourceRow = [
+        0,
+        0,
+        false,
+        false,
+        0,
+        0,
+        "key0",
+        false,
+        0,
+        false,
+      ];
+      const metadataRow1: DataSourceRow = [
+        1,
+        1,
+        false,
+        false,
+        0,
+        0,
+        "key1",
+        false,
+        0,
+        false,
+      ];
+
+      mockSessionDataSource.subscribe.mockImplementation(
+        (_props: unknown, callback: (msg: unknown) => void) => {
+          callback({
+            type: "subscribed",
+            columns: ["ric", "currency", "description", "vuuRowNum"],
+          });
+          callback({
+            type: "viewport-update",
+            mode: "size-only",
+            size: 2,
+          });
+          // Send row 1 first in batch 1, then row 0 in batch 2
+          callback({
+            type: "viewport-update",
+            mode: "batch",
+            rows: [[...metadataRow1, "BP.L", "GBP", "BP", 2]],
+          });
+          callback({
+            type: "viewport-update",
+            mode: "batch",
+            rows: [[...metadataRow0, "VOD.L", "GBP", "Vodafone", 1]],
+          });
+        },
+      );
+
+      const onSuccess = vi.fn();
+      await exportToCsv(mockDataSource as unknown as DataSource, {
+        filename: "out-of-order.csv",
+        onSuccess,
+      });
+
+      const lines = csvContent.split("\r\n").filter(Boolean);
+      expect(lines[0]).toBe("ric,currency,description");
+      expect(lines[1]).toBe("VOD.L,GBP,Vodafone");
+      expect(lines[2]).toBe("BP.L,GBP,BP");
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it("rejects when row count exceeds maxRows", async () => {
+      const onError = vi.fn();
+      await exportToCsv(mockDataSource as unknown as DataSource, {
+        maxRows: 1,
+        onError,
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("exceeds the 1 row limit"),
+        }),
+      );
+
+      // Also verify it rejects when onError is omitted
+      await expect(
+        exportToCsv(mockDataSource as unknown as DataSource, {
+          maxRows: 1,
+        }),
+      ).rejects.toThrow("exceeds the 1 row limit");
+    });
+
+    it("rejects when export times out", async () => {
+      mockSessionDataSource.subscribe.mockImplementation(() => {
+        // never send messages to simulate a hang
+      });
+
+      await expect(
+        exportToCsv(mockDataSource as unknown as DataSource, {
+          timeout: 20,
+        }),
+      ).rejects.toThrow("timed out");
+    });
+  });
+
+  describe("status checks", () => {
+    it("throws or calls onError when dataSource is not subscribed (status = initialising)", async () => {
+      const uninitializedDs = {
+        table: { module: "SIMUL", table: "instruments" },
+        status: "initialising",
+        createSessionDataSource: vi.fn(),
+      };
+
+      const onError = vi.fn();
+      await exportToCsv(uninitializedDs as unknown as DataSource, {
+        onError,
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("dataSource must be subscribed before exporting"),
+        }),
+      );
+      expect(uninitializedDs.createSessionDataSource).not.toHaveBeenCalled();
+    });
+
+    it("throws when onError is omitted and status is unsubscribed", async () => {
+      const uninitializedDs = {
+        table: { module: "SIMUL", table: "instruments" },
+        status: "unsubscribed",
+        createSessionDataSource: vi.fn(),
+      };
+
+      await expect(
+        exportToCsv(uninitializedDs as unknown as DataSource, { filename: "test.csv" }),
+      ).rejects.toThrow("dataSource must be subscribed before exporting");
+    });
+  });
+
+  describe("exportCsvTemplate with options object", () => {
+    it("exports template with options object and triggers onSuccess", async () => {
+      mockSessionDataSource.subscribe.mockImplementation(
+        (_props: unknown, callback: (msg: unknown) => void) => {
+          callback({
+            type: "subscribed",
+            columns: ["ric", "currency", "description"],
+          });
+        },
+      );
+
+      const onSuccess = vi.fn();
+      await exportCsvTemplate(mockDataSource as unknown as DataSource, {
+        filename: "my-template.csv",
+        excludeColumns: ["description"],
+        onSuccess,
+      });
+
+      expect(mockDataSource.createSessionDataSource).toHaveBeenCalledWith(
+        "Empty",
+        "export",
+        undefined,
+      );
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it("falls back to tableSchema if status is initialising and triggers onSuccess", async () => {
+      const uninitializedDs = {
+        table: { module: "SIMUL", table: "instruments" },
+        status: "initialising",
+        tableSchema: {
+          columns: [
+            { name: "ric", serverDataType: "string" },
+            { name: "currency", serverDataType: "string" },
+          ],
+        },
+        createSessionDataSource: vi.fn(),
+      };
+
+      const onSuccess = vi.fn();
+      await exportCsvTemplate(uninitializedDs as unknown as DataSource, {
+        filename: "schema-template.csv",
+        onSuccess,
+      });
+
+      expect(uninitializedDs.createSessionDataSource).not.toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it("handles missing tableSchema via onError or throw in fallback path", async () => {
+      const brokenDs = {
+        table: { module: "SIMUL", table: "instruments" },
+        status: "initialising",
+        createSessionDataSource: vi.fn(),
+      };
+
+      const onError = vi.fn();
+      await exportCsvTemplate(brokenDs as unknown as DataSource, {
+        onError,
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("tableSchema not available"),
+        }),
+      );
+
+      await expect(
+        exportCsvTemplate(brokenDs as unknown as DataSource),
+      ).rejects.toThrow("tableSchema not available");
+    });
+
+    it("handles empty export columns via onError or throw in fallback path", async () => {
+      const noColumnsDs = {
+        table: { module: "SIMUL", table: "instruments" },
+        status: "initialising",
+        tableSchema: {
+          columns: [{ name: "vuuRowNum", serverDataType: "string" }],
+        },
+        createSessionDataSource: vi.fn(),
+      };
+
+      const onError = vi.fn();
+      await exportCsvTemplate(noColumnsDs as unknown as DataSource, {
+        onError,
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("no columns available for export"),
+        }),
+      );
+
+      await expect(
+        exportCsvTemplate(noColumnsDs as unknown as DataSource),
+      ).rejects.toThrow("no columns available for export");
+    });
+  });
+
+  describe("exportSessionTableToCsv with options object", () => {
+    it("exports existing session table directly without calling createSessionDataSource", async () => {
+      const onSuccess = vi.fn();
+      await exportSessionTableToCsv(
+        mockSessionDataSource as unknown as DataSource,
+        {
+          filename: "session-direct.csv",
+          onSuccess,
+        },
+      );
+
+      expect(mockSessionDataSource.subscribe).toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+});

--- a/vuu-ui/packages/vuu-table-extras/test/csv-export/export-utils.test.ts
+++ b/vuu-ui/packages/vuu-table-extras/test/csv-export/export-utils.test.ts
@@ -29,26 +29,26 @@ describe("export-utils", () => {
     const metadata: DataSourceRow = [
       0,
       1,
-      false,
-      false,
+      false, // IS_LEAF
+      false, // IS_EXPANDED
       0,
       0,
       "key1",
-      false,
+      0, // SELECTED
       0,
-      false,
+      false, // IS_NEW
     ];
     const metadata2: DataSourceRow = [
       1,
       2,
-      false,
-      false,
+      false, // IS_LEAF
+      false, // IS_EXPANDED
       0,
       0,
       "key2",
-      false,
+      0, // SELECTED
       0,
-      false,
+      false, // IS_NEW
     ];
 
     mockSessionDataSource = {
@@ -242,7 +242,7 @@ describe("export-utils", () => {
         0,
         0,
         "key0",
-        false,
+        0,
         0,
         false,
       ];
@@ -254,7 +254,7 @@ describe("export-utils", () => {
         0,
         0,
         "key1",
-        false,
+        0,
         0,
         false,
       ];
@@ -334,6 +334,7 @@ describe("export-utils", () => {
   describe("status checks", () => {
     it("throws or calls onError when dataSource is not subscribed (status = initialising)", async () => {
       const uninitializedDs = {
+        isRemote: true,
         table: { module: "SIMUL", table: "instruments" },
         status: "initialising",
         createSessionDataSource: vi.fn(),
@@ -354,6 +355,7 @@ describe("export-utils", () => {
 
     it("throws when onError is omitted and status is unsubscribed", async () => {
       const uninitializedDs = {
+        isRemote: true,
         table: { module: "SIMUL", table: "instruments" },
         status: "unsubscribed",
         createSessionDataSource: vi.fn(),

--- a/vuu-ui/packages/vuu-table-extras/test/csv-upload/csv-schema-validation.test.ts
+++ b/vuu-ui/packages/vuu-table-extras/test/csv-upload/csv-schema-validation.test.ts
@@ -55,6 +55,25 @@ describe("validateCsvAgainstSchema", () => {
     );
   });
 
+  it("does not require vuuRowNum in the CSV header when the schema key is vuuRowNum", () => {
+    const result = validateCsvAgainstSchema(
+      makeParsed(["id", "count", "label"], [["a1", "10", "foo"]]),
+      makeSchema({
+        key: "vuuRowNum",
+        columns: [
+          { name: "vuuRowNum", serverDataType: "int" },
+          { name: "id", serverDataType: "string" },
+          { name: "count", serverDataType: "int" },
+          { name: "label", serverDataType: "string" },
+        ],
+      }),
+    );
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.errorMap.fileErrors["vuuRowNum"]).toBeUndefined();
+    expect(result.rows).toEqual([{ id: "a1", count: 10, label: "foo" }]);
+  });
+
   it("adds a file error for each column that is not in the schema", () => {
     const result = validateCsvAgainstSchema(
       makeParsed(["id", "unknown_col"], [["a1", "val"]]),

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvExport.examples.tsx
@@ -1,6 +1,11 @@
 import { getSchema, LocalDataSourceProvider, simulModule } from "@vuu-ui/vuu-data-test";
 import type { DataSource } from "@vuu-ui/vuu-data-types";
-import { exportCsvTemplate, exportToCsv, type ExportColumnDescriptor } from "@vuu-ui/vuu-table-extras";
+import {
+  exportCsvTemplate,
+  exportToCsv,
+  useCsvExport,
+  type ExportColumnDescriptor,
+} from "@vuu-ui/vuu-table-extras";
 import { Button } from "@salt-ds/core";
 import { Table } from "@vuu-ui/vuu-table";
 import type { TableConfig } from "@vuu-ui/vuu-table-types";
@@ -26,14 +31,18 @@ const CsvExportContent = () => {
     setIsExporting(true);
     setStatus(undefined);
     try {
-      await exportToCsv(
-        dataSource as DataSource,
-        "All",
-        "instruments-export.csv",
-        [],
-        (err) => { setStatus(`Export failed: ${err.message}`); setIsExporting(false); },
-        () => { setStatus("Download started"); setIsExporting(false); },
-      );
+      await exportToCsv(dataSource as DataSource, {
+        filename: "instruments-export.csv",
+        copyOption: "All",
+        onError: (err) => {
+          setStatus(`Export failed: ${err.message}`);
+          setIsExporting(false);
+        },
+        onSuccess: () => {
+          setStatus("Download started");
+          setIsExporting(false);
+        },
+      });
     } catch (e) {
       setStatus(`Export failed: ${(e as Error).message}`);
       setIsExporting(false);
@@ -44,14 +53,18 @@ const CsvExportContent = () => {
     setIsExporting(true);
     setStatus(undefined);
     try {
-      await exportToCsv(
-        dataSource as DataSource,
-        "Selected",
-        "instruments-selected-export.csv",
-        [],
-        (err) => { setStatus(`Export failed: ${err.message}`); setIsExporting(false); },
-        () => { setStatus("Download started"); setIsExporting(false); },
-      );
+      await exportToCsv(dataSource as DataSource, {
+        filename: "instruments-selected-export.csv",
+        copyOption: "Selected",
+        onError: (err) => {
+          setStatus(`Export failed: ${err.message}`);
+          setIsExporting(false);
+        },
+        onSuccess: () => {
+          setStatus("Download started");
+          setIsExporting(false);
+        },
+      });
     } catch (e) {
       setStatus(`Export failed: ${(e as Error).message}`);
       setIsExporting(false);
@@ -101,7 +114,9 @@ const CsvExportSimpleContent = () => {
   );
 
   const handleExport = useCallback(async () => {
-    await exportToCsv(dataSource as DataSource, "All", "instruments.csv");
+    await exportToCsv(dataSource as DataSource, {
+      filename: "instruments.csv",
+    });
   }, [dataSource]);
 
   return (
@@ -133,15 +148,12 @@ const CsvExportWithRowLimitContent = () => {
   const handleExport = useCallback(async () => {
     setStatus(undefined);
     try {
-      await exportToCsv(
-        dataSource as DataSource,
-        "All",
-        "instruments-limited.csv",
-        [],
-        (err) => setStatus(`Export failed: ${err.message}`),
-        () => setStatus("Download started"),
-        50,
-      );
+      await exportToCsv(dataSource as DataSource, {
+        filename: "instruments-limited.csv",
+        maxRows: 50,
+        onError: (err) => setStatus(`Export failed: ${err.message}`),
+        onSuccess: () => setStatus("Download started"),
+      });
     } catch (e) {
       setStatus(`Export failed: ${(e as Error).message}`);
     }
@@ -185,16 +197,16 @@ const CsvExportTemplateContent = () => {
   );
 
   const handleDownloadAllColumns = useCallback(() => {
-    exportCsvTemplate(dataSource as DataSource, "instruments-template.csv");
+    exportCsvTemplate(dataSource as DataSource, {
+      filename: "instruments-template.csv",
+    });
   }, [dataSource]);
 
   const handleDownloadSubset = useCallback(() => {
-    exportCsvTemplate(
-      dataSource as DataSource,
-      "instruments-template-subset.csv",
-      [],
-      INSTRUMENTS_TEMPLATE_COLUMNS,
-    );
+    exportCsvTemplate(dataSource as DataSource, {
+      filename: "instruments-template-subset.csv",
+      columns: INSTRUMENTS_TEMPLATE_COLUMNS,
+    });
   }, [dataSource]);
 
   return (
@@ -234,16 +246,12 @@ const CsvExportWithFormattersContent = () => {
   const handleExport = useCallback(async () => {
     setStatus(undefined);
     try {
-      await exportToCsv(
-        dataSource as DataSource,
-        "All",
-        "instruments-formatted.csv",
-        [],
-        (err) => setStatus(`Export failed: ${err.message}`),
-        () => setStatus("Download started"),
-        10_000,
-        INSTRUMENTS_EXPORT_DESCRIPTORS,
-      );
+      await exportToCsv(dataSource as DataSource, {
+        filename: "instruments-formatted.csv",
+        columnDescriptors: INSTRUMENTS_EXPORT_DESCRIPTORS,
+        onError: (err) => setStatus(`Export failed: ${err.message}`),
+        onSuccess: () => setStatus("Download started"),
+      });
     } catch (e) {
       setStatus(`Export failed: ${(e as Error).message}`);
     }
@@ -278,30 +286,22 @@ const CsvExportWithOverridesContent = () => {
   const handleExportOverrides = useCallback(async () => {
     setStatus(undefined);
     try {
-      await exportToCsv(
-        dataSource as DataSource,
-        "All",
-        "instruments-overrides.csv",
-        [],
-        (err) => setStatus(`Export failed: ${err.message}`),
-        () => setStatus("Download started"),
-        10_000,
-        undefined,
-        { columns: ["ric", "currency", "lotSize"] },
-      );
+      await exportToCsv(dataSource as DataSource, {
+        filename: "instruments-overrides.csv",
+        overrides: { columns: ["ric", "currency", "lotSize"] },
+        onError: (err) => setStatus(`Export failed: ${err.message}`),
+        onSuccess: () => setStatus("Download started"),
+      });
     } catch (e) {
       setStatus(`Export failed: ${(e as Error).message}`);
     }
   }, [dataSource]);
 
   const handleTemplateOverrides = useCallback(async () => {
-    await exportCsvTemplate(
-      dataSource as DataSource,
-      "template-overrides.csv",
-      [],
-      undefined,
-      { columns: ["ric", "isin"] },
-    );
+    await exportCsvTemplate(dataSource as DataSource, {
+      filename: "template-overrides.csv",
+      overrides: { columns: ["ric", "isin"] },
+    });
   }, [dataSource]);
 
   return (
@@ -322,6 +322,83 @@ const CsvExportWithOverridesContent = () => {
 export const CsvExportWithOverrides = () => (
   <LocalDataSourceProvider>
     <CsvExportWithOverridesContent />
+  </LocalDataSourceProvider>
+);
+
+const CsvExportWithHookContent = () => {
+  const [status, setStatus] = useState<string | undefined>();
+  const dataSource = useMemo(
+    () => simulModule.createDataSource(TABLE_NAME) as unknown as DataSource,
+    [],
+  );
+
+  const config = useMemo<TableConfig>(
+    () => ({ columns: getSchema(TABLE_NAME).columns }),
+    [],
+  );
+
+  const { isExporting, exportCsv, exportTemplate } = useCsvExport({
+    dataSource,
+    onError: (err) => setStatus(`Export failed: ${err.message}`),
+    onSuccess: () => setStatus("Download started"),
+  });
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        height: "100%",
+        padding: 12,
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Button
+          disabled={isExporting}
+          onClick={() => exportCsv({ filename: "instruments-hook-export.csv" })}
+        >
+          {isExporting ? "Exporting..." : "Export All (useCsvExport)"}
+        </Button>
+        <Button
+          disabled={isExporting}
+          onClick={() =>
+            exportCsv({
+              copyOption: "Selected",
+              filename: "instruments-hook-selected.csv",
+            })
+          }
+        >
+          Export Selected (useCsvExport)
+        </Button>
+        <Button
+          disabled={isExporting}
+          onClick={() =>
+            exportTemplate({ filename: "instruments-hook-template.csv" })
+          }
+        >
+          Download Template
+        </Button>
+        {status ? (
+          <span style={{ fontSize: 12, color: "#027a48", fontWeight: 600 }}>
+            {status}
+          </span>
+        ) : null}
+      </div>
+      <div style={{ flex: "1 1 0", border: "solid 1px lightgray" }}>
+        <Table
+          config={config}
+          dataSource={dataSource}
+          selectionModel="checkbox"
+        />
+      </div>
+    </div>
+  );
+};
+
+export const CsvExportWithHook = () => (
+  <LocalDataSourceProvider>
+    <CsvExportWithHookContent />
   </LocalDataSourceProvider>
 );
 


### PR DESCRIPTION
Reworks the CSV export API in `@vuu-ui/vuu-table-extras` around an options object, adds a `useCsvExport` React hook, and fixes several correctness issues in both export and upload. CSV export is not yet consumed anywhere, so the old positional signatures were removed outright rather than deprecated.

### CSV export

**API**
- `exportToCsv(dataSource, options)`, `exportSessionTableToCsv(dataSource, options)`, `exportCsvTemplate(dataSource, options)` now take a single options object. This removes the 9-argument call sites and the inconsistent `copyOption` position between `exportToCsv` (2nd) and `exportSessionTableToCsv` (8th).
- New `useCsvExport(dataSource | props)` hook exposing `isExporting`, `error`, `exportCsv`, `exportTemplate`.

**Fixes**
- **Unsubscribed dataSource**: `createSessionDataSource` issues a `VIEWPORT_CONTEXT` RPC, but `VuuDataSource.server`/`viewport` are only populated by `subscribe()`. Calling export on an unsubscribed source failed with the opaque `rpcCall server or viewport are undefined`. Now checked up front with a descriptive error.
- **Silent success**: `maxRows` exceeded and unknown `columnDescriptors` previously resolved the promise even with no `onError` handler, so `try/catch` callers saw a successful export with no download. These now reject when `onError` is omitted.
- **Row ordering**: rows arrive in multiple batches with no guaranteed ordering. Replaced `collectedRows.push(...)` with an index-keyed `Map` keyed on `metadataKeys.IDX`, and assemble output in strict `0..totalSize-1` order.
- **CSV escaping**: `csvCell` opened a quote without closing it and ignored `\r`, producing malformed output for values containing `,`, `"` or newlines.
- **Empty exports**: a 0-row export produced no file at all. It now downloads a header-only CSV, consistent with `exportCsvTemplate`.
- **Hangs**: added a `timeout` option (30s export / 10s template, `0` disables) that unsubscribes and fails rather than leaving the promise — and `isExporting` — pending forever.

**Docs note**: the JSDoc claimed rows were "streamed"; they are collected in memory, so wording was corrected — this is only suitable for modest volumes, bounded by `maxRows`.

### CSV upload

- `MISSING_KEY_COLUMN` no longer fires when the schema key is an internal staging column (`vuuRowNum`). That column is generated per-row by `useCsvUpload` and is never present in a user-supplied CSV, so every import against a remote staging table failed validation.
- `processFile` fails fast with a clear message if the target `dataSource` is not subscribed, for the same RPC reason as export.
- `beginEditSession` does not subscribe to the session dataSource. `VuuDataSource` allows a single subscriber, so subscribing here would make a later `<Table>`/`DataUploadPreview` subscribe throw. Subscription stays with the consumer via `onImportSessionStarted`.