### PR TITLE
fix(portal): handle federation promise failures

### DIFF
--- a/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
+++ b/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
@@ -35,14 +35,14 @@ const getLazyComponent = (
   component: string,
   manifestUrl: string,
 ) => {
-  registerRemotes([
-    {
-      name: scope,
-      entry: manifestUrl,
-    },
-  ]);
-
   return lazy(async () => {
+    registerRemotes([
+      {
+        name: scope,
+        entry: manifestUrl,
+      },
+    ]);
+
     const remote = await loadRemote<{
       default: React.ComponentType<Record<string, unknown>>;
     }>(`${scope}/${component}`, { from: "runtime" });

--- a/vuu-ui/packages/core/test/remote-module/RemoteModule.test.tsx
+++ b/vuu-ui/packages/core/test/remote-module/RemoteModule.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@module-federation/enhanced/runtime", () => ({
   registerRemotes: vi.fn(),
 }));
 
+import { registerRemotes } from "@module-federation/enhanced/runtime";
 import { RemoteModule } from "../../src/remote-module/RemoteModule";
 
 describe("RemoteModule", () => {
@@ -41,5 +42,28 @@ describe("RemoteModule", () => {
     });
 
     expect(container.textContent).toBe("Connectionless remote loaded");
+  });
+
+  it("renders a boundary message when remote registration fails", async () => {
+    vi.mocked(registerRemotes).mockImplementationOnce(() => {
+      throw Error("remote shared dependency is incompatible");
+    });
+
+    await act(async () => {
+      root.render(
+        <RemoteModule
+          mfComponent="RegistrationFailure"
+          mfScope="registration-failure"
+          mfUrl="http://localhost:5001"
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain(
+      "An error occurred while creating the remote module.",
+    );
+    expect(container.textContent).toContain(
+      "remote shared dependency is incompatible",
+    );
   });
 });

--- a/vuu-ui/portal-examples/portal-host/src/bootstrap.tsx
+++ b/vuu-ui/portal-examples/portal-host/src/bootstrap.tsx
@@ -6,11 +6,58 @@ import {
 } from "@vuu-ui/core";
 import { ConnectionManager } from "@vuu-ui/vuu-data-remote";
 import { PageVisibilityObserver } from "@vuu-ui/vuu-utils";
+import { type ReactNode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 
 import "@vuu-ui/vuu-icons/index.css";
 import "@vuu-ui/vuu-theme/index.css";
+
+const getError = (reason: unknown) =>
+  reason instanceof Error ? reason : Error(String(reason));
+
+const FederationRuntimeErrorHandler = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [error, setError] = useState<Error>();
+
+  useEffect(() => {
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const nextError = getError(event.reason);
+      if (!nextError.message.startsWith("[ Federation Runtime ]")) {
+        return;
+      }
+
+      event.preventDefault();
+      setError(nextError);
+    };
+
+    window.addEventListener("unhandledrejection", handleUnhandledRejection);
+    return () =>
+      window.removeEventListener(
+        "unhandledrejection",
+        handleUnhandledRejection,
+      );
+  }, []);
+
+  if (error) {
+    return (
+      <div role="alert">
+        <h1>Unable to load the portal module</h1>
+        <p>
+          A portal module is incompatible with the VUU version used by this
+          application. Contact your portal administrator to deploy compatible
+          versions.
+        </p>
+        <p>{error.message}</p>
+      </div>
+    );
+  }
+
+  return children;
+};
 
 init({
   name: "host",
@@ -37,19 +84,21 @@ async function start(): Promise<void> {
   try {
     const root = createRoot(container);
     root.render(
-      <AuthenticationErrorBoundary
-        fallback={(error) => (
-          <div role="alert">Unable to authenticate: {error.message}</div>
-        )}
-      >
-        <AuthenticationProvider
-          authConfig={config}
-          authHandlerClass={KeycloakAuthHandler}
-          mode="identity"
+      <FederationRuntimeErrorHandler>
+        <AuthenticationErrorBoundary
+          fallback={(error) => (
+            <div role="alert">Unable to authenticate: {error.message}</div>
+          )}
         >
-          <App />
-        </AuthenticationProvider>
-      </AuthenticationErrorBoundary>,
+          <AuthenticationProvider
+            authConfig={config}
+            authHandlerClass={KeycloakAuthHandler}
+            mode="identity"
+          >
+            <App />
+          </AuthenticationProvider>
+        </AuthenticationErrorBoundary>
+      </FederationRuntimeErrorHandler>,
     );
   } catch (err: unknown) {
     console.error(err);


### PR DESCRIPTION
## Summary
- catch detached Module Federation `unhandledrejection` events in the portal host
- prevent the browser white-screen failure and render a clear shared-dependency compatibility message
- defer remote registration into the lazy load path so synchronous registration failures reach the remote error boundary
- keep the previous runtime plugin and direct-loader fallback implementations out of this change

The reported stack shows the failure originates in `SharedHandler.loadShare` and escapes as an unhandled promise rejection, so it cannot be handled by `loadRemote` or a React error boundary alone.

## Validation
- `npx vitest run packages/core/test/remote-module/RemoteModule.test.tsx`
- `npm run typecheck`
- `npx biome check packages/core/src/remote-module/RemoteModule.tsx packages/core/test/remote-module/RemoteModule.test.tsx portal-examples/portal-host/src/bootstrap.tsx`