### PR TITLE
fix(portal): catch rejected remote loads

### DIFF
--- a/vuu-ui/packages/core/src/remote-module/ModuleFederationErrorPlugin.tsx
+++ b/vuu-ui/packages/core/src/remote-module/ModuleFederationErrorPlugin.tsx
@@ -1,24 +1,5 @@
 import type { ModuleFederationRuntimePlugin } from "@module-federation/enhanced/runtime";
-
-const getErrorMessage = (error: unknown) =>
-  error instanceof Error ? error.message : String(error);
-
-const RemoteModuleLoadError = ({
-  moduleId,
-  error,
-}: {
-  error: unknown;
-  moduleId: string;
-}) => (
-  <div role="alert">
-    <h1>Unable to load {moduleId}</h1>
-    <p>
-      This module is incompatible with the version of VUU used by this portal.
-      Contact your portal administrator to deploy compatible versions.
-    </p>
-    <p>{getErrorMessage(error)}</p>
-  </div>
-);
+import { RemoteModuleLoadError } from "./RemoteModuleLoadError";
 
 export const createRemoteModuleErrorPlugin =
   (): ModuleFederationRuntimePlugin => ({

--- a/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
+++ b/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
@@ -9,6 +9,7 @@ import {
 import React, { lazy } from "react";
 import { useInRouterContext, useLocation } from "react-router-dom";
 import { RemoteModuleErrorBoundary } from "./RemoteModuleErrorBoundary";
+import { RemoteModuleLoadError } from "./RemoteModuleLoadError";
 
 export interface RemoteModuleProps<
   ComponentProps extends object | undefined = object,
@@ -43,15 +44,25 @@ const getLazyComponent = (
   ]);
 
   return lazy(async () => {
-    const remote = await loadRemote<{
-      default: React.ComponentType<Record<string, unknown>>;
-    }>(`${scope}/${component}`, { from: "runtime" });
+    const moduleId = `${scope}/${component}`;
 
-    if (remote === null) {
-      throw Error(`Unable to load remote component ${scope}/${component}`);
+    try {
+      const remote = await loadRemote<{
+        default: React.ComponentType<Record<string, unknown>>;
+      }>(moduleId, { from: "runtime" });
+
+      if (remote === null) {
+        throw Error(`Unable to load remote component ${moduleId}`);
+      }
+
+      return remote;
+    } catch (error) {
+      return {
+        default: () => (
+          <RemoteModuleLoadError error={error} moduleId={moduleId} />
+        ),
+      };
     }
-
-    return remote;
   });
 };
 
@@ -126,12 +137,11 @@ const RoutedRemoteModule = (props: RoutedRemoteModuleProps) => {
   return <RawRemoteModule {...props} />;
 };
 
-export const RemoteModule = React.memo(
-  (props: RoutedRemoteModuleProps) =>
-    useInRouterContext() ? (
-      <RoutedRemoteModule {...props} />
-    ) : (
-      <RawRemoteModule {...props} />
-    ),
+export const RemoteModule = React.memo((props: RoutedRemoteModuleProps) =>
+  useInRouterContext() ? (
+    <RoutedRemoteModule {...props} />
+  ) : (
+    <RawRemoteModule {...props} />
+  ),
 );
 RemoteModule.displayName = "RemoteModule";

--- a/vuu-ui/packages/core/src/remote-module/RemoteModuleLoadError.tsx
+++ b/vuu-ui/packages/core/src/remote-module/RemoteModuleLoadError.tsx
@@ -1,0 +1,19 @@
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+export const RemoteModuleLoadError = ({
+  moduleId,
+  error,
+}: {
+  error: unknown;
+  moduleId: string;
+}) => (
+  <div role="alert">
+    <h1>Unable to load {moduleId}</h1>
+    <p>
+      This module is incompatible with the version of VUU used by this portal.
+      Contact your portal administrator to deploy compatible versions.
+    </p>
+    <p>{getErrorMessage(error)}</p>
+  </div>
+);

--- a/vuu-ui/packages/core/test/remote-module/RemoteModule.test.tsx
+++ b/vuu-ui/packages/core/test/remote-module/RemoteModule.test.tsx
@@ -2,6 +2,8 @@ import { act, Suspense } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { loadRemote } from "@module-federation/enhanced/runtime";
+
 vi.mock("@module-federation/enhanced/runtime", () => ({
   loadRemote: vi.fn().mockResolvedValue({
     default: () => <div>Connectionless remote loaded</div>,
@@ -43,5 +45,30 @@ describe("RemoteModule", () => {
     });
 
     expect(container.textContent).toBe("Connectionless remote loaded");
+  });
+
+  it("renders a compatibility message when a remote load rejects", async () => {
+    vi.mocked(loadRemote).mockRejectedValueOnce(
+      Error("Version 3.3.8 does not satisfy the requirement 3.3.5"),
+    );
+
+    await act(async () => {
+      root.render(
+        <Suspense fallback="Loading">
+          <RemoteModule
+            mfComponent="IncompatibleRemote"
+            mfScope="incompatible"
+            mfUrl="http://localhost:5001"
+          />
+        </Suspense>,
+      );
+    });
+
+    expect(container.textContent).toContain(
+      "This module is incompatible with the version of VUU used by this portal.",
+    );
+    expect(container.textContent).toContain(
+      "Version 3.3.8 does not satisfy the requirement 3.3.5",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- catch rejected `loadRemote` promises directly in the lazy remote component loader
- render the compatibility error UI even when the Federation failure occurs during shared dependency initialization
- add regression coverage for the strict shared-version mismatch error

This follows the merged runtime plugin change because the failure can occur before the runtime plugin's `onLoad` fallback is able to prevent the rejected lazy import from reaching the shell.

## Validation
- `npx vitest run packages/core/test/remote-module/RemoteModule.test.tsx packages/core/test/remote-module/ModuleFederationErrorPlugin.test.tsx`
- `npm run typecheck`
- `npx biome check packages/core/src/remote-module/RemoteModule.tsx packages/core/src/remote-module/RemoteModuleLoadError.tsx packages/core/src/remote-module/ModuleFederationErrorPlugin.tsx packages/core/test/remote-module/RemoteModule.test.tsx`