### PR TITLE
Optional inline add inputs

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -40,6 +40,7 @@ const toEditSessionMode = (copyOption: CopyOption): EditSessionMode => {
 };
 export type NewRowState = {
   columns: readonly string[];
+  requiredColumns?: readonly string[];
   draftRevision: number;
   errors: Readonly<Record<string, string>>;
   submitting: boolean;
@@ -104,6 +105,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   #sessionDataSource?: DataSource;
   #newRowState: NewRowState = {
     columns: [],
+    requiredColumns: [],
     draftRevision: 0,
     errors: {},
     submitting: false,
@@ -234,7 +236,8 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   }
 
   isNewRowComplete() {
-    return this.#newRowState.columns.every((column) => {
+    const requiredColumns = this.#newRowState.requiredColumns ?? this.#newRowState.columns;
+    return requiredColumns.every((column) => {
       const value = this.#newRowState.values[column];
       return (
         value !== undefined &&
@@ -243,12 +246,19 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     });
   }
 
-  configureNewRow(columns: readonly string[]) {
+  configureNewRow(columns: readonly string[], requiredColumns?: readonly string[]) {
     if (
       columns.length === this.#newRowState.columns.length &&
       columns.every(
         (column, index) => column === this.#newRowState.columns[index],
-      )
+      ) &&
+      (!requiredColumns || (
+        this.#newRowState.requiredColumns !== undefined &&
+        requiredColumns.length === this.#newRowState.requiredColumns.length &&
+        requiredColumns.every(
+          (column, index) => column === this.#newRowState.requiredColumns?.[index],
+        )
+      ))
     ) {
       return;
     }
@@ -262,6 +272,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     this.#setNewRowState({
       ...this.#newRowState,
       columns: [...columns],
+      requiredColumns: requiredColumns ? [...requiredColumns] : undefined,
       errors,
     });
   }
@@ -277,8 +288,9 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   }
 
   async addNewRow(): Promise<RpcResult> {
+    const requiredColumns = this.#newRowState.requiredColumns ?? this.#newRowState.columns;
     const missingErrors = Object.fromEntries(
-      this.#newRowState.columns
+      requiredColumns
         .filter((column) => {
           const value = this.#newRowState.values[column];
           return (
@@ -316,6 +328,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
 
       this.#setNewRowState({
         columns: this.#newRowState.columns,
+        requiredColumns: this.#newRowState.requiredColumns,
         draftRevision: this.#newRowState.draftRevision + 1,
         errors: {},
         submitting: false,

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -149,6 +149,28 @@ describe("EditSession lifecycle", () => {
     });
   });
 
+  it("allows some columns to be optional for a new row", async () => {
+    const addRow = vi.fn<AddRow>().mockResolvedValue(SUCCESS);
+    editSession = new EditSession({ dataSource: new MockDataSource(endEdit, createSession, editCell, addRow) });
+    editSession.configureNewRow(["id", "name", "description"], ["id", "name"]);
+    editSession.setNewRowValue("id", 7);
+    expect(editSession.isNewRowComplete()).toBe(false);
+
+    await expect(editSession.addNewRow()).resolves.toEqual(SUCCESS);
+    expect(editSession.newRowState.errors).toEqual({ name: "Value required" });
+    expect(addRow).not.toHaveBeenCalled();
+
+    editSession.setNewRowValue("name", "Alice");
+    expect(editSession.isNewRowComplete()).toBe(true);
+    await expect(editSession.addNewRow()).resolves.toEqual(SUCCESS);
+    expect(addRow).toHaveBeenCalledWith({ id: 7, name: "Alice" });
+    expect(editSession.newRowState).toMatchObject({
+      draftRevision: 1,
+      errors: {},
+      values: {},
+    });
+  });
+
   it("prevents duplicate new-row submissions", async () => {
     const pendingAdd = deferred<RpcResultSuccess>();
     const addRow = vi.fn<AddRow>().mockReturnValue(pendingAdd.promise);

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -153,7 +153,7 @@ export interface DataValueDescriptor {
   label?: string;
   /** unique name for this data value */
   name: string;
-  /** Whether the field is required or can be empty/nullable */
+    /** Whether the field is required or can be empty/nullable */
   required?: boolean;
   /** The type defined on server for this data value */
   serverDataType?: VuuColumnDataType;
@@ -705,6 +705,7 @@ export interface DataSourceBase<
   freezeTimestamp?: number | undefined;
   select?: (selectRequest: Omit<SelectRequest, "vpId">) => void;
 
+  isRemote?: boolean;
   status: DataSourceStatus;
   /**
    *

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -153,6 +153,8 @@ export interface DataValueDescriptor {
   label?: string;
   /** unique name for this data value */
   name: string;
+  /** Whether the field is required or can be empty/nullable */
+  required?: boolean;
   /** The type defined on server for this data value */
   serverDataType?: VuuColumnDataType;
   /** Type hints for the UI that supplement the serverDataType */
@@ -703,7 +705,6 @@ export interface DataSourceBase<
   freezeTimestamp?: number | undefined;
   select?: (selectRequest: Omit<SelectRequest, "vpId">) => void;
 
-  isRemote?: boolean;
   status: DataSourceStatus;
   /**
    *

--- a/vuu-ui/packages/vuu-table-extras/src/inline-add-row/useInlineAddRow.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/inline-add-row/useInlineAddRow.ts
@@ -94,7 +94,12 @@ export const useInlineAddRow = ({ columns }: UseInlineAddRowProps) => {
   }, []);
 
   useEffect(() => {
-    editSession.configureNewRow(visibleInsertColumns.map(({ name }) => name));
+    editSession.configureNewRow(
+      visibleInsertColumns.map(({ name }) => name),
+      visibleInsertColumns
+        .filter((column) => column.required !== false)
+        .map(({ name }) => name),
+    );
   }, [editSession, visibleInsertColumns]);
 
   useEffect(() => {


### PR DESCRIPTION
- Add optional required flag to DataValueDescriptor
- Track a distinct requiredColumns array in EditSession NewRowState
- Only enforce "Value required" errors on requiredColumns during validation and commit