### PR TITLE
add showcase example that weds a ColumnPicket to Table

### DIFF
--- a/vuu-ui/packages/vuu-table-extras/src/column-picker/ColumnModel.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/column-picker/ColumnModel.ts
@@ -135,7 +135,7 @@ export class ColumnModel extends EventEmitter<ColumnEvents> {
     return filterColumns(this.#selectedColumns, this.#searchPattern);
   }
   setSelectedColumns(
-    selectedColumns: ColumnDescriptor[],
+    selectedColumns: readonly ColumnDescriptor[],
     source: ColumnChangeSource,
     changeDescriptor?: SelectedColumnChangeDescriptor,
   ) {

--- a/vuu-ui/packages/vuu-table/src/table-config/useTableConfig.ts
+++ b/vuu-ui/packages/vuu-table/src/table-config/useTableConfig.ts
@@ -1,4 +1,5 @@
 import {
+  ColumnChangeSource,
   ColumnModel,
   ColumnsChangeHandler,
   TableDisplayAttributeChangeHandler,
@@ -65,18 +66,22 @@ export const useTableConfig = ({
   );
 
   const columnModel = useMemo(() => {
-    const model = new ColumnModel(availableColumns, tableConfig.columns);
+    const model = new ColumnModel(availableColumns, initialTableConfig.columns);
     model.on("change", handleColumnModelChange);
     return model;
-  }, [availableColumns, handleColumnModelChange, tableConfig.columns]);
+  }, [availableColumns, handleColumnModelChange, initialTableConfig.columns]);
 
   const handleTableConfigChange = useCallback<TableConfigChangeHandler>(
-    (_config, changeType) => {
-      if (changeType.type === "column-removed") {
-        columnModel.removeItemFromSelectedColumns(
-          changeType.column.name,
-          "table",
+    (config, changeType) => {
+      if (changeType.type === "column-moved") {
+        setTableConfig(config);
+        columnModel.reorderSelectedColumns(
+          config.columns.map(({ name }) => name),
+          ColumnChangeSource.Table,
         );
+      } else if (changeType.type === "column-removed") {
+        setTableConfig(config);
+        columnModel.setSelectedColumns(config.columns, ColumnChangeSource.Table);
       }
     },
     [columnModel],

--- a/vuu-ui/showcase/src/examples/Table/ColumnPicker.examples.tsx
+++ b/vuu-ui/showcase/src/examples/Table/ColumnPicker.examples.tsx
@@ -1,0 +1,12 @@
+import { ColumnPickerAction } from "@vuu-ui/vuu-table-extras";
+import { SimulTable } from "./SimulTableTemplate";
+
+/** tags=data-consumer */
+export const InstrumentsWithColumnPicker = () => (
+  <SimulTable
+    tableFooterAction={(columnModel) => (
+      <ColumnPickerAction columnModel={columnModel} />
+    )}
+    tableName="instruments"
+  />
+);

--- a/vuu-ui/showcase/src/examples/Table/SimulTableTemplate.tsx
+++ b/vuu-ui/showcase/src/examples/Table/SimulTableTemplate.tsx
@@ -3,6 +3,7 @@ import { useVuuMenuActions } from "@vuu-ui/vuu-data-react";
 import { getSchema, SimulTableName } from "@vuu-ui/vuu-data-test";
 import { Table, TableProps, useTableConfig } from "@vuu-ui/vuu-table";
 import {
+  ColumnModel,
   DataSourceStats,
   TableFooter,
   TabbedTableSettingsAction,
@@ -19,7 +20,7 @@ import {
   toColumnName,
   useData,
 } from "@vuu-ui/vuu-utils";
-import { useMemo } from "react";
+import { ReactNode, useMemo } from "react";
 import { DemoTableContainer } from "./DemoTableContainer";
 import { ModalProvider } from "@vuu-ui/vuu-ui-controls";
 
@@ -29,6 +30,7 @@ export type SimulTableProps = Partial<TableProps> & {
   columns?: readonly ColumnDescriptor[];
   getDefaultColumnConfig?: DefaultColumnConfiguration;
   rowClassNameGenerators?: string[];
+  tableFooterAction?: (columnModel: ColumnModel) => ReactNode;
   tableContextMenuHook?: () => TableContextMenuDef;
   tableName?: SimulTableName;
 };
@@ -43,6 +45,7 @@ const SimulTableBase = ({
   height,
   renderBufferSize = 10,
   rowClassNameGenerators,
+  tableFooterAction,
   tableContextMenuHook,
   tableName = "instruments",
   ...props
@@ -117,14 +120,16 @@ const SimulTableBase = ({
         <TableFooter>
           <DataSourceStats dataSource={dataSource} />
           <TableFooterTray>
-            <TabbedTableSettingsAction
-              allowCreateCalculatedColumn
-              columnModel={columnModel}
-              config={tableConfig}
-              data-embedded
-              onDisplayAttributeChange={onTableDisplayAttributeChange}
-              vuuTable={tableSchema.table}
-            />
+            {tableFooterAction?.(columnModel) ?? (
+              <TabbedTableSettingsAction
+                allowCreateCalculatedColumn
+                columnModel={columnModel}
+                config={tableConfig}
+                data-embedded
+                onDisplayAttributeChange={onTableDisplayAttributeChange}
+                vuuTable={tableSchema.table}
+              />
+            )}
           </TableFooterTray>
         </TableFooter>
       </ContextMenuProvider>


### PR DESCRIPTION
Add a showcase example that combines a Table with a simple ColumnPicker (rather than the TableSettingsPanel used by existing examples)

Fix issue in useTableConfig - column-moved events were not transmitted to ColumnModel, only column-rem oved

