### PR TITLE
feat(portal): show remote compatibility failures

### DIFF
--- a/vuu-ui/packages/core/src/portal.ts
+++ b/vuu-ui/packages/core/src/portal.ts
@@ -8,4 +8,5 @@ export {
   RemoteModule,
   type RemoteModuleProps,
 } from "./remote-module/RemoteModule";
+export { createRemoteModuleErrorPlugin } from "./remote-module/ModuleFederationErrorPlugin";
 export type { RemoteModuleDescriptor } from "./RemoteModuleDescriptor";

--- a/vuu-ui/packages/core/src/remote-module/ModuleFederationErrorPlugin.tsx
+++ b/vuu-ui/packages/core/src/remote-module/ModuleFederationErrorPlugin.tsx
@@ -1,0 +1,35 @@
+import type { ModuleFederationRuntimePlugin } from "@module-federation/enhanced/runtime";
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+const RemoteModuleLoadError = ({
+  moduleId,
+  error,
+}: {
+  error: unknown;
+  moduleId: string;
+}) => (
+  <div role="alert">
+    <h1>Unable to load {moduleId}</h1>
+    <p>
+      This module is incompatible with the version of VUU used by this portal.
+      Contact your portal administrator to deploy compatible versions.
+    </p>
+    <p>{getErrorMessage(error)}</p>
+  </div>
+);
+
+export const createRemoteModuleErrorPlugin =
+  (): ModuleFederationRuntimePlugin => ({
+    name: "vuu-remote-module-error-plugin",
+    errorLoadRemote({ error, id, lifecycle }) {
+      if (lifecycle !== "onLoad") {
+        return undefined;
+      }
+
+      return {
+        default: () => <RemoteModuleLoadError error={error} moduleId={id} />,
+      };
+    },
+  });

--- a/vuu-ui/packages/core/test/remote-module/ModuleFederationErrorPlugin.test.tsx
+++ b/vuu-ui/packages/core/test/remote-module/ModuleFederationErrorPlugin.test.tsx
@@ -1,0 +1,65 @@
+import { act, type ComponentType } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createRemoteModuleErrorPlugin } from "../../src/remote-module/ModuleFederationErrorPlugin";
+
+describe("createRemoteModuleErrorPlugin", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it("provides a compatibility message when a remote module cannot load", async () => {
+    const plugin = createRemoteModuleErrorPlugin();
+    const fallback = plugin.errorLoadRemote?.({
+      error: Error("Version 3.3.8 does not satisfy the requirement 3.3.5"),
+      from: "runtime",
+      id: "feature/Feature",
+      lifecycle: "onLoad",
+      origin: {} as never,
+    }) as { default: ComponentType } | undefined;
+
+    expect(fallback).toEqual({
+      default: expect.any(Function),
+    });
+
+    const FallbackComponent = fallback?.default;
+    expect(FallbackComponent).toBeDefined();
+
+    await act(async () => {
+      root.render(<FallbackComponent />);
+    });
+
+    expect(container.textContent).toContain("Unable to load feature/Feature");
+    expect(container.textContent).toContain(
+      "This module is incompatible with the version of VUU used by this portal.",
+    );
+    expect(container.textContent).toContain(
+      "Version 3.3.8 does not satisfy the requirement 3.3.5",
+    );
+  });
+
+  it("does not replace failures outside remote component loading", () => {
+    const plugin = createRemoteModuleErrorPlugin();
+
+    expect(
+      plugin.errorLoadRemote?.({
+        error: Error("Failed to resolve remote"),
+        from: "runtime",
+        id: "feature/Feature",
+        lifecycle: "afterResolve",
+        origin: {} as never,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/vuu-ui/portal-examples/portal-host/src/bootstrap.tsx
+++ b/vuu-ui/portal-examples/portal-host/src/bootstrap.tsx
@@ -4,6 +4,7 @@ import {
   AuthenticationProvider,
   KeycloakAuthHandler,
 } from "@vuu-ui/core";
+import { createRemoteModuleErrorPlugin } from "@vuu-ui/core/portal";
 import { ConnectionManager } from "@vuu-ui/vuu-data-remote";
 import { PageVisibilityObserver } from "@vuu-ui/vuu-utils";
 import { createRoot } from "react-dom/client";
@@ -14,6 +15,7 @@ import "@vuu-ui/vuu-theme/index.css";
 
 init({
   name: "host",
+  plugins: [createRemoteModuleErrorPlugin()],
   remotes: [],
 });
 


### PR DESCRIPTION
## Summary
- handle Module Federation remote load failures through the runtime `errorLoadRemote` hook
- render an accessible VUU dependency-compatibility fallback instead of a blank portal route
- register the handler in the portal host and cover its loading lifecycle behavior

## Validation
- `npx vitest run packages/core/test/remote-module/ModuleFederationErrorPlugin.test.tsx`
- `npm run typecheck`
- `npx biome check packages/core/src/remote-module/ModuleFederationErrorPlugin.tsx packages/core/src/portal.ts packages/core/test/remote-module/ModuleFederationErrorPlugin.test.tsx portal-examples/portal-host/src/bootstrap.tsx`