### PR TITLE
Improve CSV Upload error propagation

### DIFF
--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/CsvUpload.tsx
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/CsvUpload.tsx
@@ -11,7 +11,10 @@ import {
 import { useComponentCssInjection } from "@salt-ds/styles";
 import { useWindow } from "@salt-ds/window";
 import { type ReactNode, useCallback, useState } from "react";
-import type { RowDefaultDataItemValues, EditSession } from "@vuu-ui/vuu-data-editing";
+import type {
+  RowDefaultDataItemValues,
+  EditSession,
+} from "@vuu-ui/vuu-data-editing";
 import type { CsvParseError, CsvParseOptions } from "./parse/csv-parse";
 import type { CsvValidationStructuredError } from "./parse/csv-schema-validation";
 import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
@@ -90,6 +93,10 @@ export interface CsvUploadProps {
   parseOptions?: CsvParseOptions;
   importMode?: "direct" | "preview";
   rowDefaults?: RowDefaultDataItemValues;
+  /**
+   * Custom renderer for the error panel.
+   */
+  renderError?: (error: CsvUploadErrorResult) => ReactNode;
 }
 
 const classBase = "vuuCsvUpload";
@@ -102,6 +109,7 @@ export const CsvUpload = (props: CsvUploadProps) => {
     onCancel,
     onClose,
     open,
+    renderError,
   } = props;
   const isControlledOpen = open !== undefined;
   const [internalOpen, setInternalOpen] = useState(open ?? true);
@@ -125,6 +133,7 @@ export const CsvUpload = (props: CsvUploadProps) => {
     onTriggerChange,
     schema,
     validation,
+    error,
   } = useCsvUpload(props);
 
   const handleCancel = useCallback(async () => {
@@ -148,7 +157,9 @@ export const CsvUpload = (props: CsvUploadProps) => {
         disabled={schema === undefined || isProcessingFile || isImporting}
         onDrop={onDrop}
         status={
-          validation && validation.errors.length > 0 ? "error" : undefined
+          (validation && validation.errors.length > 0) || error
+            ? "error"
+            : undefined
         }
       >
         <FileDropZoneIcon />
@@ -159,7 +170,10 @@ export const CsvUpload = (props: CsvUploadProps) => {
               {validation.errors
                 .filter((e) => e.column in validation.errorMap.fileErrors)
                 .map((error, i) => (
-                  <li className={`${classBase}-errorItem`} key={i}>
+                  <li
+                    className={`${classBase}-errorItem`}
+                    key={`${error.column}-${error.message}-${i}`}
+                  >
                     {error.message}
                   </li>
                 ))}
@@ -173,6 +187,22 @@ export const CsvUpload = (props: CsvUploadProps) => {
           BROWSE FILES
         </FileDropZoneTrigger>
       </FileDropZone>
+      {error &&
+        (renderError ? (
+          renderError(error)
+        ) : (
+          <div className={`${classBase}-errors`}>
+            <div>
+              <strong>Import Error:</strong>
+            </div>
+            <div>
+              {error.errors.importError?.message ||
+                error.errors.schemaError?.message ||
+                error.errors.validationError?.message ||
+                "An unexpected error occurred during import."}
+            </div>
+          </div>
+        ))}
       {children}
     </div>
   );

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/README.md
@@ -48,6 +48,7 @@ import { CsvUpload } from "@vuu-ui/vuu-table-extras";
 | `onError` | `(result: CsvUploadErrorResult \| undefined) => void` | Fired when any error occurs. Called with `undefined` to clear a previous error. |
 | `onCancel` | `() => void` | Fired when the Cancel button is clicked. |
 | `onClose` | `() => void` | Fired after a successful import completes (i.e. the Import button was clicked and the session committed). |
+| `renderError` | `(error: CsvUploadErrorResult) => ReactNode` | Optional custom renderer for the error panel. Allows overriding the default inline error panel (e.g. to suppress or display errors in a separate element/dialog). |
 | `children` | `ReactNode` | Optional children rendered inside the dialog content area, below the drop zone. Typically used to display a read-only error table — see [Displaying validation errors](#displaying-validation-errors). |
 
 ---

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
@@ -4,7 +4,10 @@ import type {
   SessionDataSourceOverrides,
   TableSchema,
 } from "@vuu-ui/vuu-data-types";
-import { EditSession, type RowDefaultDataItemValues } from "@vuu-ui/vuu-data-editing";
+import {
+  EditSession,
+  type RowDefaultDataItemValues,
+} from "@vuu-ui/vuu-data-editing";
 import type { VuuRowDataItemType, VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { isRpcError, isSessionTable, useData, Range } from "@vuu-ui/vuu-utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -68,6 +71,7 @@ export type UseCsvUploadReturn = {
   sessionTable: CsvUploadSessionTable | undefined;
   schema: TableSchema | undefined;
   validation: CsvValidationResult | undefined;
+  error: CsvUploadErrorResult | undefined;
 };
 
 export const useCsvUpload = ({
@@ -97,6 +101,14 @@ export const useCsvUpload = ({
   const [fetchedImportSchema, setFetchedImportSchema] = useState<
     TableSchema | undefined
   >();
+  const [error, setError] = useState<CsvUploadErrorResult | undefined>();
+  const handleError = useCallback(
+    (errResult: CsvUploadErrorResult | undefined) => {
+      setError(errResult);
+      onError?.(errResult);
+    },
+    [onError],
+  );
 
   useEffect(() => {
     if (importSchema || importTable === undefined) {
@@ -124,14 +136,18 @@ export const useCsvUpload = ({
   }, [getServerAPI, importSchema, importTable]);
 
   const resolvedImportSchema = importSchema ?? fetchedImportSchema;
-  const sessionOverrides = useMemo<SessionDataSourceOverrides | undefined>(() => {
+  const sessionOverrides = useMemo<
+    SessionDataSourceOverrides | undefined
+  >(() => {
     const columns = resolvedImportSchema?.columns.map(({ name }) => name);
     return columns || importTable ? { columns, table: importTable } : undefined;
   }, [resolvedImportSchema, importTable]);
   // EditSession's constructor takes no session/schema config - the override is applied
   // here, at the createSessionDataSource call site, since `dataSource` is supplied by the
   // caller and may be shared with a view that has no knowledge of the import table.
-  const importDataSource = useMemo<EditApi & { tableSchema?: TableSchema }>(() => {
+  const importDataSource = useMemo<
+    EditApi & { tableSchema?: TableSchema }
+  >(() => {
     return {
       tableSchema: dataSource.tableSchema,
       createSessionDataSource: async (copyOption, sessionType) => {
@@ -306,7 +322,9 @@ export const useCsvUpload = ({
           return false;
         }
         try {
-          const payload = vuuMsg ? { vuuRowNum: rowNum, vuuMsg } : { ...rowData, vuuRowNum: rowNum, vuuMsg };
+          const payload = vuuMsg
+            ? { vuuRowNum: rowNum, vuuMsg }
+            : { ...rowData, vuuRowNum: rowNum, vuuMsg };
           const result = await editSession.addRow(payload);
           if (isRpcError(result)) {
             throw Error(result.errorMessage);
@@ -358,18 +376,17 @@ export const useCsvUpload = ({
 
   const cancelImport = useCallback(async () => {
     operationIdRef.current++;
-    try {
-      await processingPromiseRef.current;
-    } catch {
-      // File-processing errors are surfaced by handleFiles.
-    }
+    processingPromiseRef.current = undefined;
+    setIsProcessingFile(false);
+    setIsImporting(false);
+    handleError(undefined);
     await closePendingEditSession(false);
-  }, [closePendingEditSession]);
+  }, [closePendingEditSession, handleError]);
 
   const processFile = useCallback(
     async (file: File, operationId: number) => {
       setValidation(undefined);
-      onError?.(undefined);
+      handleError(undefined);
 
       await closePendingEditSession(false);
       if (operationId !== operationIdRef.current) {
@@ -382,7 +399,7 @@ export const useCsvUpload = ({
           dataSource.status === "unsubscribed")
       ) {
         const errorMessage = `CsvUpload requires dataSource to be subscribed before uploading (current status: "${dataSource.status}").`;
-        onError?.({
+        handleError({
           errors: {
             validationError: createUploadError("validation", errorMessage),
           },
@@ -405,7 +422,7 @@ export const useCsvUpload = ({
       const parsedCsv = parseCsv(fileContents, parseOptions);
       if (parsedCsv.error && hasFileParseErrors(parsedCsv.error)) {
         setValidation(undefined);
-        onError?.({
+        handleError({
           errors: {
             validationError: createUploadError(
               "validation",
@@ -423,7 +440,7 @@ export const useCsvUpload = ({
 
       if (Object.keys(schemaValidation.errorMap.fileErrors).length > 0) {
         setValidation(schemaValidation);
-        onError?.({
+        handleError({
           errors: {
             schemaError: createUploadError(
               "schema",
@@ -448,20 +465,28 @@ export const useCsvUpload = ({
       setValidation(mergedValidation);
 
       if (mergedValidation.rows.length > 0) {
-        await beginEditSession();
-        if (operationId !== operationIdRef.current) {
-          return;
-        }
-
         try {
+          await beginEditSession();
+          if (operationId !== operationIdRef.current) {
+            return;
+          }
+
           const rowsAdded = await addAllRows(mergedValidation, operationId);
           if (!rowsAdded) {
             return;
           }
         } catch (error) {
-          await endEditSessionAndNotify(false, "failed");
+          if (sessionDataSourceRef.current !== undefined) {
+            await endEditSessionAndNotify(false, "failed");
+          } else {
+            try {
+              await editSession.end(false);
+            } catch (err) {
+              console.error("[useCsvUpload] failed to end clean session", err);
+            }
+          }
           setValidation(undefined);
-          onError?.({
+          handleError({
             errors: {
               importError: createUploadError(
                 "import",
@@ -473,7 +498,8 @@ export const useCsvUpload = ({
       }
     },
     [
-      onError,
+      handleError,
+      editSession,
       addAllRows,
       maxRows,
       parseOptions,
@@ -516,7 +542,7 @@ export const useCsvUpload = ({
             ),
           },
         };
-        onError?.(errors);
+        handleError(errors);
       } finally {
         if (processingPromiseRef.current === processingPromise) {
           processingPromiseRef.current = undefined;
@@ -524,7 +550,7 @@ export const useCsvUpload = ({
         setIsProcessingFile(false);
       }
     },
-    [onError, onProcessingStarted, processFile, setActiveSessionDataSource],
+    [handleError, onProcessingStarted, processFile, setActiveSessionDataSource],
   );
 
   const onDrop = useCallback(
@@ -557,7 +583,7 @@ export const useCsvUpload = ({
     }
 
     setIsImporting(true);
-    onError?.(undefined);
+    handleError(undefined);
 
     try {
       const fallbackTableData = {
@@ -594,7 +620,7 @@ export const useCsvUpload = ({
           importError: createUploadError("import", errorMessage),
         },
       };
-      onError?.(errors);
+      handleError(errors);
       return false;
     } finally {
       setIsImporting(false);
@@ -603,7 +629,7 @@ export const useCsvUpload = ({
     canImport,
     editSession,
     endEditSessionAndNotify,
-    onError,
+    handleError,
     onImported,
     onPreview,
     importMode,
@@ -621,5 +647,6 @@ export const useCsvUpload = ({
     sessionTable,
     schema,
     validation,
+    error,
   };
 };

--- a/vuu-ui/showcase/src/examples/TableExtras/CsvUpload.examples.tsx
+++ b/vuu-ui/showcase/src/examples/TableExtras/CsvUpload.examples.tsx
@@ -1,10 +1,17 @@
 import {
   CsvUpload,
+  type CsvUploadErrorResult,
 } from "@vuu-ui/vuu-table-extras";
 import type { DataSource, TableSchema } from "@vuu-ui/vuu-data-types";
 import type { VuuRowDataItemType, VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { useCallback, useMemo, useState } from "react";
-import { Button } from "@salt-ds/core";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogHeader,
+} from "@salt-ds/core";
 import { LocalDataSourceProvider, simulModule } from "@vuu-ui/vuu-data-test";
 import { Table } from "@vuu-ui/vuu-table";
 import type { TableConfig } from "@vuu-ui/vuu-table-types";
@@ -238,6 +245,116 @@ export const CsvUploadWithImportTableOnly = () => {
         importTable={{ module: "SIMUL", table: "instruments" }}
       />
     </LocalDataSourceProvider>
+  );
+};
+
+export const CsvUploadWithImportFailure = () => {
+  const [capturedError, setCapturedError] = useState<string | undefined>();
+  const dataSource = useMemo(() => {
+    const sessionDs = {
+      table: { module: "TEST", table: "session-items" },
+      tableSchema: rowDefaultsSchema,
+      columns: ["id", "name"],
+      addRow: async () => {
+        return {
+          type: "ERROR_RESULT" as const,
+          errorMessage: "Database duplicate key constraint violated on row inserter.",
+        };
+      },
+      endEditSession: async () => void 0,
+    };
+    return {
+      table: { module: "TEST", table: "items" },
+      tableSchema: rowDefaultsSchema,
+      createSessionDataSource: async () => sessionDs as unknown as DataSource,
+      subscribe: async () => void 0,
+      unsubscribe: () => void 0,
+    } as unknown as DataSource;
+  }, []);
+
+  return (
+    <div style={{ display: "grid", gap: "10px" }}>
+      <h3>Simulated Failing RPC Upload</h3>
+      <p>
+        In this example, dropping or selecting any valid <code>.csv</code> file will trigger a simulated RPC failure inside <code>addRow</code>.
+        This demonstrates the dynamic propagation of backend insert errors to the UI below the DropZone.
+      </p>
+      <CsvUpload
+        dataSource={dataSource}
+        onError={(errResult) => {
+          setCapturedError(errResult?.errors.importError?.message);
+        }}
+      />
+      {capturedError && (
+        <div style={{ marginTop: 10, color: "var(--salt-status-error-foreground)" }} data-testid="test-error-output">
+          <strong>Captured onError callback:</strong> {capturedError}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const CsvUploadWithExternalErrorDialog = () => {
+  const [errorResult, setErrorResult] = useState<CsvUploadErrorResult | undefined>();
+  const [isErrorDialogOpen, setIsErrorDialogOpen] = useState(false);
+
+  const dataSource = useMemo(() => {
+    const sessionDs = {
+      table: { module: "TEST", table: "session-items" },
+      tableSchema: rowDefaultsSchema,
+      columns: ["id", "name"],
+      addRow: async () => {
+        return {
+          type: "ERROR_RESULT" as const,
+          errorMessage: "Unable to insert records. Staging connection interrupted.",
+        };
+      },
+      endEditSession: async () => void 0,
+    };
+    return {
+      table: { module: "TEST", table: "items" },
+      tableSchema: rowDefaultsSchema,
+      createSessionDataSource: async () => sessionDs as unknown as DataSource,
+      subscribe: async () => void 0,
+      unsubscribe: () => void 0,
+    } as unknown as DataSource;
+  }, []);
+
+  const handleError = useCallback((errResult: CsvUploadErrorResult | undefined) => {
+    if (errResult) {
+      setErrorResult(errResult);
+      setIsErrorDialogOpen(true);
+    } else {
+      setErrorResult(undefined);
+    }
+  }, []);
+
+  return (
+    <div style={{ display: "grid", gap: "10px" }}>
+      <h3>Failing RPC Upload with Custom Dialog Error</h3>
+      <p>
+        In this example, the default inline error panel is suppressed by passing <code>{`renderError={() => null}`}</code>. 
+        Instead, errors are intercepted via <code>onError</code> and rendered in a fully styled Salt <code>Dialog</code> container.
+      </p>
+      <CsvUpload
+        dataSource={dataSource}
+        onError={handleError}
+        renderError={() => null}
+      />
+
+      <Dialog open={isErrorDialogOpen} onOpenChange={setIsErrorDialogOpen}>
+        <DialogHeader header="Custom Dialog: Import Failed" />
+        <DialogContent>
+          <div style={{ padding: 16, color: "var(--salt-status-error-foreground)" }}>
+            <p><strong>System Exception Detected:</strong></p>
+            <p>{errorResult?.errors.importError?.message || "An unexpected error occurred during database injection."}</p>
+          </div>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setIsErrorDialogOpen(false)}>Acknowledge</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
   );
 };
 


### PR DESCRIPTION
- Prevent cancel operations from hanging when RPC calls or validations stall.
- Implement UI error propagation for backend and schema validation failures.
- Introduce customizable `renderError` function prop to support custom dialogs/banners.
- Update CsvUpload README documentation.
