### PR TITLE
fix(portal): handle federation startup failure before bootstrap

### DIFF
--- a/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
+++ b/vuu-ui/packages/core/src/remote-module/RemoteModule.tsx
@@ -6,7 +6,7 @@ import {
   loadRemote,
   registerRemotes,
 } from "@module-federation/enhanced/runtime";
-import React, { lazy, Suspense } from "react";
+import React, { lazy } from "react";
 import { useInRouterContext, useLocation } from "react-router-dom";
 import { RemoteModuleErrorBoundary } from "./RemoteModuleErrorBoundary";
 
@@ -35,14 +35,14 @@ const getLazyComponent = (
   component: string,
   manifestUrl: string,
 ) => {
-  return lazy(async () => {
-    registerRemotes([
-      {
-        name: scope,
-        entry: manifestUrl,
-      },
-    ]);
+  registerRemotes([
+    {
+      name: scope,
+      entry: manifestUrl,
+    },
+  ]);
 
+  return lazy(async () => {
     const remote = await loadRemote<{
       default: React.ComponentType<Record<string, unknown>>;
     }>(`${scope}/${component}`, { from: "runtime" });
@@ -126,13 +126,11 @@ const RoutedRemoteModule = (props: RoutedRemoteModuleProps) => {
   return <RawRemoteModule {...props} />;
 };
 
-export const RemoteModule = React.memo((props: RoutedRemoteModuleProps) => (
-  <Suspense fallback={<div role="status">Loading remote module...</div>}>
-    {useInRouterContext() ? (
-      <RoutedRemoteModule {...props} />
-    ) : (
-      <RawRemoteModule {...props} />
-    )}
-  </Suspense>
-));
+export const RemoteModule = React.memo((props: RoutedRemoteModuleProps) =>
+  useInRouterContext() ? (
+    <RoutedRemoteModule {...props} />
+  ) : (
+    <RawRemoteModule {...props} />
+  ),
+);
 RemoteModule.displayName = "RemoteModule";

--- a/vuu-ui/packages/core/test/remote-module/RemoteModule.test.tsx
+++ b/vuu-ui/packages/core/test/remote-module/RemoteModule.test.tsx
@@ -1,4 +1,4 @@
-import { act } from "react";
+import { act, Suspense } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -9,7 +9,6 @@ vi.mock("@module-federation/enhanced/runtime", () => ({
   registerRemotes: vi.fn(),
 }));
 
-import { registerRemotes } from "@module-federation/enhanced/runtime";
 import { RemoteModule } from "../../src/remote-module/RemoteModule";
 
 describe("RemoteModule", () => {
@@ -33,37 +32,16 @@ describe("RemoteModule", () => {
   it("loads a remote without a Vuu connection when metadata is absent", async () => {
     await act(async () => {
       root.render(
-        <RemoteModule
-          mfComponent="ConnectionlessRemote"
-          mfScope="connectionless"
-          mfUrl="http://localhost:5000"
-        />,
+        <Suspense fallback="Loading">
+          <RemoteModule
+            mfComponent="ConnectionlessRemote"
+            mfScope="connectionless"
+            mfUrl="http://localhost:5000"
+          />
+        </Suspense>,
       );
     });
 
     expect(container.textContent).toBe("Connectionless remote loaded");
-  });
-
-  it("renders a boundary message when remote registration fails", async () => {
-    vi.mocked(registerRemotes).mockImplementationOnce(() => {
-      throw Error("remote shared dependency is incompatible");
-    });
-
-    await act(async () => {
-      root.render(
-        <RemoteModule
-          mfComponent="RegistrationFailure"
-          mfScope="registration-failure"
-          mfUrl="http://localhost:5001"
-        />,
-      );
-    });
-
-    expect(container.textContent).toContain(
-      "An error occurred while creating the remote module.",
-    );
-    expect(container.textContent).toContain(
-      "remote shared dependency is incompatible",
-    );
   });
 });

--- a/vuu-ui/portal-examples/portal-host/public/index.html
+++ b/vuu-ui/portal-examples/portal-host/public/index.html
@@ -7,6 +7,43 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Vuu generic UI" />
+    <script>
+      window.addEventListener("unhandledrejection", (event) => {
+        const message =
+          event.reason instanceof Error
+            ? event.reason.message
+            : String(event.reason);
+
+        if (!message.startsWith("[ Federation Runtime ]")) {
+          return;
+        }
+
+        event.preventDefault();
+
+        const root = document.getElementById("root");
+        if (!root) {
+          return;
+        }
+
+        root.replaceChildren();
+
+        const alert = document.createElement("div");
+        alert.setAttribute("role", "alert");
+
+        const heading = document.createElement("h1");
+        heading.textContent = "Unable to start the portal";
+
+        const explanation = document.createElement("p");
+        explanation.textContent =
+          "A portal module is incompatible with the VUU version used by this application. Contact your portal administrator to deploy compatible versions.";
+
+        const details = document.createElement("p");
+        details.textContent = message;
+
+        alert.append(heading, explanation, details);
+        root.append(alert);
+      });
+    </script>
     <script type="module">
       window.vuuConfig = fetch("/config.json").then((res) => {
         if (res.ok) {

--- a/vuu-ui/portal-examples/portal-host/src/bootstrap.tsx
+++ b/vuu-ui/portal-examples/portal-host/src/bootstrap.tsx
@@ -6,58 +6,11 @@ import {
 } from "@vuu-ui/core";
 import { ConnectionManager } from "@vuu-ui/vuu-data-remote";
 import { PageVisibilityObserver } from "@vuu-ui/vuu-utils";
-import { type ReactNode, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 
 import "@vuu-ui/vuu-icons/index.css";
 import "@vuu-ui/vuu-theme/index.css";
-
-const getError = (reason: unknown) =>
-  reason instanceof Error ? reason : Error(String(reason));
-
-const FederationRuntimeErrorHandler = ({
-  children,
-}: {
-  children: ReactNode;
-}) => {
-  const [error, setError] = useState<Error>();
-
-  useEffect(() => {
-    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
-      const nextError = getError(event.reason);
-      if (!nextError.message.startsWith("[ Federation Runtime ]")) {
-        return;
-      }
-
-      event.preventDefault();
-      setError(nextError);
-    };
-
-    window.addEventListener("unhandledrejection", handleUnhandledRejection);
-    return () =>
-      window.removeEventListener(
-        "unhandledrejection",
-        handleUnhandledRejection,
-      );
-  }, []);
-
-  if (error) {
-    return (
-      <div role="alert">
-        <h1>Unable to load the portal module</h1>
-        <p>
-          A portal module is incompatible with the VUU version used by this
-          application. Contact your portal administrator to deploy compatible
-          versions.
-        </p>
-        <p>{error.message}</p>
-      </div>
-    );
-  }
-
-  return children;
-};
 
 init({
   name: "host",
@@ -84,21 +37,19 @@ async function start(): Promise<void> {
   try {
     const root = createRoot(container);
     root.render(
-      <FederationRuntimeErrorHandler>
-        <AuthenticationErrorBoundary
-          fallback={(error) => (
-            <div role="alert">Unable to authenticate: {error.message}</div>
-          )}
+      <AuthenticationErrorBoundary
+        fallback={(error) => (
+          <div role="alert">Unable to authenticate: {error.message}</div>
+        )}
+      >
+        <AuthenticationProvider
+          authConfig={config}
+          authHandlerClass={KeycloakAuthHandler}
+          mode="identity"
         >
-          <AuthenticationProvider
-            authConfig={config}
-            authHandlerClass={KeycloakAuthHandler}
-            mode="identity"
-          >
-            <App />
-          </AuthenticationProvider>
-        </AuthenticationErrorBoundary>
-      </FederationRuntimeErrorHandler>,
+          <App />
+        </AuthenticationProvider>
+      </AuthenticationErrorBoundary>,
     );
   } catch (err: unknown) {
     console.error(err);


### PR DESCRIPTION
## Root cause
The shared singleton mismatch occurs while Rspack loads the federated entry chunk. `@vuu-ui/core` is resolved before `bootstrap.tsx` is evaluated, so none of the previous React, `loadRemote`, `Suspense`, or bootstrap-level rejection handlers could execute.

## Changes
- install the Federation rejection handler in the HTML template before `index.js`
- render a safe, accessible compatibility error directly into the portal root
- remove the unsuccessful bootstrap React handler, internal `Suspense` change, and deferred remote registration change

## Browser reproduction and verification
Built `portal-host` with its current intentional mismatch (`@vuu-ui/core` actual `3.3.8`, required `3.3.5`) and loaded the production output in Chromium.

Before this change:
- `#root` text: empty
- page error: `[ Federation Runtime ]: Version 3.3.8 ... does not satisfy ... 3.3.5`

After this change:
- `#root` contains the compatibility alert and exact Federation details
- page errors: none

## Additional validation
- `npm run build:mf -- --portal-host`
- `npx vitest run packages/core/test/remote-module/RemoteModule.test.tsx`
- `npm run typecheck`
- `npx biome check packages/core/src/remote-module/RemoteModule.tsx packages/core/test/remote-module/RemoteModule.test.tsx portal-examples/portal-host/src/bootstrap.tsx`