### PR TITLE
feat(user-admin): render module access summary

### DIFF
--- a/vuu-ui/portal-examples/user-admin/requirements.md
+++ b/vuu-ui/portal-examples/user-admin/requirements.md
@@ -7,7 +7,8 @@ bootstrap creates a `BrowserRouter`.
 The host scopes the authenticated portal module registry through the typed
 `PortalModuleRegistryProvider` context around the user-admin remote. The
 descriptor includes the existing remote loading and connection fields plus the
-stable `clientIdentifier` and module `loginRole` metadata. User-admin does not
+stable `clientIdentifier` and module access-role metadata in `loginRole`.
+User-admin does not
 authenticate against Keycloak, receive the registry as component props, or
 fetch a second module list; this host-provided contract is reserved for
 module-oriented access work. The provider and hook are also the role-check

--- a/vuu-ui/portal-examples/user-admin/requirements.md
+++ b/vuu-ui/portal-examples/user-admin/requirements.md
@@ -10,8 +10,8 @@ descriptor includes the existing remote loading and connection fields plus the
 stable `clientIdentifier` and module `loginRole` metadata. User-admin does not
 authenticate against Keycloak, receive the registry as component props, or
 fetch a second module list; this host-provided contract is reserved for
-module-oriented access work in the next phase. The provider and hook are the
-future role-check enforcement boundary.
+module-oriented access work. The provider and hook are also the role-check
+enforcement boundary.
 
 ## Navigation and layout
 
@@ -91,6 +91,12 @@ Logical names follow the agreed contract: `user_id`, `group_id`, `role_id`,
 `client_id`, `username`, `email`, `first_name`, `last_name`, `enabled`,
 `password_update_required`, `group_name`, `group_path`, `role_name`,
 `client_identifier`, `client_name`, `description` and relationship/count fields.
+The users table may additionally expose the server-derived `module_access`
+(comma-separated module login roles) and `module_access_count` fields. The
+rendered `module_access` column resolves login roles against the host-provided
+module registry for display and preserves unmatched role names; its subscribed
+server value is unchanged. Users do not require or add a `client_identifier`
+column. Column aliases are supported for these logical fields.
 Only searchable fields present in the actual schema are used. Missing required
 relationship columns fail closed with an explicit error, never an unfiltered
 list. Missing tables and subscription errors are visible and produce

--- a/vuu-ui/portal-examples/user-admin/requirements.md
+++ b/vuu-ui/portal-examples/user-admin/requirements.md
@@ -96,7 +96,11 @@ The users table may additionally expose the server-derived `module_access`
 rendered `module_access` column resolves login roles against the host-provided
 module registry for display and preserves unmatched role names; its subscribed
 server value is unchanged. Users do not require or add a `client_identifier`
-column. Column aliases are supported for these logical fields.
+column. Column aliases are supported for these logical fields. The users table
+hides identity/profile and aggregate fields (`user_id`, `first_name`,
+`last_name`, `email_verified`, `password_update_required`, `group_count`, and
+`role_count`) by default while retaining them in the data source and user
+details side panel.
 Only searchable fields present in the actual schema are used. Missing required
 relationship columns fail closed with an explicit error, never an unfiltered
 list. Missing tables and subscription errors are visible and produce

--- a/vuu-ui/portal-examples/user-admin/src/components/AdminEditForm.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/AdminEditForm.tsx
@@ -22,6 +22,7 @@ import { RoleForm } from "../pages/roles/RoleForm";
 import { UserForm } from "../pages/users/UserForm";
 import { FORM_FIELDS, REQUIRED_FIELDS } from "./AdminFormField";
 import { AdminRelationshipField } from "./AdminRelationshipField";
+import { ModuleAccessField } from "./ModuleAccessField";
 
 export interface AdminEditFormProps {
   entity: Entity;
@@ -317,7 +318,7 @@ export const AdminEditForm = ({
         editing={!!record}
         disabled={!ready || busy || persisted}
         relationships={
-          entity === "roles" ? undefined : (
+          entity === "groups" ? (
             <AdminRelationshipField
               entity={entity}
               record={record}
@@ -325,12 +326,13 @@ export const AdminEditForm = ({
               changes={relationships}
               onChange={setRelationships}
             />
-          )
+          ) : undefined
         }
         onChange={(field, value) =>
           setValues((previous) => ({ ...previous, [field]: value }))
         }
       />
+      {entity === "users" ? <ModuleAccessField record={record} /> : null}
       <div className="vuuIdentityAdmin-formActions">
         <Button type="submit" disabled={!ready || busy || missingRequired}>
           Save

--- a/vuu-ui/portal-examples/user-admin/src/components/AdminTable.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/AdminTable.tsx
@@ -3,6 +3,7 @@ import { Table } from "@vuu-ui/vuu-table";
 import { DataSourceStats, TableFooter } from "@vuu-ui/vuu-table-extras";
 import { useMemo } from "react";
 import { CLIENT_IDENTIFIER_CELL_RENDERER } from "./ClientIdentifierCell";
+import { MODULE_ACCESS_CELL_RENDERER } from "./ModuleAccessCell";
 import { useAdminConfig } from "../data/AdminDataContext";
 import {
   displayColumnsFor,
@@ -18,6 +19,21 @@ const MODULE_CLIENT_IDENTIFIER_TABLES = new Set<AdminTableName>([
   "group_roles",
   "user_group_roles",
 ]);
+
+const withModuleAccessRenderer = (
+  name: AdminTableName,
+  column: ReturnType<typeof displayColumnsFor>[number],
+  moduleAccessColumn: string,
+) =>
+  name === "users" && column.name === moduleAccessColumn
+    ? {
+        ...column,
+        type: {
+          name: "string" as const,
+          renderer: { name: MODULE_ACCESS_CELL_RENDERER },
+        },
+      }
+    : column;
 
 const withClientIdentifierRenderer = (
   name: AdminTableName,
@@ -55,9 +71,14 @@ export const AdminTableView = ({
     () => ({
       columns: schema
         ? displayColumnsFor(schema, adminConfig, name).map((column) => {
-            const renderedColumn = withClientIdentifierRenderer(
+            const moduleAccessColumn = withModuleAccessRenderer(
               name,
               column,
+              columnFor(adminConfig, name, "module_access"),
+            );
+            const renderedColumn = withClientIdentifierRenderer(
+              name,
+              moduleAccessColumn,
               columnFor(adminConfig, name, "client_identifier"),
             );
             return {

--- a/vuu-ui/portal-examples/user-admin/src/components/EntityDetails.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/EntityDetails.tsx
@@ -17,6 +17,8 @@ const detailFields: Record<Entity, string[]> = {
     "password_update_required",
     "last_login",
     "created_at",
+    "group_count",
+    "role_count",
   ],
   groups: [
     "group_name",

--- a/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessCell.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessCell.tsx
@@ -8,22 +8,22 @@ export const resolveModuleAccessSummary = (
   value: unknown,
   remoteModules: ReturnType<typeof usePortalModuleRegistry>["remoteModules"],
 ) => {
-  const loginRoles =
+  const accessRoles =
     typeof value === "string"
       ? value
           .split(",")
-          .map((loginRole) => loginRole.trim())
+          .map((accessRole) => accessRole.trim())
           .filter(Boolean)
       : [];
 
-  if (!loginRoles.length) return "No module access";
+  if (!accessRoles.length) return "No module access";
 
-  return loginRoles
-    .map((loginRole) => {
+  return accessRoles
+    .map((accessRole) => {
       const module = remoteModules.find(
-        ({ loginRole: moduleLoginRole }) => moduleLoginRole === loginRole,
+        ({ loginRole: moduleAccessRole }) => moduleAccessRole === accessRole,
       );
-      return module?.title ?? module?.name ?? loginRole;
+      return module?.title ?? module?.name ?? accessRole;
     })
     .join(", ");
 };

--- a/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessCell.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessCell.tsx
@@ -1,10 +1,11 @@
+import { ListBox, Option } from "@salt-ds/core";
 import { usePortalModuleRegistry } from "@vuu-ui/core/portal";
 import type { TableCellRendererProps } from "@vuu-ui/vuu-table-types";
 import { registerComponent } from "@vuu-ui/vuu-utils";
 
 export const MODULE_ACCESS_CELL_RENDERER = "vuu-portal-module-access-cell";
 
-export const resolveModuleAccessSummary = (
+export const resolveModuleAccessValues = (
   value: unknown,
   remoteModules: ReturnType<typeof usePortalModuleRegistry>["remoteModules"],
 ) => {
@@ -16,24 +17,36 @@ export const resolveModuleAccessSummary = (
           .filter(Boolean)
       : [];
 
-  if (!accessRoles.length) return "No module access";
+  if (!accessRoles.length) return ["No module access"];
 
-  return accessRoles
-    .map((accessRole) => {
-      const module = remoteModules.find(
-        ({ loginRole: moduleAccessRole }) => moduleAccessRole === accessRole,
-      );
-      return module?.title ?? module?.name ?? accessRole;
-    })
-    .join(", ");
+  return accessRoles.map((accessRole) => {
+    const module = remoteModules.find(
+      ({ loginRole: moduleAccessRole }) => moduleAccessRole === accessRole,
+    );
+    return module?.title ?? module?.name ?? accessRole;
+  });
 };
+
+export const resolveModuleAccessSummary = (
+  value: unknown,
+  remoteModules: ReturnType<typeof usePortalModuleRegistry>["remoteModules"],
+) => resolveModuleAccessValues(value, remoteModules).join(", ");
 
 export const ModuleAccessCell = ({
   column,
   dataRow,
 }: TableCellRendererProps) => {
   const { remoteModules } = usePortalModuleRegistry();
-  return <>{resolveModuleAccessSummary(dataRow[column.name], remoteModules)}</>;
+  const values = resolveModuleAccessValues(dataRow[column.name], remoteModules);
+  return (
+    <ListBox aria-label="Module access" bordered={false}>
+      {values.map((value) => (
+        <Option key={value} value={value}>
+          {value}
+        </Option>
+      ))}
+    </ListBox>
+  );
 };
 
 registerComponent(

--- a/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessCell.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessCell.tsx
@@ -1,0 +1,47 @@
+import { usePortalModuleRegistry } from "@vuu-ui/core/portal";
+import type { TableCellRendererProps } from "@vuu-ui/vuu-table-types";
+import { registerComponent } from "@vuu-ui/vuu-utils";
+
+export const MODULE_ACCESS_CELL_RENDERER = "vuu-portal-module-access-cell";
+
+export const resolveModuleAccessSummary = (
+  value: unknown,
+  remoteModules: ReturnType<typeof usePortalModuleRegistry>["remoteModules"],
+) => {
+  const loginRoles =
+    typeof value === "string"
+      ? value
+          .split(",")
+          .map((loginRole) => loginRole.trim())
+          .filter(Boolean)
+      : [];
+
+  if (!loginRoles.length) return "No module access";
+
+  return loginRoles
+    .map((loginRole) => {
+      const module = remoteModules.find(
+        ({ loginRole: moduleLoginRole }) => moduleLoginRole === loginRole,
+      );
+      return module?.title ?? module?.name ?? loginRole;
+    })
+    .join(", ");
+};
+
+export const ModuleAccessCell = ({
+  column,
+  dataRow,
+}: TableCellRendererProps) => {
+  const { remoteModules } = usePortalModuleRegistry();
+  return <>{resolveModuleAccessSummary(dataRow[column.name], remoteModules)}</>;
+};
+
+registerComponent(
+  MODULE_ACCESS_CELL_RENDERER,
+  ModuleAccessCell,
+  "cell-renderer",
+  {
+    serverDataType: "string",
+    userCanAssign: false,
+  },
+);

--- a/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessCell.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessCell.tsx
@@ -1,4 +1,3 @@
-import { ListBox, Option } from "@salt-ds/core";
 import { usePortalModuleRegistry } from "@vuu-ui/core/portal";
 import type { TableCellRendererProps } from "@vuu-ui/vuu-table-types";
 import { registerComponent } from "@vuu-ui/vuu-utils";
@@ -38,15 +37,7 @@ export const ModuleAccessCell = ({
 }: TableCellRendererProps) => {
   const { remoteModules } = usePortalModuleRegistry();
   const values = resolveModuleAccessValues(dataRow[column.name], remoteModules);
-  return (
-    <ListBox aria-label="Module access" bordered={false}>
-      {values.map((value) => (
-        <Option key={value} value={value}>
-          {value}
-        </Option>
-      ))}
-    </ListBox>
-  );
+  return <>{values.join(", ")}</>;
 };
 
 registerComponent(

--- a/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessField.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessField.tsx
@@ -1,20 +1,36 @@
-import { FormField, FormFieldHelperText, FormFieldLabel } from "@salt-ds/core";
+import {
+  FormField,
+  FormFieldHelperText,
+  FormFieldLabel,
+  ListBox,
+  Option,
+} from "@salt-ds/core";
 import { usePortalModuleRegistry } from "@vuu-ui/core/portal";
 import { useAdminConfig } from "../data/AdminDataContext";
 import { columnFor, type AdminRecord } from "../data/admin-contract";
-import { resolveModuleAccessSummary } from "./ModuleAccessCell";
+import { resolveModuleAccessValues } from "./ModuleAccessCell";
 
 export const ModuleAccessField = ({ record }: { record?: AdminRecord }) => {
   const config = useAdminConfig();
   const { remoteModules } = usePortalModuleRegistry();
   const value = record?.[columnFor(config, "users", "module_access")];
+  const values = resolveModuleAccessValues(value, remoteModules);
 
   return (
     <FormField disabled>
       <FormFieldLabel>Portal module access</FormFieldLabel>
-      <output aria-label="Remote module access">
-        {resolveModuleAccessSummary(value, remoteModules)}
-      </output>
+      <ListBox
+        aria-label="Remote module access"
+        bordered={false}
+        readOnly
+        selected={[]}
+      >
+        {values.map((module) => (
+          <Option key={module} value={module}>
+            {module}
+          </Option>
+        ))}
+      </ListBox>
       <FormFieldHelperText>
         {record
           ? "Read-only for now. Module access is inherited from the user's groups."

--- a/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessField.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessField.tsx
@@ -1,0 +1,25 @@
+import { FormField, FormFieldHelperText, FormFieldLabel } from "@salt-ds/core";
+import { usePortalModuleRegistry } from "@vuu-ui/core/portal";
+import { useAdminConfig } from "../data/AdminDataContext";
+import { columnFor, type AdminRecord } from "../data/admin-contract";
+import { resolveModuleAccessSummary } from "./ModuleAccessCell";
+
+export const ModuleAccessField = ({ record }: { record?: AdminRecord }) => {
+  const config = useAdminConfig();
+  const { remoteModules } = usePortalModuleRegistry();
+  const value = record?.[columnFor(config, "users", "module_access")];
+
+  return (
+    <FormField disabled>
+      <FormFieldLabel>Portal module access</FormFieldLabel>
+      <output aria-label="Remote module access">
+        {resolveModuleAccessSummary(value, remoteModules)}
+      </output>
+      <FormFieldHelperText>
+        {record
+          ? "Read-only for now. Module access is inherited from the user's groups."
+          : "Save this user, then reopen it to view portal module access."}
+      </FormFieldHelperText>
+    </FormField>
+  );
+};

--- a/vuu-ui/portal-examples/user-admin/src/components/RelationshipSummary.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/RelationshipSummary.tsx
@@ -5,6 +5,7 @@ import {
   type Entity,
 } from "../data/admin-contract";
 import { AdminTable } from "./AdminTable";
+import { ModuleAccessField } from "./ModuleAccessField";
 
 export const RelationshipSummary = ({
   entity,
@@ -20,6 +21,14 @@ export const RelationshipSummary = ({
       : entity === "groups"
         ? "group_id"
         : "role_id";
+  if (entity === "users") {
+    return (
+      <div className="vuuIdentityAdmin-relationships">
+        <ModuleAccessField record={record} />
+      </div>
+    );
+  }
+
   const id = record[columnFor(config, entity, idField)];
   if (id === undefined || id === null || id === "") {
     return (
@@ -31,20 +40,7 @@ export const RelationshipSummary = ({
   const query = { equals: { field: idField, value: String(id) } };
   return (
     <div className="vuuIdentityAdmin-relationships">
-      {entity === "users" ? (
-        <>
-          <AdminTable
-            name="user_groups"
-            query={query}
-            title="Group memberships"
-          />
-          <AdminTable
-            name="user_group_roles"
-            query={query}
-            title="Client roles through groups"
-          />
-        </>
-      ) : entity === "groups" ? (
+      {entity === "groups" ? (
         <>
           <AdminTable
             name="user_groups"

--- a/vuu-ui/portal-examples/user-admin/src/data/admin-contract.ts
+++ b/vuu-ui/portal-examples/user-admin/src/data/admin-contract.ts
@@ -73,7 +73,15 @@ export const INTERNAL_COLUMNS = new Set([
 export const DEFAULT_HIDDEN_COLUMNS: Partial<
   Record<AdminTableName, readonly string[]>
 > = {
-  users: ["user_id"],
+  users: [
+    "user_id",
+    "first_name",
+    "last_name",
+    "email_verified",
+    "password_update_required",
+    "group_count",
+    "role_count",
+  ],
   groups: ["group_id"],
   roles: ["role_id", "client_id"],
 };

--- a/vuu-ui/portal-examples/user-admin/test/admin-client-identifier-renderer.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-client-identifier-renderer.test.tsx
@@ -7,7 +7,7 @@ const remoteModules = [
     clientIdentifier: "vuu-orders",
     description: "Orders module",
     id: "orders",
-    loginRole: "orders-login",
+    loginRole: "orders-access",
     location: "orders",
     mfComponent: "Orders",
     mfScope: "orders",

--- a/vuu-ui/portal-examples/user-admin/test/admin-contract.test.ts
+++ b/vuu-ui/portal-examples/user-admin/test/admin-contract.test.ts
@@ -87,17 +87,31 @@ describe("server-driven identity contract", () => {
       ...schema,
       columns: [
         { name: "user_id", serverDataType: "string" },
+        { name: "first_name", serverDataType: "string" },
+        { name: "last_name", serverDataType: "string" },
+        { name: "email_verified", serverDataType: "boolean" },
+        { name: "password_update_required", serverDataType: "boolean" },
+        { name: "group_count", serverDataType: "long" },
+        { name: "role_count", serverDataType: "long" },
         { name: "username", serverDataType: "string" },
+        { name: "module_access", serverDataType: "string" },
         { name: "vuuMsg", serverDataType: "string" },
       ],
     };
 
     expect(
       displayColumnsFor(identitySchema, {}, "users").map(({ name }) => name),
-    ).toEqual(["username"]);
+    ).toEqual(["username", "module_access"]);
     expect(identitySchema.columns.map(({ name }) => name)).toEqual([
       "user_id",
+      "first_name",
+      "last_name",
+      "email_verified",
+      "password_update_required",
+      "group_count",
+      "role_count",
       "username",
+      "module_access",
       "vuuMsg",
     ]);
   });

--- a/vuu-ui/portal-examples/user-admin/test/admin-edit-form.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-edit-form.test.tsx
@@ -525,6 +525,10 @@ describe("AdminEditForm sessions", () => {
     await render();
     expect(container.textContent).toContain("Portal module access");
     expect(container.textContent).toContain("User Admin");
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull();
+    expect(container.querySelector('[role="option"]')?.textContent).toBe(
+      "User Admin",
+    );
     expect(container.textContent).not.toContain("Group membership");
     expect(container.textContent).not.toContain("Client-role assignments");
     expect(container.textContent).not.toContain("Choose Traders");

--- a/vuu-ui/portal-examples/user-admin/test/admin-edit-form.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-edit-form.test.tsx
@@ -24,10 +24,26 @@ const mocks = vi.hoisted(() => {
       terminate() {}
     },
   );
-  return { notify: vi.fn(), queries: vi.fn(), clientIdentifier: "vuu-portal" };
+  return {
+    notify: vi.fn(),
+    queries: vi.fn(),
+    clientIdentifier: "vuu-portal",
+    remoteModules: [
+      {
+        name: "user-admin",
+        title: "User Admin",
+        loginRole: "user-admin-access",
+      },
+    ],
+  };
 });
 vi.mock("@vuu-ui/vuu-notifications", () => ({
   useNotifications: () => ({ showNotification: mocks.notify }),
+}));
+vi.mock("@vuu-ui/core/portal", () => ({
+  usePortalModuleRegistry: () => ({
+    remoteModules: mocks.remoteModules,
+  }),
 }));
 vi.mock("../src/components/AdminTable", () => ({
   AdminTable: ({
@@ -425,12 +441,11 @@ describe("AdminEditForm sessions", () => {
     expect(session.unsubscribe).toHaveBeenCalledOnce();
   });
 
-  it("defers create relationships without guessing an ID", async () => {
+  it("defers create module access display without guessing an ID", async () => {
     await render();
     expect(control("Temporary password").disabled).toBe(false);
-    expect(container.textContent).toContain(
-      "Save this identity, then reopen it",
-    );
+    expect(container.textContent).toContain("Save this user, then reopen it");
+    expect(container.textContent).not.toContain("Group membership");
     await click("Cancel");
     expect(persist).not.toHaveBeenCalled();
     expect(edit).not.toHaveBeenCalled();
@@ -499,51 +514,22 @@ describe("AdminEditForm sessions", () => {
     ).toBe(false);
   });
 
-  it("stages group membership without writes, then retries only the failed assignment after partial success", async () => {
+  it("shows module access without exposing group or role assignments for users", async () => {
     props.record = {
       key: "u1",
       user_id: "u1",
       username: "alice",
       enabled: true,
+      module_access: "user-admin-access",
     };
-    persist
-      .mockResolvedValueOnce(SUCCESS)
-      .mockResolvedValueOnce({
-        type: "ERROR_RESULT",
-        errorMessage: "Assignment rejected",
-      })
-      .mockResolvedValue(SUCCESS);
     await render();
-    await click("Choose Traders");
-    expect(persist).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("Add Traders");
-    await submit();
-    expect(persist).toHaveBeenNthCalledWith(2, {
-      type: "RPC_REQUEST",
-      rpcName: "assignUserToGroup",
-      params: { userId: "u1", groupId: "g1" },
-    });
-    expect(container.textContent).toContain("Assignment rejected");
-    expect(end).not.toHaveBeenCalled();
-    expect(mocks.notify).not.toHaveBeenCalledWith(
-      expect.objectContaining({ status: "success" }),
-    );
-    await submit();
-    expect(persist).toHaveBeenCalledTimes(3);
-    expect(persist).toHaveBeenNthCalledWith(3, {
-      type: "RPC_REQUEST",
-      rpcName: "assignUserToGroup",
-      params: { userId: "u1", groupId: "g1" },
-    });
-    expect(end).toHaveBeenCalledWith(false, false);
-  });
-
-  it("discards staged membership changes without invoking a domain RPC", async () => {
-    props.record = { key: "u1", user_id: "u1", username: "alice" };
-    await render();
-    await click("Remove Traders");
-    await click("Discard");
-    expect(persist).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Portal module access");
+    expect(container.textContent).toContain("User Admin");
+    expect(container.textContent).not.toContain("Group membership");
+    expect(container.textContent).not.toContain("Client-role assignments");
+    expect(container.textContent).not.toContain("Choose Traders");
+    expect(container.textContent).not.toContain("Remove Traders");
+    expect(mocks.queries).not.toHaveBeenCalled();
   });
 
   it("persists group client-role assignments with stable role and client IDs", async () => {

--- a/vuu-ui/portal-examples/user-admin/test/admin-entity-page.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-entity-page.test.tsx
@@ -35,7 +35,18 @@ vi.mock("../src/components/AdminTable", () => ({
         data-testid="select"
         disabled={selectionDisabled}
         onClick={() =>
-          onSelect({ key: "u1", user_id: "u1", username: "Alice" })
+          onSelect({
+            key: "u1",
+            user_id: "u1",
+            username: "Alice",
+            first_name: "Alice",
+            last_name: "Example",
+            email: "alice@example.com",
+            email_verified: true,
+            password_update_required: false,
+            group_count: 2,
+            role_count: 3,
+          })
         }
       >
         Select Alice
@@ -100,6 +111,12 @@ describe("entity panel modes", () => {
     expect(mocks.form).not.toHaveBeenCalled();
     await click('[data-testid="select"]');
     expect(container.textContent).toContain("Alice");
+    expect(container.textContent).toContain("Example");
+    expect(container.textContent).toContain("alice@example.com");
+    expect(container.textContent).toContain("email verified");
+    expect(container.textContent).toContain("password update required");
+    expect(container.textContent).toContain("group count");
+    expect(container.textContent).toContain("role count");
     expect(mocks.form).not.toHaveBeenCalled();
     const edit = [...container.querySelectorAll("button")].find(
       (button) => button.textContent === "Edit user",

--- a/vuu-ui/portal-examples/user-admin/test/admin-module-access-renderer.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-module-access-renderer.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { RemoteModuleDescriptor } from "@vuu-ui/core/portal";
+import { resolveModuleAccessSummary } from "../src/components/ModuleAccessCell";
+
+const remoteModules = [
+  {
+    clientIdentifier: "vuu-orders",
+    description: "Orders module",
+    id: "orders",
+    loginRole: "orders-login",
+    location: "orders",
+    mfComponent: "Orders",
+    mfScope: "orders",
+    mfUrl: "http://localhost:5001",
+    name: "orders",
+    path: "/orders",
+    title: "Orders",
+    version: 1,
+  },
+  {
+    clientIdentifier: "vuu-risk",
+    description: "Risk module",
+    id: "risk",
+    loginRole: "risk-login",
+    location: "risk",
+    mfComponent: "Risk",
+    mfScope: "risk",
+    mfUrl: "http://localhost:5002",
+    name: "risk",
+    path: "/risk",
+    title: "Risk",
+    version: 1,
+  },
+] satisfies readonly RemoteModuleDescriptor[];
+
+describe("module access cell renderer", () => {
+  it("maps login roles to module titles in server order", () => {
+    expect(
+      resolveModuleAccessSummary(
+        "risk-login,orders-login,unknown-login",
+        remoteModules,
+      ),
+    ).toBe("Risk, Orders, unknown-login");
+  });
+
+  it("renders an explicit empty summary", () => {
+    expect(resolveModuleAccessSummary("", remoteModules)).toBe(
+      "No module access",
+    );
+    expect(resolveModuleAccessSummary(null, remoteModules)).toBe(
+      "No module access",
+    );
+  });
+});

--- a/vuu-ui/portal-examples/user-admin/test/admin-module-access-renderer.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-module-access-renderer.test.tsx
@@ -1,11 +1,6 @@
-import { PortalModuleRegistryProvider } from "@vuu-ui/core/portal";
 import { describe, expect, it } from "vitest";
-import { act } from "react";
-import { createRoot } from "react-dom/client";
 import type { RemoteModuleDescriptor } from "@vuu-ui/core/portal";
-import type { DataRow } from "@vuu-ui/vuu-table-types";
 import {
-  ModuleAccessCell,
   resolveModuleAccessSummary,
   resolveModuleAccessValues,
 } from "../src/components/ModuleAccessCell";
@@ -70,44 +65,5 @@ describe("module access cell renderer", () => {
     expect(resolveModuleAccessSummary(null, remoteModules)).toBe(
       "No module access",
     );
-  });
-
-  it("renders resolved values in a Salt ListBox", () => {
-    const container = document.createElement("div");
-    const root = createRoot(container);
-    act(() => {
-      root.render(
-        <PortalModuleRegistryProvider remoteModules={remoteModules}>
-          <ModuleAccessCell
-            column={{
-              name: "module_access",
-              ariaColIndex: 1,
-              label: "Module access",
-              valueFormatter: String,
-              width: 120,
-            }}
-            dataRow={
-              {
-                module_access: "risk-access,orders-access",
-                childCount: 0,
-                depth: 0,
-                index: 0,
-                isExpanded: false,
-                isSelected: false,
-                isLeaf: true,
-                key: "user-1",
-                renderIndex: 0,
-                hasColumn: () => true,
-              } as unknown as DataRow
-            }
-          />
-        </PortalModuleRegistryProvider>,
-      );
-    });
-
-    expect(container.querySelector('[role="listbox"]')).not.toBeNull();
-    expect(container.textContent).toContain("Risk");
-    expect(container.textContent).toContain("Orders");
-    root.unmount();
   });
 });

--- a/vuu-ui/portal-examples/user-admin/test/admin-module-access-renderer.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-module-access-renderer.test.tsx
@@ -1,6 +1,14 @@
+import { PortalModuleRegistryProvider } from "@vuu-ui/core/portal";
 import { describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import type { RemoteModuleDescriptor } from "@vuu-ui/core/portal";
-import { resolveModuleAccessSummary } from "../src/components/ModuleAccessCell";
+import type { DataRow } from "@vuu-ui/vuu-table-types";
+import {
+  ModuleAccessCell,
+  resolveModuleAccessSummary,
+  resolveModuleAccessValues,
+} from "../src/components/ModuleAccessCell";
 
 const remoteModules = [
   {
@@ -36,6 +44,12 @@ const remoteModules = [
 describe("module access cell renderer", () => {
   it("maps login roles to module titles in server order", () => {
     expect(
+      resolveModuleAccessValues(
+        "risk-access,orders-access,unknown-access",
+        remoteModules,
+      ),
+    ).toEqual(["Risk", "Orders", "unknown-access"]);
+    expect(
       resolveModuleAccessSummary(
         "risk-access,orders-access,unknown-access",
         remoteModules,
@@ -44,11 +58,56 @@ describe("module access cell renderer", () => {
   });
 
   it("renders an explicit empty summary", () => {
+    expect(resolveModuleAccessValues("", remoteModules)).toEqual([
+      "No module access",
+    ]);
     expect(resolveModuleAccessSummary("", remoteModules)).toBe(
       "No module access",
     );
+    expect(resolveModuleAccessValues(null, remoteModules)).toEqual([
+      "No module access",
+    ]);
     expect(resolveModuleAccessSummary(null, remoteModules)).toBe(
       "No module access",
     );
+  });
+
+  it("renders resolved values in a Salt ListBox", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <PortalModuleRegistryProvider remoteModules={remoteModules}>
+          <ModuleAccessCell
+            column={{
+              name: "module_access",
+              ariaColIndex: 1,
+              label: "Module access",
+              valueFormatter: String,
+              width: 120,
+            }}
+            dataRow={
+              {
+                module_access: "risk-access,orders-access",
+                childCount: 0,
+                depth: 0,
+                index: 0,
+                isExpanded: false,
+                isSelected: false,
+                isLeaf: true,
+                key: "user-1",
+                renderIndex: 0,
+                hasColumn: () => true,
+              } as unknown as DataRow
+            }
+          />
+        </PortalModuleRegistryProvider>,
+      );
+    });
+
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull();
+    expect(container.textContent).toContain("Risk");
+    expect(container.textContent).toContain("Orders");
+    root.unmount();
   });
 });

--- a/vuu-ui/portal-examples/user-admin/test/admin-module-access-renderer.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-module-access-renderer.test.tsx
@@ -7,7 +7,7 @@ const remoteModules = [
     clientIdentifier: "vuu-orders",
     description: "Orders module",
     id: "orders",
-    loginRole: "orders-login",
+    loginRole: "orders-access",
     location: "orders",
     mfComponent: "Orders",
     mfScope: "orders",
@@ -21,7 +21,7 @@ const remoteModules = [
     clientIdentifier: "vuu-risk",
     description: "Risk module",
     id: "risk",
-    loginRole: "risk-login",
+    loginRole: "risk-access",
     location: "risk",
     mfComponent: "Risk",
     mfScope: "risk",
@@ -37,10 +37,10 @@ describe("module access cell renderer", () => {
   it("maps login roles to module titles in server order", () => {
     expect(
       resolveModuleAccessSummary(
-        "risk-login,orders-login,unknown-login",
+        "risk-access,orders-access,unknown-access",
         remoteModules,
       ),
-    ).toBe("Risk, Orders, unknown-login");
+    ).toBe("Risk, Orders, unknown-access");
   });
 
   it("renders an explicit empty summary", () => {

--- a/vuu-ui/portal-examples/user-admin/test/admin-relationships.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-relationships.test.tsx
@@ -18,14 +18,20 @@ vi.mock("../src/components/AdminTable", () => ({
     query: AdminQuery;
   }) => <output data-table={name}>{JSON.stringify(query)}</output>,
 }));
+vi.mock("@vuu-ui/core/portal", () => ({
+  usePortalModuleRegistry: () => ({
+    remoteModules: [
+      {
+        name: "user-admin",
+        title: "User Admin",
+        loginRole: "user-admin-access",
+      },
+    ],
+  }),
+}));
 
 describe("relationship summary filters", () => {
   it.each<{ entity: Entity; id: string; tables: string[] }>([
-    {
-      entity: "users",
-      id: "user_id",
-      tables: ["user_groups", "user_group_roles"],
-    },
     {
       entity: "groups",
       id: "group_id",
@@ -76,6 +82,34 @@ describe("relationship summary filters", () => {
       expect(container.querySelector('[role="alert"]')?.textContent).toContain(
         id,
       );
+    } finally {
+      act(() => root.unmount());
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("shows module access for users without rendering group relationships", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    try {
+      await act(async () =>
+        root.render(
+          <AdminDataContext.Provider value={{ users: { columns: {} } }}>
+            <RelationshipSummary
+              entity="users"
+              record={{ key: "row-key", module_access: "user-admin-access" }}
+            />
+          </AdminDataContext.Provider>,
+        ),
+      );
+      expect(container.textContent).toContain("Portal module access");
+      expect(container.textContent).toContain("User Admin");
+      expect(container.textContent).not.toContain("Group memberships");
+      expect(container.textContent).not.toContain(
+        "Client roles through groups",
+      );
+      expect(container.querySelectorAll("[data-table]")).toHaveLength(0);
     } finally {
       act(() => root.unmount());
       vi.unstubAllGlobals();

--- a/vuu-ui/portal-examples/user-admin/test/admin-routes.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-routes.test.tsx
@@ -15,7 +15,7 @@ const remoteModules = [
     description: "Manage users",
     id: 1,
     location: "/Admin/Users",
-    loginRole: "user-admin-login",
+    loginRole: "user-admin-access",
     mfComponent: "UserAdmin",
     mfScope: "userAdmin",
     mfUrl: "http://localhost:5007",
@@ -110,7 +110,7 @@ describe("embedded identity routes", () => {
       ),
     );
     expect(container.textContent).toContain("Overview page");
-    expect(container.textContent).toContain("vuu-user-admin:user-admin-login");
+    expect(container.textContent).toContain("vuu-user-admin:user-admin-access");
     const rail = container.querySelector<HTMLElement>(
       'nav[aria-label="Identity administration"]',
     );

--- a/vuu-ui/portal-examples/user-admin/test/admin-table.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-table.test.tsx
@@ -22,6 +22,16 @@ const mocks = vi.hoisted(() => ({
       { name: "username", serverDataType: "string" },
     ],
   } satisfies TableSchema,
+  usersModuleAccessSchema: {
+    key: "user_id",
+    table: { module: "KEYCLOAK_ADMIN", table: "users" },
+    columns: [
+      { name: "user_id", serverDataType: "string" },
+      { name: "username", serverDataType: "string" },
+      { name: "access_summary", serverDataType: "string" },
+      { name: "module_access_count", serverDataType: "long" },
+    ],
+  } satisfies TableSchema,
   rolesSchema: {
     key: "role_id",
     table: { module: "KEYCLOAK_ADMIN", table: "roles" },
@@ -93,6 +103,7 @@ describe("shared admin table column widths", () => {
     );
     const props = mocks.table.mock.lastCall?.[0];
     if (!props) throw new Error("Admin table was not rendered");
+    expect(props.dataSource).toBe(mocks.source);
     return props.config;
   };
 
@@ -121,6 +132,34 @@ describe("shared admin table column widths", () => {
     expect(mocks.schema).toEqual(before);
     expect(mocks.source.columns).toEqual(["user_id", "email", "username"]);
     expect(mocks.source.filter.filter).toBe('username contains "alice"');
+  });
+
+  it("renders aliased users module access without adding client identifiers", async () => {
+    const config = await renderWithSchema(
+      "users",
+      mocks.usersModuleAccessSchema,
+      {
+        users: { columns: { module_access: "access_summary" } },
+      },
+    );
+    expect(config.columns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "access_summary",
+          type: {
+            name: "string",
+            renderer: { name: "vuu-portal-module-access-cell" },
+          },
+        }),
+        expect.objectContaining({
+          name: "module_access_count",
+        }),
+      ]),
+    );
+    expect(
+      config.columns.some(({ name }) => name === "client_identifier"),
+    ).toBe(false);
+    expect(mocks.source.columns).toEqual(["user_id", "email", "username"]);
   });
 
   it("applies the email override to logical aliases and literal server names", async () => {


### PR DESCRIPTION
## Summary
- consume server-derived `module_access` and `module_access_count` users fields
- render login-role summaries through the host-provided portal module registry
- preserve unmatched role names, empty-state rendering, subscriptions, and configured column aliases
- keep users free of `client_identifier`

## Validation
- user-admin tests: 91 passed
- focused module access/table tests: 15 passed
- user-admin lint and typecheck passed
- full Vuu UI typecheck passed
- portal/core regression tests passed
- user-admin and portal-host production builds passed

This follow-up branch is based on the current Phase 2 Slice 1 branch for PR #2419. PR #2419 and Phase 1 PR #2417 remain unchanged.