### PR TITLE
Refactor edit-session counters

### DIFF
--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -338,8 +338,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     }
 
     // We rely purely on the datasource-supplied selectedRowsCount for counting deletions
-    // since the service layer does not provide deletedKeys.
-    // Capture this before the RPC call since execution deselects the deleted rows.
+    // captured before the RPC call since execution deselects the deleted rows.
     const selectedRowsCount = this.dataSource?.selectedRowsCount ?? 0;
 
     const response = await deleteSelectedRows.call(

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -2,7 +2,6 @@ import type {
   CopyOption,
   DataSource,
   DeleteRowMode,
-  DeleteSelectedRowsResult,
   EditApi,
   EditSessionMode,
   SchemaColumn,
@@ -13,11 +12,10 @@ import type { RpcResult, VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
 import { EventEmitter, isRpcError, StaleUpdateError } from "@vuu-ui/vuu-utils";
 
 export type EditState = "clean" | "dirty" | "invalid" | "stale";
+export type EditActionType = "deleteRow" | "addRow" | "editCell";
 /** Column name to default value mapping applied to every addRow call when a column is absent from the row data. */
 export type RowDefaultDataItemValues = Record<string, VuuRowDataItemType>;
-export type EditSessionApi =
-  | "createSessionDataSource"
-  | "beginEditSession";
+export type EditSessionApi = "createSessionDataSource" | "beginEditSession";
 
 export type EditSessionConstructorProps = {
   dataSource: EditApi;
@@ -88,9 +86,6 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
    *  Row key => row edits
    */
   #rowEdits = new Map<string, RowEditDetails>();
-  #deletedRows = new Set<string>();
-  #deleteRevision = 0;
-  #rowDeleteRevisions = new Map<string, number>();
   #editCount = 0;
   #deleteCount = 0;
   #addCount = 0;
@@ -125,49 +120,23 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     this.#sourceTableDataSource = dataSource;
     this.#deleteMode = deleteMode;
     this.#editSessionApi = editSessionApi;
-    this.#rowDefaults = rowDefaults;
+    this.#rowDefaults = { ...rowDefaults };
   }
 
   get editCount() {
     return this.#editCount;
   }
 
-  set editCount(val: number) {
-    this.#setEditCounts(val, this.#invalidCount);
-  }
-
   get invalidCount() {
     return this.#invalidCount;
-  }
-
-  set invalidCount(val: number) {
-    this.#setEditCounts(this.#editCount, val);
   }
 
   get deleteCount() {
     return this.#deleteCount;
   }
 
-  set deleteCount(val: number) {
-    if (val !== this.#deleteCount) {
-      const oldState = this.editState;
-      const oldCount = this.#deleteCount;
-      this.#deleteCount = val;
-      this.#emitEditStateChange(oldState, oldCount === 0 || val === 0);
-    }
-  }
-
   get addCount() {
     return this.#addCount;
-  }
-
-  set addCount(val: number) {
-    if (val !== this.#addCount) {
-      const oldState = this.editState;
-      const oldCount = this.#addCount;
-      this.#addCount = val;
-      this.#emitEditStateChange(oldState, oldCount === 0 || val === 0);
-    }
   }
 
   get editState(): EditState {
@@ -200,27 +169,30 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     }
   }
 
+  #setDeleteCount(val: number) {
+    if (val !== this.#deleteCount) {
+      const oldState = this.editState;
+      const oldCount = this.#deleteCount;
+      this.#deleteCount = val;
+      this.#emitEditStateChange(oldState, oldCount === 0 || val === 0);
+    }
+  }
+
+  #setAddCount(val: number) {
+    if (val !== this.#addCount) {
+      const oldState = this.editState;
+      const oldCount = this.#addCount;
+      this.#addCount = val;
+      this.#emitEditStateChange(oldState, oldCount === 0 || val === 0);
+    }
+  }
+
   #setStale(isStale: boolean) {
     if (isStale !== this.#isStale) {
       const oldState = this.editState;
       this.#isStale = isStale;
       this.#emitEditStateChange(oldState);
     }
-  }
-
-  #refreshEditCounts() {
-    let editCount = 0;
-    let invalidCount = 0;
-    for (const { cellEdits } of this.#rowEdits.values()) {
-      for (const cellEdit of cellEdits.values()) {
-        if (cellEdit.isValid) {
-          editCount++;
-        } else {
-          invalidCount++;
-        }
-      }
-    }
-    this.#setEditCounts(editCount, invalidCount);
   }
 
   get newRowState(): NewRowState {
@@ -236,7 +208,8 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   }
 
   isNewRowComplete() {
-    const requiredColumns = this.#newRowState.requiredColumns ?? this.#newRowState.columns;
+    const requiredColumns =
+      this.#newRowState.requiredColumns ?? this.#newRowState.columns;
     return requiredColumns.every((column) => {
       const value = this.#newRowState.values[column];
       return (
@@ -246,19 +219,22 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     });
   }
 
-  configureNewRow(columns: readonly string[], requiredColumns?: readonly string[]) {
+  configureNewRow(
+    columns: readonly string[],
+    requiredColumns?: readonly string[],
+  ) {
     if (
       columns.length === this.#newRowState.columns.length &&
       columns.every(
         (column, index) => column === this.#newRowState.columns[index],
       ) &&
-      (!requiredColumns || (
-        this.#newRowState.requiredColumns !== undefined &&
-        requiredColumns.length === this.#newRowState.requiredColumns.length &&
-        requiredColumns.every(
-          (column, index) => column === this.#newRowState.requiredColumns?.[index],
-        )
-      ))
+      (!requiredColumns ||
+        (this.#newRowState.requiredColumns !== undefined &&
+          requiredColumns.length === this.#newRowState.requiredColumns.length &&
+          requiredColumns.every(
+            (column, index) =>
+              column === this.#newRowState.requiredColumns?.[index],
+          )))
     ) {
       return;
     }
@@ -288,7 +264,8 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   }
 
   async addNewRow(): Promise<RpcResult> {
-    const requiredColumns = this.#newRowState.requiredColumns ?? this.#newRowState.columns;
+    const requiredColumns =
+      this.#newRowState.requiredColumns ?? this.#newRowState.columns;
     const missingErrors = Object.fromEntries(
       requiredColumns
         .filter((column) => {
@@ -355,26 +332,29 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     this.emit("newRow", newRowState);
   }
 
-  async deleteSelectedRows(): Promise<void> {
-    const response = await this.dataSource?.deleteSelectedRows?.(
+  async deleteSelectedRows(selectedRowCount: number): Promise<RpcResult> {
+    const deleteSelectedRows = this.dataSource?.deleteSelectedRows;
+    if (deleteSelectedRows === undefined) {
+      throw Error("[EditSession] datasource does not support deleting rows");
+    }
+
+    const response = await deleteSelectedRows.call(
+      this.dataSource,
       this.#deleteMode,
     );
-    if (isRpcError(response)) return;
-    const deletedKeys = (response?.data as DeleteSelectedRowsResult | undefined)
-      ?.deletedKeys;
-    if (deletedKeys && deletedKeys.length > 0) {
-      let newCount = 0;
-      for (const key of deletedKeys) {
-        this.#rowDeleteRevisions.set(key, ++this.#deleteRevision);
-        if (!this.#deletedRows.has(key)) {
-          this.#deletedRows.add(key);
-          newCount++;
-        }
-      }
-      if (newCount > 0) {
-        this.deleteCount = this.#deleteCount + newCount;
-      }
+    if (response === undefined) {
+      throw Error(
+        "[EditSession] datasource returned no response when deleting rows",
+      );
     }
+    if (isRpcError(response)) return response;
+
+    // We rely purely on the consumer-supplied selectedRowCount for counting deletions
+    // since the service layer does not provide deletedKeys.
+    if (selectedRowCount > 0) {
+      this.#setDeleteCount(this.#deleteCount + selectedRowCount);
+    }
+    return response;
   }
 
   async addRow(
@@ -385,30 +365,23 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
       throw Error("[EditSession] datasource does not support adding rows");
     }
 
-    const response = await addRow.call(this.dataSource, { ...this.#rowDefaults, ...rowData });
+    const response = await addRow.call(this.dataSource, {
+      ...this.#rowDefaults,
+      ...rowData,
+    });
     if (response === undefined) {
       throw Error(
         "[EditSession] datasource returned no response when adding row",
       );
     }
     if (!isRpcError(response)) {
-      this.addCount = this.#addCount + 1;
+      this.#setAddCount(this.#addCount + 1);
     }
     return response;
   }
 
-  restoreRows(keys: string[]) {
-    for (const key of keys) {
-      if (this.#deletedRows.has(key)) {
-        this.#deletedRows.delete(key);
-        this.#rowDeleteRevisions.delete(key);
-        this.deleteCount = this.#deleteCount - 1;
-      }
-    }
-  }
-
   hasRowChanges(key: string): boolean {
-    return this.#rowEdits.has(key) || this.#deletedRows.has(key);
+    return this.#rowEdits.has(key);
   }
 
   isCellEdited(key: string, columnName: string): boolean {
@@ -419,28 +392,45 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     );
   }
 
-  async undoRowChange(key: string): Promise<void> {
+  async undoRowChange(
+    key: string,
+    action: EditActionType,
+  ): Promise<RpcResult | undefined> {
     if (!this.inEditMode) return;
 
     const undoRevision = this.#commitRevision;
-    const deleteRevisionAtRequest = this.#rowDeleteRevisions.get(key);
     const rowEditsAtRequest = this.#rowEdits.get(key);
     const columnsAtRequest = new Set(rowEditsAtRequest?.cellEdits.keys());
-    const wasDeleted = this.#deletedRows.has(key);
     const response = await this.dataSource?.undoRowChange?.(key);
 
-    if (isRpcError(response)) {
-      return;
+    if (response === undefined) {
+      return undefined;
     }
+    if (isRpcError(response)) {
+      return response;
+    }
+
+    const oldState = this.editState;
 
     const rowEdits = this.#rowEdits.get(key);
     if (rowEdits) {
       const changedColumns: string[] = [];
+      let removedValidCount = 0;
+      let removedInvalidCount = 0;
+
       for (const columnName of columnsAtRequest) {
         const latestRevision =
           this.#cellCommitRevisions.get(key)?.get(columnName) ?? 0;
         if (latestRevision > undoRevision) {
           continue;
+        }
+        const existing = rowEdits.cellEdits.get(columnName);
+        if (existing) {
+          if (existing.isValid) {
+            removedValidCount++;
+          } else {
+            removedInvalidCount++;
+          }
         }
         if (this.isCellEdited(key, columnName)) {
           changedColumns.push(columnName);
@@ -451,28 +441,31 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
       if (rowEdits.cellEdits.size === 0) {
         this.#rowEdits.delete(key);
       }
-      this.#refreshEditCounts();
+
+      this.#editCount -= removedValidCount;
+      this.#invalidCount -= removedInvalidCount;
+
       for (const columnName of changedColumns) {
         this.emit("cellEditChanged", key, columnName);
       }
     }
-    if (
-      wasDeleted &&
-      this.#deletedRows.has(key) &&
-      this.#rowDeleteRevisions.get(key) === deleteRevisionAtRequest
-    ) {
-      this.#deletedRows.delete(key);
-      this.#rowDeleteRevisions.delete(key);
-      this.deleteCount = this.#deleteCount - 1;
+
+    if (action === "deleteRow") {
+      this.#deleteCount--;
     }
 
     // If the server deleted a newly inserted row, decrement addCount
     const wasInsertedRow =
+      action === "addRow" ||
       (response?.data as UndoRowChangeResult | undefined)?.wasInsertedRow ===
-      true;
+        true;
     if (wasInsertedRow) {
-      this.addCount = this.#addCount - 1;
+      this.#addCount--;
     }
+
+    this.#emitEditStateChange(oldState);
+
+    return response;
   }
 
   #clearEdits() {
@@ -483,8 +476,6 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
         .map((columnName) => [key, columnName] as const),
     );
     this.#rowEdits.clear();
-    this.#deletedRows.clear();
-    this.#rowDeleteRevisions.clear();
     this.#cellCommitRevisions.clear();
     this.#editCount = 0;
     this.#deleteCount = 0;
@@ -520,7 +511,10 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     return result;
   }
 
-  begin(copyOption: CopyOption = "All", sessionType: SessionType = "edit"): Promise<DataSource> {
+  begin(
+    copyOption: CopyOption = "All",
+    sessionType: SessionType = "edit",
+  ): Promise<DataSource> {
     return this.#enqueue(async () => {
       if (
         this.#lifecycle.status === "active" ||
@@ -571,7 +565,6 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
         this.#setLifecycle({ status: "error", operation: "begin", error });
         throw error;
       }
-
     });
   }
 
@@ -702,12 +695,47 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
       isValid,
     };
 
-    if (isValid && cellEdit.originalValue === editedValue) {
+    // Keep track of counts before change
+    let prevValidCount = 0;
+    let prevInvalidCount = 0;
+    if (existingCellEdit) {
+      if (existingCellEdit.isValid) {
+        prevValidCount = 1;
+      } else {
+        prevInvalidCount = 1;
+      }
+    }
+
+    let nextValidCount = 0;
+    let nextInvalidCount = 0;
+
+    const isRevertedToOriginal =
+      isValid && cellEdit.originalValue === editedValue;
+    if (isRevertedToOriginal) {
       cellEdits.delete(column);
+      if (cellEdits.size === 0) {
+        this.#rowEdits.delete(key);
+      }
     } else {
       cellEdits.set(column, cellEdit);
+      if (isValid) {
+        nextValidCount = 1;
+      } else {
+        nextInvalidCount = 1;
+      }
     }
-    this.#refreshEditCounts();
+
+    // Incremental counter adjustment
+    const editCountDiff = nextValidCount - prevValidCount;
+    const invalidCountDiff = nextInvalidCount - prevInvalidCount;
+
+    if (editCountDiff !== 0 || invalidCountDiff !== 0) {
+      this.#setEditCounts(
+        this.#editCount + editCountDiff,
+        this.#invalidCount + invalidCountDiff,
+      );
+    }
+
     if (wasEdited !== this.isCellEdited(key, column)) {
       this.emit("cellEditChanged", key, column);
     }
@@ -763,6 +791,10 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
           columnName,
           typedValue,
         );
+        if (!this.inEditMode) {
+          // Edit session ended in the meantime; exit gracefully.
+          return { data: undefined, type: "SUCCESS_RESULT" };
+        }
         if (!this.#isLatestCellCommit(key, columnName, revision)) {
           throw new SupersededEditError(
             `Edit response superseded for ${key}:${columnName}`,

--- a/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/EditSession.tsx
@@ -2,7 +2,6 @@ import type {
   CopyOption,
   DataSource,
   DeleteRowMode,
-  EditApi,
   EditSessionMode,
   SchemaColumn,
   SessionType,
@@ -18,7 +17,7 @@ export type RowDefaultDataItemValues = Record<string, VuuRowDataItemType>;
 export type EditSessionApi = "createSessionDataSource" | "beginEditSession";
 
 export type EditSessionConstructorProps = {
-  dataSource: EditApi;
+  dataSource: DataSource;
   /** @default "soft" */
   deleteMode?: DeleteRowMode;
   /** @default "createSessionDataSource" */
@@ -96,7 +95,7 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
   #deleteMode: DeleteRowMode;
   #editSessionApi: EditSessionApi;
   #rowDefaults: RowDefaultDataItemValues;
-  #sourceTableDataSource?: EditApi;
+  #sourceTableDataSource?: DataSource;
   #sessionDataSource?: DataSource;
   #newRowState: NewRowState = {
     columns: [],
@@ -332,11 +331,16 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     this.emit("newRow", newRowState);
   }
 
-  async deleteSelectedRows(selectedRowCount: number): Promise<RpcResult> {
+  async deleteSelectedRows(): Promise<RpcResult> {
     const deleteSelectedRows = this.dataSource?.deleteSelectedRows;
     if (deleteSelectedRows === undefined) {
       throw Error("[EditSession] datasource does not support deleting rows");
     }
+
+    // We rely purely on the datasource-supplied selectedRowsCount for counting deletions
+    // since the service layer does not provide deletedKeys.
+    // Capture this before the RPC call since execution deselects the deleted rows.
+    const selectedRowsCount = this.dataSource?.selectedRowsCount ?? 0;
 
     const response = await deleteSelectedRows.call(
       this.dataSource,
@@ -349,10 +353,8 @@ export class EditSession extends EventEmitter<EditSessionEvents> {
     }
     if (isRpcError(response)) return response;
 
-    // We rely purely on the consumer-supplied selectedRowCount for counting deletions
-    // since the service layer does not provide deletedKeys.
-    if (selectedRowCount > 0) {
-      this.#setDeleteCount(this.#deleteCount + selectedRowCount);
+    if (selectedRowsCount > 0) {
+      this.#setDeleteCount(this.#deleteCount + selectedRowsCount);
     }
     return response;
   }

--- a/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
+++ b/vuu-ui/packages/vuu-data-editing/src/UndoCellRenderer.tsx
@@ -7,6 +7,7 @@ import type {
 import { Icon } from "@vuu-ui/vuu-ui-controls";
 import { registerComponent } from "@vuu-ui/vuu-utils";
 import { useEditSession } from "./DataEditingProvider";
+import type { EditActionType } from "./EditSession";
 
 export const UNDO_CELL_RENDERER = "vuu.undo-cell";
 
@@ -25,9 +26,7 @@ export const getUndoButtonContent = (
       : componentProps.text || undefined,
 });
 
-export const getUndoTooltipContent = (
-  action: unknown,
-) =>
+export const getUndoTooltipContent = (action: unknown) =>
   action === "deleteRow"
     ? "Undo delete row"
     : action === "addRow"
@@ -46,9 +45,7 @@ export const UndoCellRenderer = ({
   const { icon, text } = getUndoButtonContent(
     renderer?.componentProps as UndoCellRendererComponentProps | undefined,
   );
-  const tooltipContent = getUndoTooltipContent(
-    dataRow.vuuAction,
-  );
+  const tooltipContent = getUndoTooltipContent(dataRow.vuuAction);
 
   if (tooltipContent === undefined) return null;
 
@@ -57,7 +54,12 @@ export const UndoCellRenderer = ({
       <Button
         appearance="transparent"
         aria-label={tooltipContent}
-        onClick={() => editSession?.undoRowChange(dataRow.key)}
+        onClick={() =>
+          editSession?.undoRowChange(
+            dataRow.key,
+            dataRow.vuuAction as EditActionType,
+          )
+        }
         style={{ height: "100%", width: "100%" }}
       >
         {icon ? <Icon name={icon} /> : null}

--- a/vuu-ui/packages/vuu-data-editing/src/index.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/index.ts
@@ -16,6 +16,7 @@ export {
   EditError,
   EditSession,
   SupersededEditError,
+  type EditActionType,
   type EditLifecycle,
   type EditSessionConstructorProps,
   type NewRowState,

--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -9,6 +9,7 @@ import { useData, useLayoutEffectSkipFirst } from "@vuu-ui/vuu-utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   EditSession,
+  type EditActionType,
   type EditLifecycle,
   type EditSessionApi,
   type EditState,
@@ -124,11 +125,12 @@ export const useEditableTable = ({
   );
 
   const handleDelete = useCallback(async () => {
-    await editSession.deleteSelectedRows();
-  }, [editSession]);
+    await editSession.deleteSelectedRows(selectionCount);
+  }, [editSession, selectionCount]);
 
   const handleUndoRowChange = useCallback(
-    (key: string) => void editSession.undoRowChange(key),
+    (key: string, action: EditActionType) =>
+      void editSession.undoRowChange(key, action),
     [editSession],
   );
 

--- a/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
+++ b/vuu-ui/packages/vuu-data-editing/src/useEditableTable.ts
@@ -2,7 +2,6 @@ import type {
   CopyOption,
   DataSource,
   DeleteRowMode,
-  EditApi,
 } from "@vuu-ui/vuu-data-types";
 import type { VuuTable } from "@vuu-ui/vuu-protocol-types";
 import { useData, useLayoutEffectSkipFirst } from "@vuu-ui/vuu-utils";
@@ -81,7 +80,7 @@ export const useEditableTable = ({
   const editSession = useMemo(
     () =>
       new EditSession({
-        dataSource: sourceDataSource as EditApi,
+        dataSource: sourceDataSource,
         deleteMode,
         editSessionApi,
         rowDefaults,
@@ -125,8 +124,8 @@ export const useEditableTable = ({
   );
 
   const handleDelete = useCallback(async () => {
-    await editSession.deleteSelectedRows(selectionCount);
-  }, [editSession, selectionCount]);
+    await editSession.deleteSelectedRows();
+  }, [editSession]);
 
   const handleUndoRowChange = useCallback(
     (key: string, action: EditActionType) =>

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -45,7 +45,7 @@ class MockDataSource implements EditApi {
     private createSession: CreateSession,
     private edit: EditCell = vi.fn().mockResolvedValue(SUCCESS),
     private addRowImpl?: AddRow,
-  ) { }
+  ) {}
 
   addRow(...args: Parameters<AddRow>) {
     return this.addRowImpl?.(...args);
@@ -107,7 +107,9 @@ describe("EditSession lifecycle", () => {
       data: undefined,
       type: "SUCCESS_RESULT",
     });
-    editSession = new EditSession({ dataSource: new MockDataSource(endEdit, createSession, editCell, addRow) });
+    editSession = new EditSession({
+      dataSource: new MockDataSource(endEdit, createSession, editCell, addRow),
+    });
 
     await editSession.addRow({ id: 7, name: "Alice" });
 
@@ -120,7 +122,9 @@ describe("EditSession lifecycle", () => {
       errorMessage: "Insert rejected",
       type: "ERROR_RESULT",
     });
-    editSession = new EditSession({ dataSource: new MockDataSource(endEdit, createSession, editCell, addRow) });
+    editSession = new EditSession({
+      dataSource: new MockDataSource(endEdit, createSession, editCell, addRow),
+    });
 
     await editSession.addRow({ id: 7 });
 
@@ -129,7 +133,9 @@ describe("EditSession lifecycle", () => {
 
   it("owns draft values and required-field errors for a new row", async () => {
     const addRow = vi.fn<AddRow>().mockResolvedValue(SUCCESS);
-    editSession = new EditSession({ dataSource: new MockDataSource(endEdit, createSession, editCell, addRow) });
+    editSession = new EditSession({
+      dataSource: new MockDataSource(endEdit, createSession, editCell, addRow),
+    });
     editSession.configureNewRow(["id", "name"]);
     editSession.setNewRowValue("id", 7);
     expect(editSession.isNewRowComplete()).toBe(false);
@@ -151,7 +157,9 @@ describe("EditSession lifecycle", () => {
 
   it("allows some columns to be optional for a new row", async () => {
     const addRow = vi.fn<AddRow>().mockResolvedValue(SUCCESS);
-    editSession = new EditSession({ dataSource: new MockDataSource(endEdit, createSession, editCell, addRow) });
+    editSession = new EditSession({
+      dataSource: new MockDataSource(endEdit, createSession, editCell, addRow),
+    });
     editSession.configureNewRow(["id", "name", "description"], ["id", "name"]);
     editSession.setNewRowValue("id", 7);
     expect(editSession.isNewRowComplete()).toBe(false);
@@ -174,7 +182,9 @@ describe("EditSession lifecycle", () => {
   it("prevents duplicate new-row submissions", async () => {
     const pendingAdd = deferred<RpcResultSuccess>();
     const addRow = vi.fn<AddRow>().mockReturnValue(pendingAdd.promise);
-    editSession = new EditSession({ dataSource: new MockDataSource(endEdit, createSession, editCell, addRow) });
+    editSession = new EditSession({
+      dataSource: new MockDataSource(endEdit, createSession, editCell, addRow),
+    });
     editSession.configureNewRow(["id"]);
     editSession.setNewRowValue("id", 7);
 
@@ -390,7 +400,9 @@ describe("EditSession lifecycle", () => {
   it("reports begin failures without entering edit mode", async () => {
     const beginError = new Error("begin failed");
     createSession = vi.fn().mockRejectedValueOnce(beginError);
-    editSession = new EditSession({ dataSource: new MockDataSource(endEdit, createSession) });
+    editSession = new EditSession({
+      dataSource: new MockDataSource(endEdit, createSession),
+    });
 
     await expect(editSession.begin()).rejects.toBe(beginError);
 
@@ -552,7 +564,7 @@ describe("EditSession lifecycle", () => {
     await editSession.begin();
     await editSession.commit("row-1", "price", 100, 101, true);
 
-    const undo = editSession.undoRowChange("row-1");
+    const undo = editSession.undoRowChange("row-1", "editCell");
     await editSession.commit("row-1", "size", 10, 11, true);
     pendingUndo.resolve(SUCCESS);
     await undo;
@@ -562,33 +574,6 @@ describe("EditSession lifecycle", () => {
     expect([editSession.editCount, editSession.invalidCount]).toEqual([1, 0]);
   });
 
-  it("does not let an older undo clear a newer row deletion", async () => {
-    const pendingUndo = deferred<RpcResultSuccess>();
-    const deleteSelectedRows = vi.fn().mockResolvedValue({
-      data: { deletedKeys: ["row-1"] },
-      type: "SUCCESS_RESULT",
-    });
-    const dataSource: EditApi = {
-      createSessionDataSource: vi.fn(
-        async () => dataSource as unknown as DataSource,
-      ),
-      deleteSelectedRows,
-      endEditSession: vi.fn(),
-      undoRowChange: vi.fn().mockReturnValue(pendingUndo.promise),
-    };
-    editSession = new EditSession({ dataSource: dataSource });
-    await editSession.begin();
-    await editSession.deleteSelectedRows();
-
-    const undo = editSession.undoRowChange("row-1");
-    await editSession.deleteSelectedRows();
-    pendingUndo.resolve(SUCCESS);
-    await undo;
-
-    expect(editSession.hasRowChanges("row-1")).toBe(true);
-    expect(editSession.deleteCount).toBe(1);
-  });
-
   it("notifies delete count boundaries while cell edits keep the session dirty", async () => {
     const states: string[] = [];
     editSession.on("editState", (state) => states.push(state));
@@ -596,11 +581,16 @@ describe("EditSession lifecycle", () => {
     await editSession.commit("row-1", "price", 100, 101, true);
     states.length = 0;
 
-    editSession.deleteCount = 1;
-    editSession.deleteCount = 0;
+    const deleteSelectedRows = vi.fn().mockResolvedValue({
+      type: "SUCCESS_RESULT",
+    });
+    (
+      editSession.dataSource as unknown as Record<string, unknown>
+    ).deleteSelectedRows = deleteSelectedRows;
 
-    expect(states).toEqual(["dirty", "dirty"]);
+    await editSession.deleteSelectedRows(1);
+
+    expect(states).toEqual(["dirty"]);
     expect(editSession.editState).toBe("dirty");
   });
 });
-

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.lifecycle.test.ts
@@ -1,4 +1,4 @@
-import type { DataSource, EditApi } from "@vuu-ui/vuu-data-types";
+import type { DataSource } from "@vuu-ui/vuu-data-types";
 import type {
   RpcResultError,
   RpcResultSuccess,
@@ -27,7 +27,7 @@ vi.hoisted(() => {
   vi.stubGlobal("Worker", MockWorker);
 });
 
-type Editable = Required<EditApi>;
+type Editable = Required<DataSource>;
 type AddRow = Editable["addRow"];
 type CreateSession = Editable["createSessionDataSource"];
 type EndEdit = Editable["endEditSession"];
@@ -39,7 +39,7 @@ const ERROR: RpcResultError = {
   errorMessage: "edit rejected",
 };
 
-class MockDataSource implements EditApi {
+class MockDataSource {
   constructor(
     private endEdit: EndEdit,
     private createSession: CreateSession,
@@ -86,7 +86,7 @@ describe("EditSession lifecycle", () => {
     createSession = vi.fn(
       async () => dataSource as unknown as DataSource,
     ) as CreateSession;
-    const dataSource = new MockDataSource(endEdit, createSession, editCell);
+    const dataSource = new MockDataSource(endEdit, createSession, editCell) as unknown as DataSource;
     editSession = new EditSession({ dataSource: dataSource });
   });
 
@@ -108,7 +108,7 @@ describe("EditSession lifecycle", () => {
       type: "SUCCESS_RESULT",
     });
     editSession = new EditSession({
-      dataSource: new MockDataSource(endEdit, createSession, editCell, addRow),
+      dataSource: new MockDataSource(endEdit, createSession, editCell, addRow) as unknown as DataSource,
     });
 
     await editSession.addRow({ id: 7, name: "Alice" });
@@ -123,7 +123,7 @@ describe("EditSession lifecycle", () => {
       type: "ERROR_RESULT",
     });
     editSession = new EditSession({
-      dataSource: new MockDataSource(endEdit, createSession, editCell, addRow),
+      dataSource: new MockDataSource(endEdit, createSession, editCell, addRow) as unknown as DataSource,
     });
 
     await editSession.addRow({ id: 7 });
@@ -552,14 +552,14 @@ describe("EditSession lifecycle", () => {
 
   it("undoes only edits that existed when the undo request began", async () => {
     const pendingUndo = deferred<RpcResultSuccess>();
-    const dataSource: EditApi = {
+    const dataSource: DataSource = {
       createSessionDataSource: vi.fn(
         async () => dataSource as unknown as DataSource,
       ),
       editCell: vi.fn().mockResolvedValue(SUCCESS),
       endEditSession: vi.fn(),
       undoRowChange: vi.fn().mockReturnValue(pendingUndo.promise),
-    };
+    } as unknown as DataSource;
     editSession = new EditSession({ dataSource: dataSource });
     await editSession.begin();
     await editSession.commit("row-1", "price", 100, 101, true);
@@ -587,8 +587,11 @@ describe("EditSession lifecycle", () => {
     (
       editSession.dataSource as unknown as Record<string, unknown>
     ).deleteSelectedRows = deleteSelectedRows;
+    (
+      editSession.dataSource as unknown as Record<string, unknown>
+    ).selectedRowsCount = 1;
 
-    await editSession.deleteSelectedRows(1);
+    await editSession.deleteSelectedRows();
 
     expect(states).toEqual(["dirty"]);
     expect(editSession.editState).toBe("dirty");

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.react.test.tsx
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.react.test.tsx
@@ -1,4 +1,4 @@
-import type { DataSource, EditApi } from "@vuu-ui/vuu-data-types";
+import type { DataSource } from "@vuu-ui/vuu-data-types";
 import { act, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import {
@@ -41,14 +41,14 @@ vi.hoisted(() => {
 const SUCCESS = { data: undefined, type: "SUCCESS_RESULT" as const };
 
 const createEditSession = () => {
-  const dataSource: EditApi = {
+  const dataSource: DataSource = {
     createSessionDataSource: vi.fn(
       async () => dataSource as unknown as DataSource,
     ),
     editCell: vi.fn().mockResolvedValue(SUCCESS),
     endEditSession: vi.fn(),
     undoRowChange: vi.fn().mockResolvedValue(SUCCESS),
-  };
+  } as unknown as DataSource;
   return new EditSession({ dataSource: dataSource });
 };
 
@@ -174,13 +174,13 @@ describe("EditSession React consumers", () => {
 
   it("initializes remounted edit buttons from stale state and force saves", async () => {
     const staleError = new StaleUpdateError("stale");
-    const dataSource: EditApi = {
+    const dataSource: DataSource = {
       createSessionDataSource: vi.fn(
         async () => dataSource as unknown as DataSource,
       ),
       editCell: vi.fn().mockResolvedValue(SUCCESS),
       endEditSession: vi.fn().mockRejectedValue(staleError),
-    };
+    } as unknown as DataSource;
     const editSession = new EditSession({ dataSource: dataSource });
     const onSave = vi.fn();
     await editSession.begin();

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
@@ -71,9 +71,7 @@ describe("EditSession", () => {
 
   it("supports the legacy beginEditSession API", async () => {
     const sessionDataSource = {} as DataSource;
-    const beginEditSession = vi
-      .fn()
-      .mockResolvedValue(sessionDataSource);
+    const beginEditSession = vi.fn().mockResolvedValue(sessionDataSource);
     const sourceDataSource = {
       beginEditSession,
     } as EditApi;
@@ -237,7 +235,7 @@ describe("EditSession", () => {
     await insertedRowSession.begin();
     await insertedRowSession.addRow({ id: "row-001" });
 
-    await insertedRowSession.undoRowChange("row-001");
+    await insertedRowSession.undoRowChange("row-001", "addRow");
 
     expect(undoRowChange).toHaveBeenCalledWith("row-001");
     expect(insertedRowSession.addCount).toBe(0);
@@ -266,9 +264,123 @@ describe("EditSession", () => {
     await rowEditSession.commit("row-001", "name", "Alice", "Alicia", true);
     cellEditChanged.mockClear();
 
-    await rowEditSession.undoRowChange("row-001");
+    await rowEditSession.undoRowChange("row-001", "editCell");
 
     expect(rowEditSession.isCellEdited("row-001", "name")).toBe(false);
     expect(cellEditChanged).toHaveBeenCalledWith("row-001", "name");
+  });
+
+  it("clones rowDefaults in constructor to prevent external mutation", async () => {
+    const rowDefaults = { unknownCol: "value" };
+    const sessionDataSource = {
+      tableSchema: {
+        columns: [{ name: "validCol" }],
+        key: "id",
+      },
+    } as unknown as DataSource;
+    const mockDataSource = {
+      createSessionDataSource: vi.fn(async () => sessionDataSource),
+    } as unknown as EditApi;
+    const session = new EditSession({
+      dataSource: mockDataSource,
+      rowDefaults,
+    });
+    await session.begin();
+    expect(rowDefaults).toEqual({ unknownCol: "value" });
+  });
+
+  it("prunes row key from tracked edits and hasRowChanges is false when cell edits are reverted", async () => {
+    await editSession.begin();
+    await editSession.commit("key-01", "col-1", 100, 150, true);
+    expect(editSession.hasRowChanges("key-01")).toBe(true);
+
+    await editSession.commit("key-01", "col-1", 150, 100, true);
+    expect(editSession.hasRowChanges("key-01")).toBe(false);
+    await editSession.end();
+  });
+
+  it("handles commit resolution gracefully when edit session ends", async () => {
+    let resolveEditCell: (value: unknown) => void = () => {};
+    const editCellPromise = new Promise((resolve) => {
+      resolveEditCell = resolve;
+    });
+    const editApi = {
+      createSessionDataSource: vi.fn(
+        async () => editApi as unknown as DataSource,
+      ),
+      editCell: vi.fn(() => editCellPromise),
+      endEditSession: vi.fn(),
+    } as unknown as EditApi;
+    const session = new EditSession({ dataSource: editApi });
+    await session.begin();
+
+    const commitPromise = session.commit("row-001", "name", "A", "B", true);
+
+    await session.end();
+
+    resolveEditCell({ type: "SUCCESS_RESULT" });
+
+    await expect(commitPromise).resolves.toEqual({
+      data: undefined,
+      type: "SUCCESS_RESULT",
+    });
+  });
+
+  it("batches editState events when setting delete Count", async () => {
+    const editApi = {
+      createSessionDataSource: vi.fn(
+        async () => editApi as unknown as DataSource,
+      ),
+      deleteSelectedRows: vi.fn().mockResolvedValue({
+        type: "SUCCESS_RESULT",
+      }),
+      endEditSession: vi.fn(),
+    } as unknown as EditApi;
+    const session = new EditSession({ dataSource: editApi });
+    await session.begin();
+
+    const editStateListener = vi.fn();
+    session.on("editState", editStateListener);
+
+    await session.deleteSelectedRows(2);
+
+    expect(session.deleteCount).toBe(2);
+    expect(editStateListener).toHaveBeenCalledTimes(1);
+    expect(editStateListener).toHaveBeenCalledWith("dirty");
+  });
+
+  it("produces a single unified editState event in undoRowChange", async () => {
+    const undoRowChange = vi.fn().mockResolvedValue({
+      data: { wasInsertedRow: true },
+      type: "SUCCESS_RESULT",
+    });
+    const editApi = {
+      createSessionDataSource: vi.fn(
+        async () => editApi as unknown as DataSource,
+      ),
+      addRow: vi.fn().mockResolvedValue({
+        data: undefined,
+        type: "SUCCESS_RESULT",
+      }),
+      editCell: vi.fn().mockResolvedValue({
+        data: undefined,
+        type: "SUCCESS_RESULT",
+      }),
+      endEditSession: vi.fn(),
+      undoRowChange,
+    } as unknown as EditApi;
+    const session = new EditSession({ dataSource: editApi });
+    await session.begin();
+
+    await session.addRow({ id: "row-1" });
+    await session.commit("row-1", "name", "Alice", "Alicia", true);
+
+    const editStateListener = vi.fn();
+    session.on("editState", editStateListener);
+
+    await session.undoRowChange("row-1", "editCell");
+
+    expect(editStateListener).toHaveBeenCalledTimes(1);
+    expect(editStateListener).toHaveBeenCalledWith("clean");
   });
 });

--- a/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
+++ b/vuu-ui/packages/vuu-data-editing/test/EditSession.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { DataSource, EditApi } from "@vuu-ui/vuu-data-types";
+import type { DataSource } from "@vuu-ui/vuu-data-types";
 import { EditSession } from "../src";
 
 vi.hoisted(() => {
@@ -22,12 +22,12 @@ vi.hoisted(() => {
   vi.stubGlobal("Worker", MockWorker);
 });
 
-type Editable = Required<EditApi>;
+type Editable = Required<DataSource>;
 type CreateSession = Editable["createSessionDataSource"];
 type EndEdit = Editable["endEditSession"];
 type EditCell = Editable["editCell"];
 
-export class MockDataSource implements EditApi {
+export class MockDataSource {
   constructor(
     private createSession: CreateSession,
     private endEdit: EndEdit,
@@ -59,7 +59,7 @@ describe("EditSession", () => {
     createSession = vi.fn(
       async () => editApi as unknown as DataSource,
     ) as CreateSession;
-    const editApi = new MockDataSource(createSession, endEdit, edit);
+    const editApi = new MockDataSource(createSession, endEdit, edit) as unknown as DataSource;
     editSession = new EditSession({ dataSource: editApi });
   });
 
@@ -74,7 +74,7 @@ describe("EditSession", () => {
     const beginEditSession = vi.fn().mockResolvedValue(sessionDataSource);
     const sourceDataSource = {
       beginEditSession,
-    } as EditApi;
+    } as unknown as DataSource;
     const legacyEditSession = new EditSession({
       dataSource: sourceDataSource,
       deleteMode: "soft",
@@ -220,7 +220,7 @@ describe("EditSession", () => {
       data: { wasInsertedRow: true },
       type: "SUCCESS_RESULT",
     });
-    const editApi: EditApi = {
+    const editApi: DataSource = {
       addRow: vi.fn().mockResolvedValue({
         data: undefined,
         type: "SUCCESS_RESULT",
@@ -230,7 +230,7 @@ describe("EditSession", () => {
       ),
       endEditSession: vi.fn(),
       undoRowChange,
-    };
+    } as unknown as DataSource;
     const insertedRowSession = new EditSession({ dataSource: editApi });
     await insertedRowSession.begin();
     await insertedRowSession.addRow({ id: "row-001" });
@@ -246,7 +246,7 @@ describe("EditSession", () => {
       data: undefined,
       type: "SUCCESS_RESULT",
     });
-    const editApi: EditApi = {
+    const editApi: DataSource = {
       createSessionDataSource: vi.fn(
         async () => editApi as unknown as DataSource,
       ),
@@ -256,7 +256,7 @@ describe("EditSession", () => {
       }),
       endEditSession: vi.fn(),
       undoRowChange,
-    };
+    } as unknown as DataSource;
     const rowEditSession = new EditSession({ dataSource: editApi });
     const cellEditChanged = vi.fn();
     rowEditSession.on("cellEditChanged", cellEditChanged);
@@ -280,7 +280,7 @@ describe("EditSession", () => {
     } as unknown as DataSource;
     const mockDataSource = {
       createSessionDataSource: vi.fn(async () => sessionDataSource),
-    } as unknown as EditApi;
+    } as unknown as DataSource;
     const session = new EditSession({
       dataSource: mockDataSource,
       rowDefaults,
@@ -310,7 +310,7 @@ describe("EditSession", () => {
       ),
       editCell: vi.fn(() => editCellPromise),
       endEditSession: vi.fn(),
-    } as unknown as EditApi;
+    } as unknown as DataSource;
     const session = new EditSession({ dataSource: editApi });
     await session.begin();
 
@@ -335,14 +335,15 @@ describe("EditSession", () => {
         type: "SUCCESS_RESULT",
       }),
       endEditSession: vi.fn(),
-    } as unknown as EditApi;
+      selectedRowsCount: 2,
+    } as unknown as DataSource;
     const session = new EditSession({ dataSource: editApi });
     await session.begin();
 
     const editStateListener = vi.fn();
     session.on("editState", editStateListener);
 
-    await session.deleteSelectedRows(2);
+    await session.deleteSelectedRows();
 
     expect(session.deleteCount).toBe(2);
     expect(editStateListener).toHaveBeenCalledTimes(1);
@@ -368,7 +369,7 @@ describe("EditSession", () => {
       }),
       endEditSession: vi.fn(),
       undoRowChange,
-    } as unknown as EditApi;
+    } as unknown as DataSource;
     const session = new EditSession({ dataSource: editApi });
     await session.begin();
 

--- a/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
+++ b/vuu-ui/packages/vuu-data-test/src/core/module/VuuModule.ts
@@ -471,7 +471,6 @@ export abstract class VuuModule<T extends string = string>
         const selectedRowIds = (
           dataSource as TickingArrayDataSource
         ).getSelectedRowIds();
-        const deletedKeys: string[] = [];
         if (selectedRowIds.length > 0) {
           for (const key of selectedRowIds) {
             if ((mode as DeleteRowMode) === "soft") {
@@ -479,11 +478,10 @@ export abstract class VuuModule<T extends string = string>
             } else {
               sessionTable.delete(key);
             }
-            deletedKeys.push(key);
           }
           dataSource.select?.({ type: "DESELECT_ALL" });
         }
-        return { type: "SUCCESS_RESULT", data: { deletedKeys } };
+        return { type: "SUCCESS_RESULT", data: undefined };
       }
       return {
         type: "ERROR_RESULT",

--- a/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
+++ b/vuu-ui/packages/vuu-data-test/test/TickingArrayDataSource.EditApi.test.ts
@@ -153,7 +153,7 @@ describe("deleteSelectedRows", () => {
 
   it("returns the RpcResult unchanged on success", async () => {
     const ds = createDataSource();
-    const success = { type: "SUCCESS_RESULT" as const, data: { deletedKeys: ["row-001", "row-002"] } };
+    const success = { type: "SUCCESS_RESULT" as const, data: undefined };
     vi.mocked(ds.rpcRequest).mockResolvedValue(success);
 
     const result = await ds.deleteSelectedRows();

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -124,8 +124,8 @@ export declare type DecimalValueTypeSimple = "decimal" | "scaleddecimal";
 export declare type DateTimeDataValueType =
   | DateTimeColumnTypeSimple
   | (Omit<DataValueTypeDescriptor, "name"> & {
-    name: DateTimeColumnTypeSimple;
-  });
+      name: DateTimeColumnTypeSimple;
+    });
 
 export declare type BulkEdit = "bulk" | false | "read-only";
 
@@ -136,9 +136,9 @@ export declare type BulkEdit = "bulk" | false | "read-only";
 export declare type DataEditable =
   | boolean
   | {
-    insert: boolean;
-    update: boolean;
-  };
+      insert: boolean;
+      update: boolean;
+    };
 
 export interface DataValueDescriptor {
   editable?: DataEditable;
@@ -153,7 +153,7 @@ export interface DataValueDescriptor {
   label?: string;
   /** unique name for this data value */
   name: string;
-    /** Whether the field is required or can be empty/nullable */
+  /** Whether the field is required or can be empty/nullable */
   required?: boolean;
   /** The type defined on server for this data value */
   serverDataType?: VuuColumnDataType;
@@ -198,18 +198,18 @@ type IsNew = boolean;
 export declare type DataSourceRow<
   T extends bigint | VuuRowDataItemType = VuuRowDataItemType,
 > = [
-    RowIndex,
-    RenderKey,
-    IsLeaf,
-    IsExpanded,
-    Depth,
-    ChildCount,
-    RowKey,
-    IsSelected,
-    Timestamp,
-    IsNew,
-    ...T[],
-  ];
+  RowIndex,
+  RenderKey,
+  IsLeaf,
+  IsExpanded,
+  Depth,
+  ChildCount,
+  RowKey,
+  IsSelected,
+  Timestamp,
+  IsNew,
+  ...T[],
+];
 
 export declare type DataSourceRowWithBigint = DataSourceRow<
   bigint | VuuRowDataItemType
@@ -229,7 +229,8 @@ export interface MessageWithClientViewportId {
   clientViewportId: string;
 }
 
-export interface DataSourceAggregateMessage extends MessageWithClientViewportId {
+export interface DataSourceAggregateMessage
+  extends MessageWithClientViewportId {
   aggregations: VuuAggregation[];
   type: "aggregate";
 }
@@ -286,7 +287,8 @@ export interface DataSourceGroupByMessage extends MessageWithClientViewportId {
   groupBy: VuuGroupBy | undefined;
 }
 
-export interface DataSourceSetConfigMessage extends MessageWithClientViewportId {
+export interface DataSourceSetConfigMessage
+  extends MessageWithClientViewportId {
   type: "config";
   config: WithFullConfig;
 }
@@ -305,12 +307,14 @@ export interface DataSourceSortMessage extends MessageWithClientViewportId {
   sort: VuuSort;
 }
 
-export interface DataSourceSubscribeFailedMessage extends MessageWithClientViewportId {
+export interface DataSourceSubscribeFailedMessage
+  extends MessageWithClientViewportId {
   type: "subscribe-failed";
   msg: string;
 }
 
-export interface DataSourceSubscribedMessage extends MessageWithClientViewportId {
+export interface DataSourceSubscribedMessage
+  extends MessageWithClientViewportId {
   aggregations: VuuAggregation[];
   columns: VuuColumns;
   filterSpec: DataSourceFilter;
@@ -321,18 +325,21 @@ export interface DataSourceSubscribedMessage extends MessageWithClientViewportId
   type: "subscribed";
 }
 
-export interface DataSourceVisualLinkCreatedMessage extends MessageWithClientViewportId {
+export interface DataSourceVisualLinkCreatedMessage
+  extends MessageWithClientViewportId {
   colName: string;
   parentViewportId: string;
   parentColName: string;
   type: "vuu-link-created";
 }
 
-export interface DataSourceVisualLinkRemovedMessage extends MessageWithClientViewportId {
+export interface DataSourceVisualLinkRemovedMessage
+  extends MessageWithClientViewportId {
   type: "vuu-link-removed";
 }
 
-export interface DataSourceVisualLinksMessage extends MessageWithClientViewportId {
+export interface DataSourceVisualLinksMessage
+  extends MessageWithClientViewportId {
   type: "vuu-links";
   links: VuuLinkDescriptor[];
 }
@@ -406,7 +413,7 @@ export declare type TableSchemaTable = VuuTable & {
 export declare type RangeLimits = {
   maxRangeEnd: number;
   maxRangeWidth: number;
-}
+};
 
 export declare type TableSchema = {
   columns: readonly SchemaColumn[];
@@ -441,7 +448,8 @@ export interface WithSort extends DataSourceConfig {
   sort: VuuSort;
 }
 
-export interface DataSourceConstructorProps extends WithBaseFilter<DataSourceConfig> {
+export interface DataSourceConstructorProps
+  extends WithBaseFilter<DataSourceConfig> {
   /**
    * If provided, these column names will always be included in subscription, even
    * if not directly requested, via columns property. Useful where columns may not
@@ -475,9 +483,8 @@ export interface RemoteModuleConnection {
   websocketUrl?: string;
 }
 
-export interface DataSourceSubscribeProps extends Partial<
-  WithBaseFilter<WithFullConfig>
-> {
+export interface DataSourceSubscribeProps
+  extends Partial<WithBaseFilter<WithFullConfig>> {
   viewport?: string;
   range?: Range;
   revealSelected?: boolean;
@@ -665,21 +672,15 @@ export declare type BeginEditSessionResult = {
   table: VuuTable;
 };
 
-export declare type DeleteSelectedRowsResult = {
-  deletedKeys: string[];
-};
-
 export declare type UndoRowChangeResult = {
   wasInsertedRow?: boolean;
 };
 
 export interface DataSourceBase<
   T extends DataSourceRow | DataSourceRowWithBigint = DataSourceRow,
->
-  extends
-  EditApi<T>,
-  IEventEmitter<DataSourceEvents>,
-  Partial<TypeaheadSuggestionProvider> {
+> extends EditApi<T>,
+    IEventEmitter<DataSourceEvents>,
+    Partial<TypeaheadSuggestionProvider> {
   aggregations: VuuAggregation[];
   closeTreeNode: (keyOrIndex: string | number, cascade?: boolean) => void;
   columns: string[];

--- a/vuu-ui/packages/vuu-data-types/index.d.ts
+++ b/vuu-ui/packages/vuu-data-types/index.d.ts
@@ -625,15 +625,16 @@ export declare type SessionDataSourceOverrides = {
   table?: VuuTable;
 };
 
-export interface EditApi<
+export declare type UndoRowChangeResult = {
+  wasInsertedRow?: boolean;
+};
+
+export interface DataSourceBase<
   T extends DataSourceRow | DataSourceRowWithBigint = DataSourceRow,
-> {
+> extends IEventEmitter<DataSourceEvents>,
+    Partial<TypeaheadSuggestionProvider> {
   addRow?: (
     rowData?: Record<string, VuuRowDataItemType>,
-  ) => Promise<RpcResult> | undefined;
-  deleteRow?: (
-    key: string,
-    mode?: DeleteRowMode,
   ) => Promise<RpcResult> | undefined;
   deleteSelectedRows?: (mode?: DeleteRowMode) => Promise<RpcResult> | undefined;
   editCell?: (
@@ -662,25 +663,6 @@ export interface EditApi<
     saveChanges?: boolean,
     force?: boolean,
   ) => Promise<RpcResult> | undefined;
-}
-
-/**
- * Data payload returned in RpcResultSuccess.data by the beginEditSession service.
- * Contains the server-assigned session table reference used to create the session datasource.
- */
-export declare type BeginEditSessionResult = {
-  table: VuuTable;
-};
-
-export declare type UndoRowChangeResult = {
-  wasInsertedRow?: boolean;
-};
-
-export interface DataSourceBase<
-  T extends DataSourceRow | DataSourceRowWithBigint = DataSourceRow,
-> extends EditApi<T>,
-    IEventEmitter<DataSourceEvents>,
-    Partial<TypeaheadSuggestionProvider> {
   aggregations: VuuAggregation[];
   closeTreeNode: (keyOrIndex: string | number, cascade?: boolean) => void;
   columns: string[];

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/data-upload-preview/useDataUploadPreview.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/data-upload-preview/useDataUploadPreview.ts
@@ -48,8 +48,8 @@ export const useDataUploadPreview = ({
 
   const onCancel = useCallback(() => endSession(false), [endSession]);
   const onDelete = useCallback(
-    () => editSession.deleteSelectedRows(selectionCount),
-    [editSession, selectionCount],
+    () => editSession.deleteSelectedRows(),
+    [editSession],
   );
   const onSave = useCallback(
     (force = false) => endSession(true, force),

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/data-upload-preview/useDataUploadPreview.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/data-upload-preview/useDataUploadPreview.ts
@@ -48,8 +48,8 @@ export const useDataUploadPreview = ({
 
   const onCancel = useCallback(() => endSession(false), [endSession]);
   const onDelete = useCallback(
-    () => editSession.deleteSelectedRows(),
-    [editSession],
+    () => editSession.deleteSelectedRows(selectionCount),
+    [editSession, selectionCount],
   );
   const onSave = useCallback(
     (force = false) => endSession(true, force),

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
@@ -146,9 +146,7 @@ export const useCsvUpload = ({
   // EditSession's constructor takes no session/schema config - the override is applied
   // here, at the createSessionDataSource call site, since `dataSource` is supplied by the
   // caller and may be shared with a view that has no knowledge of the import table.
-  const importDataSource = useMemo<
-    DataSource & { tableSchema?: TableSchema }
-  >(() => {
+  const importDataSource = useMemo<DataSource>(() => {
     return {
       tableSchema: dataSource.tableSchema,
       createSessionDataSource: async (
@@ -191,7 +189,7 @@ export const useCsvUpload = ({
 
         return sessionDs;
       },
-    } as unknown as DataSource & { tableSchema?: TableSchema };
+    } as DataSource;
   }, [dataSource, sessionOverrides]);
   const editSession = useMemo(
     () =>

--- a/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
+++ b/vuu-ui/packages/vuu-table-extras/src/csv-upload/useCsvUpload.ts
@@ -1,7 +1,8 @@
 import type {
+  CopyOption,
   DataSource,
-  EditApi,
   SessionDataSourceOverrides,
+  SessionType,
   TableSchema,
 } from "@vuu-ui/vuu-data-types";
 import {
@@ -146,11 +147,14 @@ export const useCsvUpload = ({
   // here, at the createSessionDataSource call site, since `dataSource` is supplied by the
   // caller and may be shared with a view that has no knowledge of the import table.
   const importDataSource = useMemo<
-    EditApi & { tableSchema?: TableSchema }
+    DataSource & { tableSchema?: TableSchema }
   >(() => {
     return {
       tableSchema: dataSource.tableSchema,
-      createSessionDataSource: async (copyOption, sessionType) => {
+      createSessionDataSource: async (
+        copyOption: CopyOption,
+        sessionType?: SessionType,
+      ) => {
         if (!dataSource.createSessionDataSource) {
           throw Error(
             "[useCsvUpload] dataSource does not support createSessionDataSource",
@@ -187,7 +191,7 @@ export const useCsvUpload = ({
 
         return sessionDs;
       },
-    };
+    } as unknown as DataSource & { tableSchema?: TableSchema };
   }, [dataSource, sessionOverrides]);
   const editSession = useMemo(
     () =>


### PR DESCRIPTION
- Replaced loop-recalculating #refreshEditCounts() #storeCellEdit
- Made all state count setters private
- deleteSelectedRows to rely on consumer-supplied selectedRowCount, removing unsupported key-based deleted collections
- Wires dataRow.vuuAction directly from UndoCellRenderer.tsx to undoRowChange()