### PR TITLE
feat(user-admin): add module-oriented access editing

### DIFF
--- a/vuu-ui/packages/vuu-ui-controls/src/item-picker/ItemPicker.tsx
+++ b/vuu-ui/packages/vuu-ui-controls/src/item-picker/ItemPicker.tsx
@@ -47,6 +47,8 @@ export interface ItemPickerProps
     HTMLAttributes<HTMLDivElement>,
     Pick<ListBoxProps<ItemDescriptor>, "selected" | "onSelectionChange"> {
   itemTypeName: ItemTypeName;
+  /** Render the search control as a form. Set false when the picker is nested in a form. */
+  searchForm?: boolean;
   createCustomItemProps?: CreateCustomItemProps;
 }
 
@@ -170,6 +172,7 @@ export const ItemPicker = forwardRef(function ItemPicker(
   {
     className,
     itemTypeName,
+    searchForm = true,
     allItems,
     selectedItems,
     maxSelections,
@@ -245,15 +248,27 @@ export const ItemPicker = forwardRef(function ItemPicker(
       className={cx(classBase, className)}
       ref={forwardedRef}
     >
-      <form className={`${classBase}-search`} role="search">
-        <Input
-          startAdornment={searchIcon}
-          placeholder={searchPlaceholderText}
-          ref={searchCallbackRef}
-          value={searchText}
-          onChange={onChangeSearchInput}
-        />
-      </form>
+      {searchForm ? (
+        <form className={`${classBase}-search`} role="search">
+          <Input
+            startAdornment={searchIcon}
+            placeholder={searchPlaceholderText}
+            ref={searchCallbackRef}
+            value={searchText}
+            onChange={onChangeSearchInput}
+          />
+        </form>
+      ) : (
+        <div className={`${classBase}-search`} role="search">
+          <Input
+            startAdornment={searchIcon}
+            placeholder={searchPlaceholderText}
+            ref={searchCallbackRef}
+            value={searchText}
+            onChange={onChangeSearchInput}
+          />
+        </div>
+      )}
 
       <div className={`${classBase}-scrollContainer vuuScrollable`}>
         <div className={`${classBase}-sectionHeader`}>

--- a/vuu-ui/portal-examples/user-admin/requirements.md
+++ b/vuu-ui/portal-examples/user-admin/requirements.md
@@ -153,6 +153,26 @@ new user/group and reopen it before assigning relationships. No unsafe array
 coercions or guessed IDs are used. This module does not currently expose delete
 actions, client administration, or direct user-role assignments.
 
+For an existing user, the module-oriented access editor loads its options through
+the source data service RPC `getUserModuleAccessOptions({ userId })`. The
+response must return each portal module's `clientIdentifier`, `loginRole`, its
+eligible groups, and the currently selected group. Each group must include
+`groupId`, `groupName`, `roleId`, `roleName`, and an explicit `isDefault` flag;
+`groupPath` and privilege metadata are displayed when supplied. The server, not
+the browser, determines the least-privileged default. The module picker stages
+additions, removals and eligible-group changes locally, then sends a
+deterministically ordered JSON assignment list through
+`setUserModuleAccess({ userId, assignments })` after the user entity save.
+Confirmed entity and module-access writes are tracked independently so retries do
+not repeat successful RPCs.
+
+The new module-access RPCs are an explicit backend prerequisite. If the source
+does not expose them or returns malformed data, the editor reports the contract
+gap and does not guess group membership; ordinary user fields remain editable.
+Associating groups with portal modules is not part of this slice and remains a
+Phase 3 boundary. This phase only consumes server-derived module options and
+assigns users to existing eligible groups.
+
 The old DockLayout/drawer and editable-users-grid requirements are superseded
 by this routed Identity Admin design.
 

--- a/vuu-ui/portal-examples/user-admin/src/components/AdminEditForm.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/AdminEditForm.tsx
@@ -17,6 +17,13 @@ import {
   saveAdminRelationship,
   type RelationshipChange,
 } from "../data/admin-mutations";
+import {
+  equalModuleAccessAssignments,
+  loadUserModuleAccess,
+  saveUserModuleAccess,
+  type ModuleAccessAssignment,
+  type UserModuleAccess,
+} from "../data/module-access";
 import { GroupForm } from "../pages/groups/GroupForm";
 import { RoleForm } from "../pages/roles/RoleForm";
 import { UserForm } from "../pages/users/UserForm";
@@ -67,6 +74,7 @@ interface EditorRun {
   disposed: boolean;
   busy: boolean;
   persisted: boolean;
+  moduleAccessPersisted: boolean;
   relationshipIndex: number;
   notified?: boolean;
   task: Promise<void>;
@@ -135,6 +143,7 @@ export const AdminEditForm = ({
       disposed: false,
       busy: false,
       persisted: false,
+      moduleAccessPersisted: false,
       relationshipIndex: 0,
       task: Promise.resolve(),
     };
@@ -196,10 +205,67 @@ export const AdminEditForm = ({
     };
   }, [dataSource, record, schema]);
 
+  const [moduleAccess, setModuleAccess] = useState<UserModuleAccess>();
+  const [moduleAssignments, setModuleAssignments] = useState<
+    ModuleAccessAssignment[]
+  >([]);
+  const [moduleAccessLoading, setModuleAccessLoading] = useState(false);
+  const [moduleAccessError, setModuleAccessError] = useState<string>();
+
+  useEffect(() => {
+    let active = true;
+    setModuleAccess(undefined);
+    setModuleAssignments([]);
+    setModuleAccessError(undefined);
+    if (entity !== "users" || !record) {
+      setModuleAccessLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+    const userId = record[columnFor(config, "users", "user_id")];
+    if (typeof userId !== "string" || !userId) {
+      setModuleAccessLoading(false);
+      setModuleAccessError(
+        "Backend contract unavailable: the selected user has no stable user ID.",
+      );
+      return () => {
+        active = false;
+      };
+    }
+    setModuleAccessLoading(true);
+    void loadUserModuleAccess(dataSource, userId)
+      .then((access) => {
+        if (!active) return;
+        setModuleAccess(access);
+        setModuleAssignments(access.assignments);
+      })
+      .catch((cause) => {
+        if (active) setModuleAccessError(errorMessage(cause));
+      })
+      .finally(() => {
+        if (active) setModuleAccessLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [config, dataSource, entity, record]);
+
+  const moduleAccessDirty =
+    !!moduleAccess &&
+    !equalModuleAccessAssignments(moduleAssignments, moduleAccess.assignments);
+
   const save = (event: FormEvent) => {
     event.preventDefault();
     const run = runRef.current;
-    if (!run || run.busy || !ready || missingRequired) return;
+    if (
+      !run ||
+      run.busy ||
+      !ready ||
+      missingRequired ||
+      (entity === "users" && !!record && moduleAccessLoading)
+    )
+      return;
     const missing = REQUIRED_FIELDS[entity].find(
       (field) => !String(values[field] ?? "").trim(),
     );
@@ -257,6 +323,23 @@ export const AdminEditForm = ({
             if (run.disposed) return;
           }
         }
+        if (
+          entity === "users" &&
+          record &&
+          moduleAccess &&
+          moduleAccessDirty &&
+          !run.moduleAccessPersisted
+        ) {
+          const userId = record[columnFor(config, "users", "user_id")];
+          if (typeof userId !== "string" || !userId) {
+            throw new Error(
+              "Backend contract unavailable: the selected user has no stable user ID.",
+            );
+          }
+          await saveUserModuleAccess(dataSource, userId, moduleAssignments);
+          run.moduleAccessPersisted = true;
+        }
+        if (run.disposed) return;
         if (!run.notified) {
           notifyRef.current({
             type: "toast",
@@ -332,9 +415,27 @@ export const AdminEditForm = ({
           setValues((previous) => ({ ...previous, [field]: value }))
         }
       />
-      {entity === "users" ? <ModuleAccessField record={record} /> : null}
+      {entity === "users" ? (
+        <ModuleAccessField
+          access={moduleAccess}
+          assignments={moduleAssignments}
+          disabled={!ready || busy || persisted}
+          error={moduleAccessError}
+          loading={moduleAccessLoading}
+          onChange={setModuleAssignments}
+          record={record}
+        />
+      ) : null}
       <div className="vuuIdentityAdmin-formActions">
-        <Button type="submit" disabled={!ready || busy || missingRequired}>
+        <Button
+          type="submit"
+          disabled={
+            !ready ||
+            busy ||
+            missingRequired ||
+            (entity === "users" && !!record && moduleAccessLoading)
+          }
+        >
           Save
         </Button>
         <Button type="button" disabled={busy} onClick={discard}>

--- a/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessField.tsx
+++ b/vuu-ui/portal-examples/user-admin/src/components/ModuleAccessField.tsx
@@ -6,36 +6,202 @@ import {
   Option,
 } from "@salt-ds/core";
 import { usePortalModuleRegistry } from "@vuu-ui/core/portal";
-import { useAdminConfig } from "../data/AdminDataContext";
+import { ItemPicker, type ItemDescriptor } from "@vuu-ui/vuu-ui-controls";
+import { useMemo, useState } from "react";
 import { columnFor, type AdminRecord } from "../data/admin-contract";
+import { useAdminConfig } from "../data/AdminDataContext";
 import { resolveModuleAccessValues } from "./ModuleAccessCell";
+import type {
+  ModuleAccessAssignment,
+  ModuleAccessModule,
+  UserModuleAccess,
+} from "../data/module-access";
 
-export const ModuleAccessField = ({ record }: { record?: AdminRecord }) => {
+export interface ModuleAccessFieldProps {
+  access?: UserModuleAccess;
+  assignments?: readonly ModuleAccessAssignment[];
+  disabled?: boolean;
+  error?: string;
+  loading?: boolean;
+  onChange?: (assignments: ModuleAccessAssignment[]) => void;
+  record?: AdminRecord;
+}
+
+const assignmentFor = (
+  assignments: readonly ModuleAccessAssignment[],
+  loginRole: string,
+) => assignments.find((assignment) => assignment.loginRole === loginRole);
+
+const groupLabel = (group: ModuleAccessModule["groups"][number]) =>
+  [group.groupName, group.groupPath, group.roleName, group.privilege]
+    .filter(Boolean)
+    .join(" · ");
+
+export const ModuleAccessField = ({
+  access,
+  assignments,
+  disabled = false,
+  error,
+  loading = false,
+  onChange,
+  record,
+}: ModuleAccessFieldProps) => {
   const config = useAdminConfig();
   const { remoteModules } = usePortalModuleRegistry();
-  const value = record?.[columnFor(config, "users", "module_access")];
-  const values = resolveModuleAccessValues(value, remoteModules);
+  const [selectionError, setSelectionError] = useState<string>();
+  const allItems = useMemo<ItemDescriptor[]>(
+    () =>
+      remoteModules.map((module) => ({
+        name: module.loginRole,
+        label: module.title ?? module.name,
+      })),
+    [remoteModules],
+  );
+  const currentAssignments = assignments ?? [];
+  const selectedItems = useMemo(
+    () =>
+      allItems.filter((item) =>
+        currentAssignments.some(({ loginRole }) => loginRole === item.name),
+      ),
+    [allItems, currentAssignments],
+  );
+  const selectedModules = useMemo(
+    () =>
+      (access?.modules ?? []).filter((module) =>
+        currentAssignments.some(
+          ({ loginRole }) => loginRole === module.loginRole,
+        ),
+      ),
+    [access?.modules, currentAssignments],
+  );
+
+  const changeSelection = (items: ItemDescriptor[]) => {
+    setSelectionError(undefined);
+    const selectedRoles = new Set(items.map(({ name }) => name));
+    const next = currentAssignments.filter(({ loginRole }) =>
+      selectedRoles.has(loginRole),
+    );
+    for (const item of items) {
+      if (assignmentFor(next, item.name)) continue;
+      const module = access?.modules.find(
+        ({ loginRole }) => loginRole === item.name,
+      );
+      const defaultGroup =
+        module?.groups.find(({ isDefault }) => isDefault) ??
+        (module?.groups.length === 1 ? module.groups[0] : undefined);
+      if (!defaultGroup) {
+        setSelectionError(
+          `No least-privileged group is available for ${item.label ?? item.name}.`,
+        );
+        return;
+      }
+      next.push({ loginRole: item.name, groupId: defaultGroup.groupId });
+    }
+    onChange?.(next);
+  };
+
+  const changeGroup = (loginRole: string, selected: string[]) => {
+    const groupId = selected[0];
+    if (!groupId) return;
+    onChange?.(
+      currentAssignments.map((assignment) =>
+        assignment.loginRole === loginRole
+          ? { ...assignment, groupId }
+          : assignment,
+      ),
+    );
+  };
+
+  if (!access || !onChange) {
+    const value = record?.[columnFor(config, "users", "module_access")];
+    const values = resolveModuleAccessValues(value, remoteModules);
+    return (
+      <FormField disabled>
+        <FormFieldLabel>Portal module access</FormFieldLabel>
+        <ListBox
+          aria-label="Remote module access"
+          bordered={false}
+          readOnly
+          selected={[]}
+        >
+          {values.map((module) => (
+            <Option key={module} value={module}>
+              {module}
+            </Option>
+          ))}
+        </ListBox>
+        <FormFieldHelperText>
+          {record
+            ? "Module access is inherited from the user's groups."
+            : "Save this user, then reopen it to edit portal module access."}
+        </FormFieldHelperText>
+      </FormField>
+    );
+  }
 
   return (
-    <FormField disabled>
+    <FormField disabled={disabled || loading || !record}>
       <FormFieldLabel>Portal module access</FormFieldLabel>
-      <ListBox
-        aria-label="Remote module access"
-        bordered={false}
-        readOnly
-        selected={[]}
-      >
-        {values.map((module) => (
-          <Option key={module} value={module}>
-            {module}
-          </Option>
-        ))}
-      </ListBox>
-      <FormFieldHelperText>
-        {record
-          ? "Read-only for now. Module access is inherited from the user's groups."
-          : "Save this user, then reopen it to view portal module access."}
-      </FormFieldHelperText>
+      {record ? (
+        <>
+          {loading ? <p role="status">Loading module access...</p> : null}
+          {error ? <p role="alert">{error}</p> : null}
+          {access ? (
+            <>
+              <ItemPicker
+                allItems={allItems}
+                aria-label="Portal modules"
+                itemTypeName="remote module"
+                searchForm={false}
+                selectedItems={selectedItems}
+                onSelectedItemsChange={changeSelection}
+              />
+              {selectedModules.map((module) => {
+                const assignment = assignmentFor(
+                  currentAssignments,
+                  module.loginRole,
+                );
+                return (
+                  <FormField key={module.loginRole}>
+                    <FormFieldLabel>
+                      {remoteModules.find(
+                        ({ loginRole }) => loginRole === module.loginRole,
+                      )?.title ??
+                        remoteModules.find(
+                          ({ loginRole }) => loginRole === module.loginRole,
+                        )?.name ??
+                        module.loginRole}{" "}
+                      group
+                    </FormFieldLabel>
+                    <ListBox
+                      aria-label={`${module.loginRole} group`}
+                      selected={assignment ? [assignment.groupId] : []}
+                      onSelectionChange={(_, selected) =>
+                        changeGroup(module.loginRole, selected)
+                      }
+                    >
+                      {module.groups.map((group) => (
+                        <Option key={group.groupId} value={group.groupId}>
+                          {groupLabel(group)}
+                        </Option>
+                      ))}
+                    </ListBox>
+                  </FormField>
+                );
+              })}
+            </>
+          ) : null}
+          {selectionError ? <p role="alert">{selectionError}</p> : null}
+          <FormFieldHelperText>
+            Add a module to use its least-privileged group, or choose an
+            eligible group for elevated access. Changes are saved with the user.
+          </FormFieldHelperText>
+        </>
+      ) : (
+        <FormFieldHelperText>
+          Save this user, then reopen it to edit portal module access.
+        </FormFieldHelperText>
+      )}
     </FormField>
   );
 };

--- a/vuu-ui/portal-examples/user-admin/src/data/module-access.ts
+++ b/vuu-ui/portal-examples/user-admin/src/data/module-access.ts
@@ -1,0 +1,178 @@
+import type { DataSource } from "@vuu-ui/vuu-data-types";
+import type { VuuRowDataItemType } from "@vuu-ui/vuu-protocol-types";
+import { isRpcError } from "@vuu-ui/vuu-utils";
+
+export const MODULE_ACCESS_OPTIONS_RPC = "getUserModuleAccessOptions";
+export const MODULE_ACCESS_RECONCILE_RPC = "setUserModuleAccess";
+
+export interface ModuleAccessGroup {
+  groupId: string;
+  groupName: string;
+  groupPath?: string;
+  roleId: string;
+  roleName: string;
+  privilege?: string;
+  isDefault: boolean;
+}
+
+export interface ModuleAccessModule {
+  clientIdentifier: string;
+  loginRole: string;
+  groups: ModuleAccessGroup[];
+  selectedGroupId?: string;
+}
+
+export interface ModuleAccessAssignment {
+  groupId: string;
+  loginRole: string;
+}
+
+export interface UserModuleAccess {
+  modules: ModuleAccessModule[];
+  assignments: ModuleAccessAssignment[];
+}
+
+export const sortModuleAccessAssignments = (
+  assignments: readonly ModuleAccessAssignment[],
+) =>
+  [...assignments].sort((left, right) =>
+    left.loginRole.localeCompare(right.loginRole),
+  );
+
+export const equalModuleAccessAssignments = (
+  left: readonly ModuleAccessAssignment[],
+  right: readonly ModuleAccessAssignment[],
+) =>
+  JSON.stringify(sortModuleAccessAssignments(left)) ===
+  JSON.stringify(sortModuleAccessAssignments(right));
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const requiredString = (
+  value: unknown,
+  field: string,
+  context: string,
+): string => {
+  if (typeof value !== "string" || !value) {
+    throw new Error(
+      `Backend contract unavailable: ${context} is missing "${field}".`,
+    );
+  }
+  return value;
+};
+
+const optionalString = (value: unknown): string | undefined =>
+  typeof value === "string" && value ? value : undefined;
+
+const parseGroup = (value: unknown, index: number): ModuleAccessGroup => {
+  if (!isRecord(value)) {
+    throw new Error(
+      `Backend contract unavailable: module access group ${index} is invalid.`,
+    );
+  }
+  const context = `module access group ${index}`;
+  if (typeof value.isDefault !== "boolean") {
+    throw new Error(
+      `Backend contract unavailable: ${context} is missing "isDefault".`,
+    );
+  }
+  return {
+    groupId: requiredString(value.groupId, "groupId", context),
+    groupName: requiredString(value.groupName, "groupName", context),
+    groupPath: optionalString(value.groupPath),
+    roleId: requiredString(value.roleId, "roleId", context),
+    roleName: requiredString(value.roleName, "roleName", context),
+    privilege: optionalString(value.privilege),
+    isDefault: value.isDefault,
+  };
+};
+
+const parseModule = (value: unknown, index: number): ModuleAccessModule => {
+  if (!isRecord(value)) {
+    throw new Error(
+      `Backend contract unavailable: module access module ${index} is invalid.`,
+    );
+  }
+  const context = `module access module ${index}`;
+  if (!Array.isArray(value.groups)) {
+    throw new Error(
+      `Backend contract unavailable: ${context} is missing "groups".`,
+    );
+  }
+  const groups = value.groups.map(parseGroup);
+  const selectedGroupId = optionalString(value.selectedGroupId);
+  if (
+    selectedGroupId &&
+    !groups.some(({ groupId }) => groupId === selectedGroupId)
+  ) {
+    throw new Error(
+      `Backend contract unavailable: ${context} selectedGroupId is not eligible.`,
+    );
+  }
+  return {
+    clientIdentifier: requiredString(
+      value.clientIdentifier,
+      "clientIdentifier",
+      context,
+    ),
+    loginRole: requiredString(value.loginRole, "loginRole", context),
+    groups,
+    selectedGroupId,
+  };
+};
+
+export const parseUserModuleAccess = (value: unknown): UserModuleAccess => {
+  if (!isRecord(value) || !Array.isArray(value.modules)) {
+    throw new Error(
+      'Backend contract unavailable: module access response is missing "modules".',
+    );
+  }
+  const modules = value.modules.map(parseModule);
+  const assignments = modules.flatMap(({ loginRole, selectedGroupId }) =>
+    selectedGroupId ? [{ loginRole, groupId: selectedGroupId }] : [],
+  );
+  return { modules, assignments };
+};
+
+const rpc = async (
+  dataSource: Pick<DataSource, "rpcRequest">,
+  rpcName: string,
+  params: Record<string, VuuRowDataItemType>,
+) => {
+  if (!dataSource.rpcRequest) {
+    throw new Error(
+      "Backend contract unavailable: module access RPCs are not supported.",
+    );
+  }
+  const result = await dataSource.rpcRequest({
+    type: "RPC_REQUEST",
+    rpcName,
+    params,
+  });
+  if (!result) {
+    throw new Error(`The ${rpcName} RPC returned no result.`);
+  }
+  if (isRpcError(result)) throw new Error(result.errorMessage);
+  return result.data;
+};
+
+export const loadUserModuleAccess = async (
+  dataSource: Pick<DataSource, "rpcRequest">,
+  userId: string,
+) =>
+  parseUserModuleAccess(
+    await rpc(dataSource, MODULE_ACCESS_OPTIONS_RPC, { userId }),
+  );
+
+export const saveUserModuleAccess = async (
+  dataSource: Pick<DataSource, "rpcRequest">,
+  userId: string,
+  assignments: readonly ModuleAccessAssignment[],
+) => {
+  const orderedAssignments = sortModuleAccessAssignments(assignments);
+  await rpc(dataSource, MODULE_ACCESS_RECONCILE_RPC, {
+    userId,
+    assignments: JSON.stringify(orderedAssignments),
+  });
+};

--- a/vuu-ui/portal-examples/user-admin/test/admin-edit-form.test.tsx
+++ b/vuu-ui/portal-examples/user-admin/test/admin-edit-form.test.tsx
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => {
       {
         name: "user-admin",
         title: "User Admin",
+        clientIdentifier: "vuu-user-admin",
         loginRole: "user-admin-access",
       },
     ],
@@ -164,6 +165,12 @@ describe("AdminEditForm sessions", () => {
     mocks.notify.mockClear();
     mocks.queries.mockClear();
     mocks.clientIdentifier = "vuu-portal";
+    mocks.remoteModules.splice(0, mocks.remoteModules.length, {
+      name: "user-admin",
+      title: "User Admin",
+      clientIdentifier: "vuu-user-admin",
+      loginRole: "user-admin-access",
+    });
     container = document.createElement("div");
     document.body.append(container);
     root = createRoot(container);
@@ -171,6 +178,45 @@ describe("AdminEditForm sessions", () => {
     add = vi.fn().mockResolvedValue(SUCCESS);
     edit = vi.fn().mockResolvedValue(SUCCESS);
     persist = vi.fn().mockResolvedValue(SUCCESS);
+    const rpcRequest = vi.fn((request) => {
+      if (request.rpcName === "getUserModuleAccessOptions") {
+        return Promise.resolve({
+          type: "SUCCESS_RESULT",
+          data: {
+            modules: mocks.remoteModules.map((module, index) => {
+              const groupId =
+                index === 0 ? "g-default" : `${module.name}-default`;
+              return {
+                clientIdentifier: module.clientIdentifier,
+                loginRole: module.loginRole,
+                selectedGroupId: index === 0 ? groupId : undefined,
+                groups: [
+                  {
+                    groupId,
+                    groupName: `${module.title} viewers`,
+                    groupPath: `/${module.name}/viewers`,
+                    roleId: `${module.name}-viewer-role`,
+                    roleName: `${module.loginRole}-access`,
+                    privilege: "default",
+                    isDefault: true,
+                  },
+                  {
+                    groupId: `${module.name}-elevated`,
+                    groupName: `${module.title} operators`,
+                    groupPath: `/${module.name}/operators`,
+                    roleId: `${module.name}-operator-role`,
+                    roleName: `${module.loginRole}-access`,
+                    privilege: "elevated",
+                    isDefault: false,
+                  },
+                ],
+              };
+            }),
+          },
+        });
+      }
+      return persist(request);
+    });
     session = {
       endEditSession: end,
       addRow: add,
@@ -192,7 +238,7 @@ describe("AdminEditForm sessions", () => {
       dataSource: {
         createSessionDataSource: begin,
         selectedRowsCount: 1,
-        rpcRequest: persist,
+        rpcRequest,
       } as unknown as DataSource,
       onClose: vi.fn(),
     };
@@ -534,6 +580,55 @@ describe("AdminEditForm sessions", () => {
     expect(container.textContent).not.toContain("Choose Traders");
     expect(container.textContent).not.toContain("Remove Traders");
     expect(mocks.queries).not.toHaveBeenCalled();
+  });
+
+  it("stages module additions with default groups and saves selected alternatives", async () => {
+    mocks.remoteModules.push({
+      name: "trading",
+      title: "Trading",
+      clientIdentifier: "vuu-trading",
+      loginRole: "trading-login",
+    });
+    props.record = {
+      key: "u1",
+      user_id: "u1",
+      username: "alice",
+      enabled: true,
+      module_access: "user-admin-access",
+    };
+    await render();
+    expect(container.textContent).not.toContain(
+      "Associate groups with modules",
+    );
+    const addTrading = container.querySelector<HTMLButtonElement>(
+      '.vuuItemPicker-availableList [data-name="trading-login"] button',
+    );
+    expect(addTrading).not.toBeNull();
+    await act(async () => addTrading?.click());
+    expect(container.textContent).toContain("Trading group");
+    const tradingGroups = container.querySelector<HTMLElement>(
+      '[aria-label="trading-login group"]',
+    );
+    expect(tradingGroups).not.toBeNull();
+    const elevated = [
+      ...(tradingGroups?.querySelectorAll('[role="option"]') ?? []),
+    ].find((option) => option.textContent?.includes("elevated"));
+    expect(elevated).not.toBeNull();
+    await act(async () =>
+      elevated?.dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    await submit();
+    expect(persist).toHaveBeenCalledWith({
+      type: "RPC_REQUEST",
+      rpcName: "setUserModuleAccess",
+      params: {
+        userId: "u1",
+        assignments: JSON.stringify([
+          { loginRole: "trading-login", groupId: "trading-elevated" },
+          { loginRole: "user-admin-access", groupId: "g-default" },
+        ]),
+      },
+    });
   });
 
   it("persists group client-role assignments with stable role and client IDs", async () => {

--- a/vuu-ui/portal-examples/user-admin/test/admin-module-access.test.ts
+++ b/vuu-ui/portal-examples/user-admin/test/admin-module-access.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  loadUserModuleAccess,
+  MODULE_ACCESS_OPTIONS_RPC,
+  MODULE_ACCESS_RECONCILE_RPC,
+  parseUserModuleAccess,
+  saveUserModuleAccess,
+} from "../src/data/module-access";
+
+const moduleResponse = {
+  modules: [
+    {
+      clientIdentifier: "vuu-trading",
+      loginRole: "trading-login",
+      selectedGroupId: "trader",
+      groups: [
+        {
+          groupId: "viewer",
+          groupName: "Trading viewers",
+          groupPath: "/Trading/viewers",
+          roleId: "viewer-role",
+          roleName: "trading-access",
+          privilege: "read",
+          isDefault: true,
+        },
+        {
+          groupId: "trader",
+          groupName: "Traders",
+          groupPath: "/Trading/traders",
+          roleId: "trader-role",
+          roleName: "trading-access",
+          privilege: "trade",
+          isDefault: false,
+        },
+      ],
+    },
+  ],
+};
+
+describe("module access RPC contract", () => {
+  it("normalizes selected module groups into assignments", () => {
+    expect(parseUserModuleAccess(moduleResponse)).toEqual({
+      modules: moduleResponse.modules,
+      assignments: [{ loginRole: "trading-login", groupId: "trader" }],
+    });
+  });
+
+  it("rejects incomplete group metadata instead of guessing", () => {
+    expect(() =>
+      parseUserModuleAccess({
+        modules: [
+          {
+            ...moduleResponse.modules[0],
+            groups: [{ isDefault: true }],
+          },
+        ],
+      }),
+    ).toThrow('missing "groupId"');
+  });
+
+  it("loads options through the existing data-source RPC boundary", async () => {
+    const rpcRequest = vi.fn().mockResolvedValue({
+      type: "SUCCESS_RESULT",
+      data: moduleResponse,
+    });
+    await expect(loadUserModuleAccess({ rpcRequest }, "u1")).resolves.toEqual({
+      modules: moduleResponse.modules,
+      assignments: [{ loginRole: "trading-login", groupId: "trader" }],
+    });
+    expect(rpcRequest).toHaveBeenCalledWith({
+      type: "RPC_REQUEST",
+      rpcName: MODULE_ACCESS_OPTIONS_RPC,
+      params: { userId: "u1" },
+    });
+  });
+
+  it("serializes stable assignment payloads for reconciliation", async () => {
+    const rpcRequest = vi.fn().mockResolvedValue({
+      type: "SUCCESS_RESULT",
+      data: undefined,
+    });
+    await saveUserModuleAccess({ rpcRequest }, "u1", [
+      { loginRole: "z-login", groupId: "z-group" },
+      { loginRole: "a-login", groupId: "a-group" },
+    ]);
+    expect(rpcRequest).toHaveBeenCalledWith({
+      type: "RPC_REQUEST",
+      rpcName: MODULE_ACCESS_RECONCILE_RPC,
+      params: {
+        userId: "u1",
+        assignments: JSON.stringify([
+          { loginRole: "a-login", groupId: "a-group" },
+          { loginRole: "z-login", groupId: "z-group" },
+        ]),
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replace read-only user module access with a controlled `ItemPicker`.
- Render eligible groups per selected portal module with group path and role/privilege metadata.
- Stage module additions/removals and elevated-group changes, then persist them through the serialized user save flow with deterministic, retry-safe reconciliation.
- Keep group/module association out of scope as an explicit Phase 3 boundary.
- Add the typed `getUserModuleAccessOptions` / `setUserModuleAccess` contract seam and explicit malformed/missing-contract errors.

## Backend contract gap

The current checkout does not contain the server implementation for the two new RPCs. The UI expects `getUserModuleAccessOptions({ userId })` to return portal modules, `selectedGroupId`, eligible groups, and explicit `isDefault` metadata; it sends `setUserModuleAccess({ userId, assignments })` with deterministic JSON assignments. Until those handlers are available, the editor reports the gap and does not guess membership; ordinary user fields remain editable.

## Validation

- `npm run test --workspace user-admin` (95 tests)
- `npm run test --workspace @vuu-ui/core` (27 tests)
- `npm run typecheck --workspace user-admin`
- `npm run typecheck -- --pretty false`
- `npm run lint --workspace user-admin`
- `npm run build --workspace user-admin`
- `npm run build --workspace portal-host`
