### PR TITLE
test: fix flaky playwright table scrolling test

### DIFF
--- a/vuu-ui/packages/vuu-chart/src/__tests__/__component__/Chart.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-chart/src/__tests__/__component__/Chart.playwright.test.tsx
@@ -39,18 +39,17 @@ test.describe("Chart examples", () => {
     await page.getByRole("radio", { name: "Edit" }).click();
     await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
 
-    const editHeight = (await chartElement.boundingBox())?.height;
-    const editSvgHeight = (await chartElement.locator("svg").boundingBox())
-      ?.height;
-    if (
-      viewHeight === undefined ||
-      editHeight === undefined ||
-      viewSvgHeight === undefined ||
-      editSvgHeight === undefined
-    ) {
+    if (viewHeight === undefined || viewSvgHeight === undefined) {
       throw Error("Unable to measure chart");
     }
-    await expect(editHeight).toBeLessThan(viewHeight);
-    await expect(editSvgHeight).toBeLessThan(viewSvgHeight);
+    await expect
+      .poll(async () => (await chartElement.boundingBox())?.height ?? 0)
+      .toBeLessThan(viewHeight);
+    await expect
+      .poll(
+        async () =>
+          (await chartElement.locator("svg").boundingBox())?.height ?? 0,
+      )
+      .toBeLessThan(viewSvgHeight);
   });
 });

--- a/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-scrolling.playwright.test.tsx
+++ b/vuu-ui/packages/vuu-table/src/__tests__/__component__/Table-scrolling.playwright.test.tsx
@@ -107,8 +107,9 @@ test.describe("Table scrolling and keyboard navigation", () => {
           await cell.press("End");
 
           cell = table.locateCell(1001, 1);
-          await expect(cell).toHaveAttribute("tabindex", "0");
           await table.assertRenderedRows({ from: 970, to: 1000 }, 5, 1000);
+          await expect(cell).toHaveAttribute("tabindex", "0");
+          await expect(cell).toBeFocused();
         });
       });
       test.describe("WHEN topmost rows are in viewport, cell mid viewport focussed and End key pressed ", () => {
@@ -125,8 +126,9 @@ test.describe("Table scrolling and keyboard navigation", () => {
           await cell.press("End");
 
           cell = table.locateCell(1001, 1);
-          await expect(cell).toHaveAttribute("tabindex", "0");
           await table.assertRenderedRows({ from: 970, to: 1000 }, 5, 1000);
+          await expect(cell).toHaveAttribute("tabindex", "0");
+          await expect(cell).toBeFocused();
         });
       });
       test.describe("Arrow Up / Down Keys", () => {


### PR DESCRIPTION
fix flaky tests in table scrolling and chart sizing
## Summary
- wait for virtualized end rows to finish rendering before asserting focus state
- assert the final cell is focused in both End-key scenarios

## Validation
- `components-webkit` Table scrolling suite: 13 passed