### PR TITLE
Resolve BigInt serialization issues on row additions and filter queries

### DIFF
--- a/vuu-ui/packages/vuu-filters/test/FilterAggregator.test.ts
+++ b/vuu-ui/packages/vuu-filters/test/FilterAggregator.test.ts
@@ -174,7 +174,7 @@ describe("FilterAggregator", () => {
         expect(aggregator.filter).toEqual({
           column: "id",
           op: "=",
-          value: 1000000000000001234n,
+          value: "1000000000000001234",
         });
       });
     });

--- a/vuu-ui/packages/vuu-utils/src/filters/filterAsQuery.ts
+++ b/vuu-ui/packages/vuu-utils/src/filters/filterAsQuery.ts
@@ -4,6 +4,7 @@ import {
   SingleValueFilterClause,
 } from "@vuu-ui/vuu-filter-types";
 import { isDateTimeDataValue } from "../column-utils";
+import { stringIsValidLong } from "../data-utils";
 import {
   isMultiClauseFilter,
   isMultiValueFilter,
@@ -13,7 +14,9 @@ import { ScaledDecimal } from "../ScaledDecimal";
 
 const filterValue = (value: string | number | boolean | ScaledDecimal) =>
   typeof value === "string"
-    ? `"${value}"`
+    ? stringIsValidLong(value)
+      ? value
+      : `"${value}"`
     : value instanceof ScaledDecimal || typeof value === "bigint"
       ? value.toString()
       : value;

--- a/vuu-ui/packages/vuu-utils/src/filters/filterAsQuery.ts
+++ b/vuu-ui/packages/vuu-utils/src/filters/filterAsQuery.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ColumnDescriptorsByName,
   Filter,
   SingleValueFilterClause,
@@ -12,14 +12,24 @@ import {
 } from "./filter-utils";
 import { ScaledDecimal } from "../ScaledDecimal";
 
-const filterValue = (value: string | number | boolean | ScaledDecimal) =>
-  typeof value === "string"
-    ? stringIsValidLong(value)
-      ? value
-      : `"${value}"`
-    : value instanceof ScaledDecimal || typeof value === "bigint"
-      ? value.toString()
-      : value;
+const filterValue = (
+  value: string | number | boolean | ScaledDecimal,
+  columnType?: string,
+) => {
+  if (typeof value === "string") {
+    if (columnType !== undefined) {
+      // If we have precise type metadata, format numeric types without quotes,
+      // and string-like types with quotes.
+      const isNumericType = ["int", "long", "double"].includes(columnType);
+      return isNumericType ? value : `"${value}"`;
+    }
+    // If no metadata is present, do a safe regex boundary check.
+    return stringIsValidLong(value) ? value : `"${value}"`;
+  }
+  return value instanceof ScaledDecimal || typeof value === "bigint"
+    ? value.toString()
+    : value;
+};
 
 const quotedStrings = (value: string | number | boolean) =>
   typeof value === "string" ? `"${value}"` : value;
@@ -58,15 +68,18 @@ function singleValueFilterAsQuery(
   } else {
     const column = opts?.columnsByName?.[f.column];
     if (column && isDateTimeDataValue(column)) {
-      return dateFilterAsQuery(f as SingleValueFilterClause<number>);
+      return dateFilterAsQuery(f as SingleValueFilterClause<number>, opts);
     } else {
-      return defaultSingleValueFilterAsQuery(f);
+      return defaultSingleValueFilterAsQuery(f, opts);
     }
   }
 }
 
 export const ONE_DAY_IN_MILLIS = 1000 * 60 * 60 * 24;
-export function dateFilterAsQuery(f: SingleValueFilterClause<number>): string {
+export function dateFilterAsQuery(
+  f: SingleValueFilterClause<number>,
+  opts?: { columnsByName?: ColumnDescriptorsByName },
+): string {
   switch (f.op) {
     case "=": {
       const filters: Array<Filter> = [
@@ -77,7 +90,7 @@ export function dateFilterAsQuery(f: SingleValueFilterClause<number>): string {
           value: f.value + ONE_DAY_IN_MILLIS,
         },
       ];
-      return filterAsQueryCore({ op: "and", filters });
+      return filterAsQueryCore({ op: "and", filters }, opts);
     }
     case "!=": {
       const filters: Array<Filter> = [
@@ -88,12 +101,17 @@ export function dateFilterAsQuery(f: SingleValueFilterClause<number>): string {
           value: f.value + ONE_DAY_IN_MILLIS,
         },
       ];
-      return filterAsQueryCore({ op: "or", filters });
+      return filterAsQueryCore({ op: "or", filters }, opts);
     }
     default:
-      return defaultSingleValueFilterAsQuery(f);
+      return defaultSingleValueFilterAsQuery(f, opts);
   }
 }
 
-const defaultSingleValueFilterAsQuery = (f: SingleValueFilterClause) =>
-  `${f.column} ${f.op} ${filterValue(f.value)}`;
+const defaultSingleValueFilterAsQuery = (
+  f: SingleValueFilterClause,
+  opts?: { columnsByName?: ColumnDescriptorsByName },
+) => {
+  const columnType = opts?.columnsByName?.[f.column]?.serverDataType;
+  return `${f.column} ${f.op} ${filterValue(f.value, columnType)}`;
+};

--- a/vuu-ui/packages/vuu-utils/src/form-utils.ts
+++ b/vuu-ui/packages/vuu-utils/src/form-utils.ts
@@ -138,7 +138,7 @@ export function getTypedValue(
 
     case "long": {
       if (stringIsValidLong(value)) {
-        return BigInt(value);
+        return value;
       } else if (throwIfInvalid) {
         throw Error(`value ${value} is not a valid ${type}`);
       } else {

--- a/vuu-ui/packages/vuu-utils/test/filters/filterAsQuery.test.ts
+++ b/vuu-ui/packages/vuu-utils/test/filters/filterAsQuery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { filterAsQuery } from "../../src/filters";
-import { Filter, NumericFilterClauseOp } from "@vuu-ui/vuu-filter-types";
+import type { Filter, NumericFilterClauseOp } from "@vuu-ui/vuu-filter-types";
 import { dateFilterAsQuery } from "../../src/filters/filterAsQuery";
 
 describe("filterAsQuery", () => {
@@ -148,17 +148,71 @@ describe("filterAsQuery", () => {
       );
     });
   });
+
+  describe("numeric string values in string columns vs numeric columns", () => {
+    it("preserves quotes for numeric string values when column type is string", () => {
+      const result = filterAsQuery(
+        {
+          column: "ticker",
+          op: "=",
+          value: "1234",
+        },
+        {
+          columnsByName: {
+            ticker: { name: "ticker", serverDataType: "string" },
+          },
+        },
+      );
+      expect(result).toEqual('ticker = "1234"');
+    });
+
+    it("omits quotes for numeric string values when column type is numeric schema", () => {
+      const result = filterAsQuery(
+        {
+          column: "id",
+          op: "=",
+          value: "1000000000000001234",
+        },
+        {
+          columnsByName: {
+            id: { name: "id", serverDataType: "long" },
+          },
+        },
+      );
+      expect(result).toEqual("id = 1000000000000001234");
+    });
+
+    it("falls back safely to regex boundary classification if columnsByName metadata is absent", () => {
+      const result = filterAsQuery({
+        column: "id",
+        op: "=",
+        value: "1000000000000001234",
+      });
+      expect(result).toEqual("id = 1000000000000001234");
+    });
+
+    it("preserves quotes if string value is not numeric and no columnsByName metadata is present", () => {
+      const result = filterAsQuery({
+        column: "ticker",
+        op: "=",
+        value: "AAPL",
+      });
+      expect(result).toEqual('ticker = "AAPL"');
+    });
+  });
 });
 
 describe("dateFilterAsQuery", () => {
-  it.each<NumericFilterClauseOp>(["<", ">", "<=", ">="])(
-    "stringifies date filter with op `%s`",
-    (op) => {
-      const filter = { op, value: 1, column: "lastUpdated" } as const;
-      const expected = [filter.column, filter.op, filter.value].join(" ");
-      expect(dateFilterAsQuery(filter)).toEqual(expected);
-    },
-  );
+  it.each<NumericFilterClauseOp>([
+    "<",
+    ">",
+    "<=",
+    ">=",
+  ])("stringifies date filter with op `%s`", (op) => {
+    const filter = { op, value: 1, column: "lastUpdated" } as const;
+    const expected = [filter.column, filter.op, filter.value].join(" ");
+    expect(dateFilterAsQuery(filter)).toEqual(expected);
+  });
 
   const testDate = new Date("2021-12-15");
   testDate.setHours(0, 0, 0, 0);

--- a/vuu-ui/packages/vuu-utils/test/form-utils.test.ts
+++ b/vuu-ui/packages/vuu-utils/test/form-utils.test.ts
@@ -5,8 +5,8 @@ describe("getTypedValue", () => {
   it("handles int values", () => {
     expect(getTypedValue("1234", "int")).toEqual(1234);
     expect(getTypedValue("0", "int")).toEqual(0);
-    expect(getTypedValue("0", "long")).toEqual(0n);
-    expect(getTypedValue("123456789", "long")).toEqual(123456789n);
+    expect(getTypedValue("0", "long")).toEqual("0");
+    expect(getTypedValue("123456789", "long")).toEqual("123456789");
   });
   it("handles int number values", () => {
     expect(getTypedValue("0", "number")).toEqual(0);


### PR DESCRIPTION
This PR resolves the uncaught `TypeError: Do not know how to serialize BigInt` thrown during standard `editSession.addRow` calls (occurring during inline additions and CSV upload processes).

Cell inputs typed as `long` were cast into native `BigInt` wrappers locally on the client-side inside `getTypedValue` to assert integer boundaries. When these values were serialized into stringified WebSocket payloads, standard `JSON.stringify` failed. 