### PR TITLE
Session table import refinements

### DIFF
--- a/example/main-java/src/main/java/org/finos/vuu/person/rpc/ImportRecordRpcHandler.java
+++ b/example/main-java/src/main/java/org/finos/vuu/person/rpc/ImportRecordRpcHandler.java
@@ -26,7 +26,7 @@ public class ImportRecordRpcHandler extends DefaultRpcHandlerImpl implements Imp
     }
 
     @Override
-    public RpcFunctionResult addRowWithoutVuuMsg(RpcParams params) {
+    public RpcFunctionResult addRowWithoutVuuMsg(String rowKey, RpcParams params) {
         String vuuAction = TableAction.ADD_ROW().value(); // example of calling TableAction in Java
         return new RpcFunctionSuccess();
     }

--- a/example/main-java/src/test/java/org/finos/vuu/PersonRpcHandlerWSApiTest.java
+++ b/example/main-java/src/test/java/org/finos/vuu/PersonRpcHandlerWSApiTest.java
@@ -295,13 +295,13 @@ public class PersonRpcHandlerWSApiTest extends WebSocketApiJavaTestBase {
 
         assertInstanceOf(RpcErrorResult.class, responseBody.result(), "Response contains error result");
         var result = (RpcErrorResult) responseBody.result();
-        assertEquals("Could not find rpcMethodHandler DoesNotExist", result.errorMessage());
+        assertEquals("Could not find handler for rpc \"DoesNotExist\"", result.errorMessage());
 
         assertInstanceOf(ShowNotificationAction.class, responseBody.action(), "Response contains show notification action");
         var action = (ShowNotificationAction) responseBody.action();
         assertEquals(NotificationType.ERROR(), action.notificationType());
         assertEquals("Failed to process DoesNotExist request", action.title());
-        assertEquals("Could not find rpcMethodHandler DoesNotExist", action.message());
+        assertEquals("Could not find handler for rpc \"DoesNotExist\"", action.message());
 
     }
 

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/RpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/RpcHandler.scala
@@ -57,11 +57,10 @@ trait RpcHandler extends StrictLogging {
         handler(params)
       } catch {
         case e: Exception =>
-          logger.error(s"Error processing rpc method $rpcName", e)
-          RpcFunctionFailure(1, e.toString, e)
+          RpcFunctionFailure(1, s"Error whilst handling rpc \"$rpcName\"", e)
       }
     } else {
-      new RpcFunctionFailure(s"Could not find rpcMethodHandler $rpcName")
+      new RpcFunctionFailure(s"Could not find handler for rpc \"$rpcName\"")
     }
   }
 }

--- a/vuu/src/main/scala/org/finos/vuu/net/rpc/sessiontable/ImportSessionRpcHandler.scala
+++ b/vuu/src/main/scala/org/finos/vuu/net/rpc/sessiontable/ImportSessionRpcHandler.scala
@@ -12,33 +12,30 @@ trait ImportSessionRpcHandler extends EditTableRpcHandler {
 
   def addRow(params: RpcParams): RpcFunctionResult = {
 
-    if (params.viewPort.table.asTable.size() >= maxSessionTableSize) {
+    val sessionTableSize = params.viewPort.table.asTable.size()
+    if (sessionTableSize >= maxSessionTableSize) {
       return new RpcFunctionFailure("Unable to add row. Session table reached max size.")
     }
 
     params.namedParams.get("data") match {
       case Some(data: Map[_, _]) =>
-        data.asInstanceOf[Map[String, Any]].get(VuuRowNum) match {
-          case Some(rowNum: String) =>
-            data.asInstanceOf[Map[String, Any]].get(MSG.name) match {
-              case Some(vuuMsg: String) => addRowWithVuuMsg(rowNum, vuuMsg, params)
-              case _ => addRowWithoutVuuMsg(params)
-            }
-          case _ => new RpcFunctionFailure("Unable to add row. Row number missing.")
+        val rowKey = (sessionTableSize + 1).toString
+        data.asInstanceOf[Map[String, Any]].get(MSG.name) match {
+          case Some(vuuMsg: String) => addRowWithVuuMsg(rowKey, vuuMsg, params)
+          case _ => addRowWithoutVuuMsg(rowKey, params)
         }
       case _ => new RpcFunctionFailure("Unable to add row. Data missing.")
     }
   }
 
-  protected def addRowWithVuuMsg(rowNum: String, vuuMsg: String, params: RpcParams): RpcFunctionResult = {
+  protected def addRowWithVuuMsg(rowKey: String, vuuMsg: String, params: RpcParams): RpcFunctionResult = {
     params.viewPort.table.asTable.processUpdate(
-      rowNum,
-      RowWithData(rowNum, Map(VuuRowNum -> rowNum, MSG.name -> vuuMsg))
+      RowWithData(rowKey, Map(VuuRowNum -> rowKey, MSG.name -> vuuMsg))
     )
     RpcFunctionSuccess(None)
   }
 
-  protected def addRowWithoutVuuMsg(params: RpcParams): RpcFunctionResult
+  protected def addRowWithoutVuuMsg(rowKey: String, params: RpcParams): RpcFunctionResult
 
   def deleteRow(params: RpcParams): RpcFunctionResult = {
     new RpcFunctionFailure(rpcNotSupportedMsg)

--- a/vuu/src/test/scala/org/finos/vuu/wsapi/ImportSessionRpcHandlerWSApiTest.scala
+++ b/vuu/src/test/scala/org/finos/vuu/wsapi/ImportSessionRpcHandlerWSApiTest.scala
@@ -193,6 +193,6 @@ class ImportSessionRpcHandlerWSApiTest extends WebSocketApiTestBase {
 
   class TestImportSessionTableRpcHandler(override val maxSessionTableSize: Int) extends ImportSessionRpcHandler {
 
-    override protected def addRowWithoutVuuMsg(params: RpcParams): RpcFunctionResult = new RpcFunctionSuccess()
+    override protected def addRowWithoutVuuMsg(rowKey: String, params: RpcParams): RpcFunctionResult = new RpcFunctionSuccess()
   }
 }


### PR DESCRIPTION
* Provide the import rowKey to consumers, rather than forcing the UI to provide it.
* Remove stack traces from failed RPC call responses to the UI